### PR TITLE
feat(clipboard): 添加剪贴板同步

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - [插件开发指南](https://ime.ximei.me/plugins/PLUGIN_DEVELOPMENT_GUIDE) - 开发插件时必读
 
 ## 硬性规则（必须遵守，CI 会验证）
-- 所有 commit 必须经过 GPG 签名
+- 禁止自己提交代码
 - PR 必须遵循最小修改原则
 - 贡献前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)
 - 禁止使用 `./gradlew clean`

--- a/app/src/main/java/com/kingzcheung/xime/XimeApplication.kt
+++ b/app/src/main/java/com/kingzcheung/xime/XimeApplication.kt
@@ -68,6 +68,12 @@ class XimeApplication : Application(), ImageLoaderFactory {
         PluginManager.wsHostApiFactory = { pluginId ->
             com.kingzcheung.xime.plugin.ws.WsHostApiImpl(this, pluginId)
         }
+        PluginManager.httpHostApiFactory = { pluginId ->
+            com.kingzcheung.xime.plugin.http.HttpHostApiImpl(this, pluginId)
+        }
+        PluginManager.cryptoHostApiFactory = {
+            com.kingzcheung.xime.plugin.crypto.CryptoHostApiImpl()
+        }
         PluginManager.initialize(this) {
             if (isDebug) {
                 PluginManager.installPluginsFromAssetsForDebug("plugins")

--- a/app/src/main/java/com/kingzcheung/xime/clipboard/ClipboardManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/ClipboardManager.kt
@@ -8,8 +8,11 @@ import android.util.Log
 import androidx.core.content.FileProvider
 import com.kingzcheung.xime.clipboard.db.ClipboardDatabase
 import com.kingzcheung.xime.clipboard.db.ClipboardEntry
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.io.File
@@ -90,6 +93,10 @@ class ClipboardManager private constructor(private val context: Context) {
 
     private val _recentItems = MutableStateFlow<List<ClipboardItem>>(emptyList())
     val recentItems: StateFlow<List<ClipboardItem>> = _recentItems.asStateFlow()
+
+    /** 本地剪贴板变更事件流（新增/更新条目时发射，供剪贴板同步等外部消费）。 */
+    private val _clipboardChanged = MutableSharedFlow<ClipboardItem>(extraBufferCapacity = 16)
+    val clipboardChanged: SharedFlow<ClipboardItem> = _clipboardChanged.asSharedFlow()
 
     private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
@@ -218,6 +225,12 @@ class ClipboardManager private constructor(private val context: Context) {
         if (text.isBlank()) return
         scope.launch {
             dao.upsertAndTrim(text, System.currentTimeMillis(), MAX_ITEMS)
+            _clipboardChanged.emit(
+                ClipboardItem(
+                    text = text,
+                    timestamp = System.currentTimeMillis()
+                )
+            )
         }
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/clipboard/sync/ClipboardSyncBridge.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/sync/ClipboardSyncBridge.kt
@@ -33,7 +33,8 @@ import kotlinx.coroutines.launch
 class ClipboardSyncBridge(
     private val context: Context,
     private val clipboardManager: ClipboardManager,
-    private val plugin: ClipboardSyncPlugin
+    private val plugin: ClipboardSyncPlugin,
+    private val pullOnOpen: Boolean = false
 ) {
     companion object {
         private const val TAG = "ClipboardSync"
@@ -69,7 +70,7 @@ class ClipboardSyncBridge(
     fun start() {
         if (running) return
         running = true
-        Log.d(TAG, "Sync started")
+        Log.d(TAG, if (pullOnOpen) "Sync started (pull on open)" else "Sync started")
 
         // 1. 订阅本地剪贴板变化 → push（回声抑制：selfWritten 命中的跳过）
         collectJob = clipboardManager.clipboardChanged
@@ -83,6 +84,12 @@ class ClipboardSyncBridge(
                 pushLocal(item.text, hash)
             }
             .launchIn(scope)
+
+        if (pullOnOpen) {
+            // 打开即拉取一次，不启动轮询（后续由键盘显示时 pullOnce() 触发）
+            scope.launch { pullRemote() }
+            return
+        }
 
         // 2. 轮询远端 → 拉取 → 写回（hash 去重）
         pollJob = scope.launch {
@@ -114,6 +121,14 @@ class ClipboardSyncBridge(
     fun release() {
         stop()
         scope.cancel()
+    }
+
+    /** 键盘显示时触发一次拉取（仅 pullOnOpen 模式；轮询模式忽略）。 */
+    fun pullOnce() {
+        if (!running || !pullOnOpen) return
+        scope.launch {
+            pullRemote()
+        }
     }
 
     private fun currentPollInterval(): Long {

--- a/app/src/main/java/com/kingzcheung/xime/clipboard/sync/ClipboardSyncBridge.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/sync/ClipboardSyncBridge.kt
@@ -1,0 +1,174 @@
+package com.kingzcheung.xime.clipboard.sync
+
+import android.content.Context
+import android.content.IntentFilter
+import android.os.PowerManager
+import android.util.Log
+import com.kingzcheung.xime.clipboard.ClipboardManager
+import com.kingzcheung.xime.plugin.core.api.ClipboardProfile
+import com.kingzcheung.xime.plugin.core.api.ClipboardSyncPlugin
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * 剪贴板同步引擎（仿 ximed SyncEngine）。
+ *
+ * 规则（与 ximed 设计一致的三通道去重语义）：
+ * - 本地剪贴板变化 → 与上次推送 hash 不同且非"自写内容" → 推送到远端
+ * - 轮询远端 → 与本地 hash 及"自写 hash"比对 → 不同才写回本地剪贴板
+ * - 自写抑制：引擎写回本地后记录 hash，监听到同一 hash 判定为回声，跳过推送
+ *
+ * 宿主只持有引擎与剪贴板桥，具体传输协议（WebDAV/S3/ximed）由 [ClipboardSyncPlugin]
+ * 的 Lua 实现承载。
+ */
+class ClipboardSyncBridge(
+    private val context: Context,
+    private val clipboardManager: ClipboardManager,
+    private val plugin: ClipboardSyncPlugin
+) {
+    companion object {
+        private const val TAG = "ClipboardSync"
+        private const val DEFAULT_POLL_MS = 3000L
+        private const val BATTERY_SAVER_POLL_MS = 60_000L
+        private const val PUSH_RETRY_BACKOFF_MS = 5_000L
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /** 上次推送/写入的 hash（去重）。 */
+    @Volatile
+    private var lastHash: String? = null
+
+    /** 自写 hash：引擎写入本地剪贴板的内容 hash，用于回声抑制。 */
+    @Volatile
+    private var selfWritten: String? = null
+
+    @Volatile
+    private var running = false
+
+    /** 推送失败后的退避截止时间。 */
+    @Volatile
+    private var retryUntil = 0L
+
+    private var pollJob: Job? = null
+    private var collectJob: Job? = null
+
+    private val powerManager by lazy {
+        context.getSystemService(Context.POWER_SERVICE) as PowerManager
+    }
+
+    fun start() {
+        if (running) return
+        running = true
+        Log.d(TAG, "Sync started")
+
+        // 1. 订阅本地剪贴板变化 → push（回声抑制：selfWritten 命中的跳过）
+        collectJob = clipboardManager.clipboardChanged
+            .filter { it.text.isNotBlank() }
+            .onEach { item ->
+                val hash = ClipboardProfile.sha256Hex(item.text.toByteArray(Charsets.UTF_8))
+                if (hash == selfWritten) {
+                    Log.d(TAG, "Echo suppressed (self-written)")
+                    return@onEach
+                }
+                pushLocal(item.text, hash)
+            }
+            .launchIn(scope)
+
+        // 2. 轮询远端 → 拉取 → 写回（hash 去重）
+        pollJob = scope.launch {
+            while (isActive) {
+                try {
+                    val interval = currentPollInterval()
+                    pullRemote()
+                    delay(interval)
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Log.e(TAG, "Poll error", e)
+                    delay(5000)
+                }
+            }
+        }
+    }
+
+    fun stop() {
+        if (!running) return
+        running = false
+        collectJob?.cancel()
+        pollJob?.cancel()
+        collectJob = null
+        pollJob = null
+        Log.d(TAG, "Sync stopped")
+    }
+
+    fun release() {
+        stop()
+        scope.cancel()
+    }
+
+    private fun currentPollInterval(): Long {
+        return if (powerManager.isPowerSaveMode) BATTERY_SAVER_POLL_MS else DEFAULT_POLL_MS
+    }
+
+    private suspend fun pushLocal(text: String, hash: String) {
+        if (!running) return
+        if (hash == lastHash) {
+            Log.d(TAG, "No change, skip push")
+            return
+        }
+        if (System.currentTimeMillis() < retryUntil) {
+            Log.d(TAG, "Push backoff active, skip")
+            return
+        }
+        val profile = ClipboardProfile.fromText(text)
+        val ok = try {
+            plugin.push(profile)
+        } catch (e: Exception) {
+            Log.e(TAG, "push failed", e)
+            false
+        }
+        if (ok) {
+            lastHash = hash
+            retryUntil = 0L
+        } else {
+            retryUntil = System.currentTimeMillis() + PUSH_RETRY_BACKOFF_MS
+        }
+    }
+
+    private suspend fun pullRemote() {
+        val remote = try {
+            plugin.pull()
+        } catch (e: Exception) {
+            Log.e(TAG, "pull failed", e)
+            null
+        }
+        if (remote == null) return
+
+        val remoteHash = remote.hash
+        val currentClipboard = clipboardManager.getCurrentClipboardText()
+        val currentHash = currentClipboard?.let {
+            ClipboardProfile.sha256Hex(it.toByteArray(Charsets.UTF_8))
+        }
+
+        // 与本地当前内容相同 或 与自己写回的内容相同 → 跳过（避免循环）
+        if (remoteHash == currentHash || remoteHash == selfWritten) {
+            Log.d(TAG, "Remote unchanged vs local, skip write")
+            return
+        }
+
+        Log.d(TAG, "Remote changed, writing to local clipboard")
+        lastHash = remoteHash
+        selfWritten = remoteHash
+        clipboardManager.copyToSystemClipboard(remote.text)
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/plugin/ExtensionManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/plugin/ExtensionManager.kt
@@ -3,6 +3,7 @@ package com.kingzcheung.xime.plugin
 import android.content.Context
 import android.util.Log
 import com.kingzcheung.xime.plugin.core.api.AsrPlugin
+import com.kingzcheung.xime.plugin.core.api.ClipboardSyncPlugin
 import com.kingzcheung.xime.plugin.core.api.EmojiPlugin
 import com.kingzcheung.xime.plugin.core.api.IPluginEntryClass
 import com.kingzcheung.xime.plugin.core.api.PluginIcon
@@ -192,6 +193,22 @@ object ExtensionManager {
 
     fun getEnabledAsrPlugins(context: Context): List<Pair<String, AsrPlugin>> {
         return getAsrPlugins().mapNotNull { plugin ->
+            val pluginId = getPluginId(plugin)
+            if (pluginId.isNotEmpty() && SettingsPreferences.isPluginEnabled(context, pluginId)) {
+                Pair(pluginId, plugin)
+            } else null
+        }
+    }
+
+    fun getClipboardSyncPlugins(): List<ClipboardSyncPlugin> {
+        val all = PluginManager.getAllPluginInstances()
+        return all.values.mapNotNull { instance ->
+            if (instance is ClipboardSyncPlugin) instance else null
+        }
+    }
+
+    fun getEnabledClipboardSyncPlugins(context: Context): List<Pair<String, ClipboardSyncPlugin>> {
+        return getClipboardSyncPlugins().mapNotNull { plugin ->
             val pluginId = getPluginId(plugin)
             if (pluginId.isNotEmpty() && SettingsPreferences.isPluginEnabled(context, pluginId)) {
                 Pair(pluginId, plugin)

--- a/app/src/main/java/com/kingzcheung/xime/plugin/crypto/CryptoHostApiImpl.kt
+++ b/app/src/main/java/com/kingzcheung/xime/plugin/crypto/CryptoHostApiImpl.kt
@@ -1,0 +1,47 @@
+package com.kingzcheung.xime.plugin.crypto
+
+import com.kingzcheung.xime.plugin.core.lua.crypto.CryptoHostApi
+import java.security.MessageDigest
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * 宿主加密/编码原语实现（S3 SigV4 签名等）。
+ *
+ * - sha256 / hmacSha256：标准 JCE
+ * - utcTime：SigV4 时间戳（YYYYMMDDTHHMMSSZ）与日期戳（YYYYMMDD）
+ */
+class CryptoHostApiImpl : CryptoHostApi {
+
+    override fun sha256(data: ByteArray): ByteArray {
+        return MessageDigest.getInstance("SHA-256").digest(data)
+    }
+
+    override fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key, "HmacSHA256"))
+        return mac.doFinal(data)
+    }
+
+    override fun hex(data: ByteArray): String {
+        return data.joinToString("") { "%02x".format(it) }
+    }
+
+    override fun base64(data: ByteArray): String {
+        return android.util.Base64.encodeToString(data, android.util.Base64.NO_WRAP)
+    }
+
+    override fun utcTime(format: String): String {
+        val result = when (format) {
+            "YYYYMMDDTHHMMSSZ" -> SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'", Locale.US)
+            "YYYYMMDD" -> SimpleDateFormat("yyyyMMdd", Locale.US)
+            else -> SimpleDateFormat(format, Locale.US)
+        }
+        result.timeZone = TimeZone.getTimeZone("UTC")
+        return result.format(Date())
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/plugin/http/HttpHostApiImpl.kt
+++ b/app/src/main/java/com/kingzcheung/xime/plugin/http/HttpHostApiImpl.kt
@@ -1,0 +1,137 @@
+package com.kingzcheung.xime.plugin.http
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import com.kingzcheung.xime.plugin.PluginConfigStoreImpl
+import com.kingzcheung.xime.plugin.core.lua.http.HttpHostApi
+import com.kingzcheung.xime.plugin.core.lua.http.HttpResponse
+import com.kingzcheung.xime.plugin.core.lua.ws.NetworkPolicy
+import com.kingzcheung.xime.plugin.core.runtime.PluginManager
+import com.kingzcheung.xime.settings.SettingsPreferences
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import java.util.concurrent.TimeUnit
+
+/**
+ * 宿主通用 HTTP 白名单 API。
+ *
+ * - URL 域名须通过 [NetworkPolicy]：命中宿主可信池（官方域名）或插件已声明且经
+ *   用户授权，否则拒绝（插件无法静默发起任意网络请求）
+ * - 同步阻塞执行：必须在 IO 线程调用（宿主同步引擎在 Dispatchers.IO 运行）
+ * - 协议无关：认证头/ETag/SigV4 全部由插件 Lua 组装，宿主只透传
+ */
+class HttpHostApiImpl(
+    private val context: Context,
+    private val pluginId: String
+) : HttpHostApi {
+
+    companion object {
+        private const val TAG = "HttpHostApi"
+    }
+
+    private val client: OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .build()
+
+    @Volatile
+    private var lastErrorMsg: String? = null
+
+    override fun request(
+        method: String,
+        url: String,
+        headers: Map<String, String>,
+        body: ByteArray?
+    ): HttpResponse? {
+        val pluginInfo = PluginManager.getAllInstallPlugins()
+            .firstOrNull { it.id == pluginId }
+        val declaredHosts = pluginInfo?.declaredHosts ?: emptyList()
+        val authorizedHosts = SettingsPreferences.getPluginAuthorizedHosts(context, pluginId)
+
+        val reason = NetworkPolicy.check(url, emptySet(), declaredHosts, authorizedHosts)
+        if (reason != null) {
+            // 插件声明了"接受用户自定义服务器地址"时：若目标域名来自用户填写的配置 URL，
+            // 视为用户意图连接该服务器，自动授权并放行。
+            val host = NetworkPolicy.extractHost(url)
+            if (pluginInfo?.allowCustomHosts == true && host != null && isConfiguredUrlHost(host)) {
+                SettingsPreferences.authorizePluginHost(context, pluginId, host)
+                Log.d(TAG, "[$pluginId] 自动授权用户配置的服务器域名: $host")
+            } else {
+                lastErrorMsg = reason
+                Log.w(TAG, "[$pluginId] 联网被拒绝: $reason")
+                return null
+            }
+        }
+        lastErrorMsg = null
+
+        return try {
+            val requestBuilder = Request.Builder().url(url)
+            headers.forEach { (k, v) -> requestBuilder.addHeader(k, v) }
+            val requestBody = (body ?: ByteArray(0)).toRequestBody(JSON_MEDIA_TYPE)
+            when (method.uppercase()) {
+                "GET" -> requestBuilder.get()
+                "DELETE" -> requestBuilder.delete()
+                "HEAD" -> requestBuilder.head()
+                "PUT" -> requestBuilder.put(requestBody)
+                "POST" -> requestBuilder.post(requestBody)
+                "PATCH" -> requestBuilder.patch(requestBody)
+                else -> requestBuilder.get()
+            }
+            client.newCall(requestBuilder.build()).execute().use { response ->
+                toHttpResponse(response)
+            }
+        } catch (e: Exception) {
+            lastErrorMsg = e.message ?: "request failed"
+            Log.e(TAG, "[$pluginId] HTTP $method $url failed", e)
+            null
+        }
+    }
+
+    override fun lastError(): String? = lastErrorMsg
+
+    /**
+     * 判断目标域名是否来自插件配置中用户填写的 URL（如 serverUrl）。
+     * 遍历插件配置所有值，凡以 http(s):// 开头的提取其域名比对。
+     */
+    private fun isConfiguredUrlHost(host: String): Boolean {
+        return try {
+            val configStore = PluginConfigStoreImpl(
+                context.applicationContext as android.app.Application,
+                pluginId
+            )
+            configStore.keys().any { key ->
+                val value = configStore.get(key) ?: return@any false
+                val configuredHost = extractHttpHost(value)
+                configuredHost != null && configuredHost == host
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "isConfiguredUrlHost failed", e)
+            false
+        }
+    }
+
+    private fun extractHttpHost(value: String): String? {
+        val trimmed = value.trim()
+        if (!trimmed.startsWith("http://") && !trimmed.startsWith("https://")) return null
+        val withScheme = if (trimmed.contains("://")) trimmed else "http://$trimmed"
+        return NetworkPolicy.extractHost(withScheme)
+    }
+
+    private fun toHttpResponse(response: Response): HttpResponse {
+        val headers = HashMap<String, String>()
+        response.headers.forEach { (k, v) -> headers[k] = v }
+        val bytes = response.body?.bytes() ?: ByteArray(0)
+        return HttpResponse(
+            status = response.code,
+            headers = headers,
+            body = bytes
+        )
+    }
+
+    private val JSON_MEDIA_TYPE = "application/octet-stream".toMediaType()
+}

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -82,6 +82,7 @@ import com.kingzcheung.xime.association.AssociationService
 import com.kingzcheung.xime.clipboard.ClipboardManager
 import com.kingzcheung.xime.clipboard.sync.ClipboardSyncBridge
 import com.kingzcheung.xime.plugin.ExtensionManager
+import com.kingzcheung.xime.plugin.core.runtime.PluginManager
 import com.kingzcheung.xime.speech.RecognitionState
 import com.kingzcheung.xime.rime.RimeConfigHelper
 import com.kingzcheung.xime.rime.RimeEngine
@@ -353,6 +354,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                     uiState.value = uiState.value.copy(isSttEnabled = SettingsPreferences.isSttEnabled(this@XimeInputMethodService))
                 }
                 SettingsPreferences.KEY_SMART_PREDICTION_ENABLED -> onPredictionSettingChanged()
+                SettingsPreferences.KEY_CLIPBOARD_SYNC_ENABLED -> updateClipboardSync()
             }
         }
         prefs.registerOnSharedPreferenceChangeListener(sharedPrefsListener)
@@ -602,6 +604,11 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 }
             }
             startClipboardSyncIfEnabled()
+            serviceScope.launch {
+                PluginManager.pluginInstancesFlow.collect {
+                    updateClipboardSync()
+                }
+            }
             Log.d(TAG, "initClipboardManager: Clipboard manager initialized successfully")
         } catch (e: Exception) {
             Log.e(TAG, "initClipboardManager: Failed to initialize clipboard manager", e)
@@ -611,7 +618,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     private fun startClipboardSyncIfEnabled() {
         if (clipboardSyncBridge != null) return
         try {
-            val enabled = com.kingzcheung.xime.plugin.ExtensionManager.getEnabledClipboardSyncPlugins(this)
+            val enabled = ExtensionManager.getEnabledClipboardSyncPlugins(this)
             val first = enabled.firstOrNull() ?: return
             val plugin = first.second
             if (!SettingsPreferences.isClipboardSyncEnabled(this)) {
@@ -629,6 +636,19 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     private fun stopClipboardSync() {
         clipboardSyncBridge?.release()
         clipboardSyncBridge = null
+    }
+
+    /** 剪贴板同步设置或插件状态变化时调用，按条件动态启停。 */
+    private fun updateClipboardSync() {
+        if (!::clipboardManager.isInitialized) return
+        if (clipboardSyncBridge == null) {
+            startClipboardSyncIfEnabled()
+        } else if (
+            !SettingsPreferences.isClipboardSyncEnabled(this) ||
+            ExtensionManager.getEnabledClipboardSyncPlugins(this).isEmpty()
+        ) {
+            stopClipboardSync()
+        }
     }
 
     private fun ensureClipboardManagerInitialized() {

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -80,6 +80,7 @@ import com.kingzcheung.xime.viewmodel.KeyboardUiState
 import com.kingzcheung.xime.viewmodel.KeyboardViewModel
 import com.kingzcheung.xime.association.AssociationService
 import com.kingzcheung.xime.clipboard.ClipboardManager
+import com.kingzcheung.xime.clipboard.sync.ClipboardSyncBridge
 import com.kingzcheung.xime.plugin.ExtensionManager
 import com.kingzcheung.xime.speech.RecognitionState
 import com.kingzcheung.xime.rime.RimeConfigHelper
@@ -164,6 +165,8 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     internal val rimeEngine = RimeEngine.getInstance()
     
     internal lateinit var clipboardManager: ClipboardManager
+
+    private var clipboardSyncBridge: ClipboardSyncBridge? = null
     
     internal lateinit var keyboardContainer: VoiceKeyboardContainer
     
@@ -598,10 +601,34 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                     quickSendItemsState.value = items
                 }
             }
+            startClipboardSyncIfEnabled()
             Log.d(TAG, "initClipboardManager: Clipboard manager initialized successfully")
         } catch (e: Exception) {
             Log.e(TAG, "initClipboardManager: Failed to initialize clipboard manager", e)
         }
+    }
+
+    private fun startClipboardSyncIfEnabled() {
+        if (clipboardSyncBridge != null) return
+        try {
+            val enabled = com.kingzcheung.xime.plugin.ExtensionManager.getEnabledClipboardSyncPlugins(this)
+            val first = enabled.firstOrNull() ?: return
+            val plugin = first.second
+            if (!SettingsPreferences.isClipboardSyncEnabled(this)) {
+                Log.d(TAG, "Clipboard sync disabled in settings")
+                return
+            }
+            clipboardSyncBridge = ClipboardSyncBridge(this, clipboardManager, plugin)
+            clipboardSyncBridge?.start()
+            Log.d(TAG, "Clipboard sync started: ${first.first}")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start clipboard sync", e)
+        }
+    }
+
+    private fun stopClipboardSync() {
+        clipboardSyncBridge?.release()
+        clipboardSyncBridge = null
     }
 
     private fun ensureClipboardManagerInitialized() {
@@ -1432,6 +1459,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             SettingsPreferences.getPrefsPublic(this).unregisterOnSharedPreferenceChangeListener(it)
         }
         RimeEngine.setDeploymentCallback { _, _ -> }
+        stopClipboardSync()
         if (::clipboardManager.isInitialized) {
             clipboardManager.release()
         }

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -355,6 +355,10 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 }
                 SettingsPreferences.KEY_SMART_PREDICTION_ENABLED -> onPredictionSettingChanged()
                 SettingsPreferences.KEY_CLIPBOARD_SYNC_ENABLED -> updateClipboardSync()
+                SettingsPreferences.KEY_CLIPBOARD_SYNC_PULL_ON_OPEN -> {
+                    stopClipboardSync()
+                    updateClipboardSync()
+                }
             }
         }
         prefs.registerOnSharedPreferenceChangeListener(sharedPrefsListener)
@@ -625,7 +629,12 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 Log.d(TAG, "Clipboard sync disabled in settings")
                 return
             }
-            clipboardSyncBridge = ClipboardSyncBridge(this, clipboardManager, plugin)
+            clipboardSyncBridge = ClipboardSyncBridge(
+                this,
+                clipboardManager,
+                plugin,
+                pullOnOpen = SettingsPreferences.isClipboardSyncPullOnOpen(this)
+            )
             clipboardSyncBridge?.start()
             Log.d(TAG, "Clipboard sync started: ${first.first}")
         } catch (e: Exception) {
@@ -1434,6 +1443,11 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         super.onWindowHidden()
         clearInputState()
         recentClipboardItemsState.value = emptyList()
+    }
+
+    override fun onWindowShown() {
+        super.onWindowShown()
+        clipboardSyncBridge?.pullOnce()
     }
     
     private fun clearInputState() {

--- a/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
@@ -591,6 +591,7 @@ object SettingsPreferences {
     }
 
     const val KEY_CLIPBOARD_SYNC_ENABLED = "clipboard_sync_enabled"
+    const val KEY_CLIPBOARD_SYNC_PULL_ON_OPEN = "clipboard_sync_pull_on_open"
 
     fun isClipboardSyncEnabled(context: Context): Boolean {
         return getPrefs(context).getBoolean(KEY_CLIPBOARD_SYNC_ENABLED, false)
@@ -598,5 +599,13 @@ object SettingsPreferences {
 
     fun setClipboardSyncEnabled(context: Context, enabled: Boolean) {
         getPrefs(context).edit().putBoolean(KEY_CLIPBOARD_SYNC_ENABLED, enabled).apply()
+    }
+
+    fun isClipboardSyncPullOnOpen(context: Context): Boolean {
+        return getPrefs(context).getBoolean(KEY_CLIPBOARD_SYNC_PULL_ON_OPEN, false)
+    }
+
+    fun setClipboardSyncPullOnOpen(context: Context, enabled: Boolean) {
+        getPrefs(context).edit().putBoolean(KEY_CLIPBOARD_SYNC_PULL_ON_OPEN, enabled).apply()
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
@@ -590,7 +590,7 @@ object SettingsPreferences {
         }
     }
 
-    private const val KEY_CLIPBOARD_SYNC_ENABLED = "clipboard_sync_enabled"
+    const val KEY_CLIPBOARD_SYNC_ENABLED = "clipboard_sync_enabled"
 
     fun isClipboardSyncEnabled(context: Context): Boolean {
         return getPrefs(context).getBoolean(KEY_CLIPBOARD_SYNC_ENABLED, false)

--- a/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
@@ -589,4 +589,14 @@ object SettingsPreferences {
             getPrefs(context).edit().putStringSet(KEY_INSTALLED_MARKET_IDS, cur).apply()
         }
     }
+
+    private const val KEY_CLIPBOARD_SYNC_ENABLED = "clipboard_sync_enabled"
+
+    fun isClipboardSyncEnabled(context: Context): Boolean {
+        return getPrefs(context).getBoolean(KEY_CLIPBOARD_SYNC_ENABLED, false)
+    }
+
+    fun setClipboardSyncEnabled(context: Context, enabled: Boolean) {
+        getPrefs(context).edit().putBoolean(KEY_CLIPBOARD_SYNC_ENABLED, enabled).apply()
+    }
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/ClipboardSyncSettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/ClipboardSyncSettingsScreen.kt
@@ -1,0 +1,131 @@
+package com.kingzcheung.xime.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.twotone.Sync
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.kingzcheung.xime.plugin.ExtensionManager
+import com.kingzcheung.xime.settings.SettingsPreferences
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ClipboardSyncSettingsContent(
+    onBack: () -> Unit,
+    onNavigateToPlugins: () -> Unit
+) {
+    val context = LocalContext.current
+    var enabled by remember {
+        mutableStateOf(SettingsPreferences.isClipboardSyncEnabled(context))
+    }
+    val syncPlugins = remember { ExtensionManager.getEnabledClipboardSyncPlugins(context) }
+    val installedPlugins = remember { ExtensionManager.getAllInstalledPlugins() }
+
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.surface,
+        topBar = {
+            TopAppBar(
+                title = { Text("剪贴板同步") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "返回"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    titleContentColor = MaterialTheme.colorScheme.onSurface
+                ),
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            SettingsSection(
+                title = "同步开关",
+                content = {
+                    SettingsToggleItem(
+                        icon = Icons.TwoTone.Sync,
+                        title = "启用剪贴板同步",
+                        subtitle = "将剪贴板文本与远端设备双向同步",
+                        checked = enabled,
+                        onCheckedChange = { checked ->
+                            enabled = checked
+                            SettingsPreferences.setClipboardSyncEnabled(context, checked)
+                        }
+                    )
+                }
+            )
+
+            if (enabled) {
+                val plugin = syncPlugins.firstOrNull()
+                if (plugin == null) {
+                    SettingsSection(
+                        title = "同步服务",
+                        content = {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                Text(
+                                    text = "未启用剪贴板同步插件，请先在插件中心启用后再配置。",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Button(
+                                    onClick = onNavigateToPlugins,
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    Text("前往插件中心")
+                                }
+                            }
+                        }
+                    )
+                } else {
+                    val pluginId = plugin.first
+                    val pluginName = installedPlugins.find { it.id == pluginId }?.name ?: pluginId
+                    PluginConfigFormScreen(
+                        pluginId = pluginId,
+                        plugin = plugin.second,
+                        pluginName = pluginName,
+                        onBack = {},
+                        embedded = true
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/ClipboardSyncSettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/ClipboardSyncSettingsScreen.kt
@@ -5,11 +5,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.twotone.Refresh
 import androidx.compose.material.icons.twotone.Sync
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -41,6 +43,9 @@ fun ClipboardSyncSettingsContent(
     var enabled by remember {
         mutableStateOf(SettingsPreferences.isClipboardSyncEnabled(context))
     }
+    var pullOnOpen by remember {
+        mutableStateOf(SettingsPreferences.isClipboardSyncPullOnOpen(context))
+    }
     val syncPlugins = remember { ExtensionManager.getEnabledClipboardSyncPlugins(context) }
     val installedPlugins = remember { ExtensionManager.getAllInstalledPlugins() }
 
@@ -69,6 +74,7 @@ fun ClipboardSyncSettingsContent(
                 .fillMaxSize()
                 .padding(padding)
                 .padding(horizontal = 16.dp)
+                .imePadding()
                 .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
@@ -83,6 +89,16 @@ fun ClipboardSyncSettingsContent(
                         onCheckedChange = { checked ->
                             enabled = checked
                             SettingsPreferences.setClipboardSyncEnabled(context, checked)
+                        }
+                    )
+                    SettingsToggleItem(
+                        icon = Icons.TwoTone.Refresh,
+                        title = "仅打开键盘时拉取",
+                        subtitle = "开启后不持续轮询，仅在键盘弹出时从远端拉取一次",
+                        checked = pullOnOpen,
+                        onCheckedChange = { checked ->
+                            pullOnOpen = checked
+                            SettingsPreferences.setClipboardSyncPullOnOpen(context, checked)
                         }
                     )
                 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/PluginConfigFormScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/PluginConfigFormScreen.kt
@@ -12,10 +12,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Visibility
@@ -146,8 +144,7 @@ fun PluginConfigFormScreen(
     if (embedded) {
         Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState()),
+                .fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             groupedFields.forEach { (section, sectionFields) ->

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/PluginConfigFormScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/PluginConfigFormScreen.kt
@@ -12,8 +12,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Visibility
@@ -68,7 +70,8 @@ fun PluginConfigFormScreen(
     pluginId: String,
     plugin: IPluginConfigurable,
     pluginName: String,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    embedded: Boolean = false
 ) {
     val context = LocalContext.current
     val configStore = remember(pluginId) {
@@ -88,84 +91,108 @@ fun PluginConfigFormScreen(
             }
     }
 
-    Scaffold(
-        containerColor = MaterialTheme.colorScheme.surface,
-        topBar = {
-            TopAppBar(
-                title = { Text(pluginName) },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "返回"
+    @Composable
+    fun sectionContent(section: String, sectionFields: List<PluginSettingField>) {
+        SettingsSection(
+            title = section.ifBlank { "插件配置" },
+            content = {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    sectionFields.forEach { field ->
+                        PluginSettingFieldEditor(
+                            field = field,
+                            configStore = configStore,
+                            options = field.options.ifEmpty {
+                                dynamicOptions[field.key].orEmpty()
+                            },
+                            plugin = plugin
                         )
                     }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                    titleContentColor = MaterialTheme.colorScheme.onSurface
-                ),
-            )
-        }
-    ) { padding ->
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .padding(horizontal = 16.dp)
-                .imePadding(),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            contentPadding = PaddingValues(top = 8.dp, bottom = 16.dp)
-        ) {
-            groupedFields.forEach { (section, sectionFields) ->
-                item {
-                    SettingsSection(
-                        title = section.ifBlank { "插件配置" },
-                        content = {
-                            Column(
-                                modifier = Modifier.padding(16.dp),
-                                verticalArrangement = Arrangement.spacedBy(12.dp)
-                            ) {
-                                sectionFields.forEach { field ->
-                                    PluginSettingFieldEditor(
-                                        field = field,
-                                        configStore = configStore,
-                                        options = field.options.ifEmpty {
-                                            dynamicOptions[field.key].orEmpty()
-                                        },
-                                        plugin = plugin
-                                    )
-                                }
-                            }
-                        }
-                    )
                 }
             }
+        )
+    }
 
-            item {
-                Button(
-                    onClick = {
-                        var allValid = true
-                        fields.forEach { field ->
-                            if (field.type == PluginFieldType.SECRET && field.required) {
-                                val current = configStore.get(field.key)
-                                if (current.isNullOrBlank()) allValid = false
-                            }
+    @Composable
+    fun saveButton() {
+        Button(
+            onClick = {
+                var allValid = true
+                fields.forEach { field ->
+                    if (field.type == PluginFieldType.SECRET && field.required) {
+                        val current = configStore.get(field.key)
+                        if (current.isNullOrBlank()) allValid = false
+                    }
+                }
+                if (!allValid) {
+                    Toast.makeText(context, "请填写必填配置", Toast.LENGTH_SHORT).show()
+                    return@Button
+                }
+                Toast.makeText(context, "配置已保存", Toast.LENGTH_SHORT).show()
+                if (!embedded) onBack()
+            },
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary
+            )
+        ) {
+            Text("保存")
+        }
+    }
+
+    if (embedded) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            groupedFields.forEach { (section, sectionFields) ->
+                sectionContent(section, sectionFields)
+            }
+            saveButton()
+        }
+    } else {
+        Scaffold(
+            containerColor = MaterialTheme.colorScheme.surface,
+            topBar = {
+                TopAppBar(
+                    title = { Text(pluginName) },
+                    navigationIcon = {
+                        IconButton(onClick = onBack) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "返回"
+                            )
                         }
-                        if (!allValid) {
-                            Toast.makeText(context, "请填写必填配置", Toast.LENGTH_SHORT).show()
-                            return@Button
-                        }
-                        Toast.makeText(context, "配置已保存", Toast.LENGTH_SHORT).show()
-                        onBack()
                     },
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        contentColor = MaterialTheme.colorScheme.onPrimary
-                    )
-                ) {
-                    Text("保存")
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.surface,
+                        titleContentColor = MaterialTheme.colorScheme.onSurface
+                    ),
+                )
+            }
+        ) { padding ->
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(horizontal = 16.dp)
+                    .imePadding(),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                contentPadding = PaddingValues(top = 8.dp, bottom = 16.dp)
+            ) {
+                groupedFields.forEach { (section, sectionFields) ->
+                    item {
+                        sectionContent(section, sectionFields)
+                    }
+                }
+
+                item {
+                    saveButton()
                 }
             }
         }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/PluginConfigFormScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/PluginConfigFormScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -58,6 +59,7 @@ import com.kingzcheung.xime.plugin.core.config.PluginConfigStore
 import com.kingzcheung.xime.plugin.core.config.PluginFieldType
 import com.kingzcheung.xime.plugin.core.config.PluginSettingField
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -130,7 +132,8 @@ fun PluginConfigFormScreen(
                                         configStore = configStore,
                                         options = field.options.ifEmpty {
                                             dynamicOptions[field.key].orEmpty()
-                                        }
+                                        },
+                                        plugin = plugin
                                     )
                                 }
                             }
@@ -174,8 +177,12 @@ fun PluginConfigFormScreen(
 private fun PluginSettingFieldEditor(
     field: PluginSettingField,
     configStore: PluginConfigStore,
-    options: List<String>
+    options: List<String>,
+    plugin: IPluginConfigurable
 ) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var buttonBusy by remember(field.key) { mutableStateOf(false) }
     var value by rememberSaveable(field.key) {
         mutableStateOf(configStore.get(field.key) ?: field.defaultValue ?: "")
     }
@@ -366,6 +373,38 @@ private fun PluginSettingFieldEditor(
                         }
                     }
                 }
+            }
+        }
+
+        PluginFieldType.BUTTON -> {
+            Button(
+                onClick = {
+                    val action = field.action
+                    if (action.isNullOrBlank()) {
+                        Toast.makeText(context, "未配置动作", Toast.LENGTH_SHORT).show()
+                        return@Button
+                    }
+                    buttonBusy = true
+                    scope.launch {
+                        val error = withContext(Dispatchers.IO) {
+                            runCatching { plugin.onAction(action) }.getOrNull()
+                        }
+                        buttonBusy = false
+                        if (error.isNullOrBlank()) {
+                            Toast.makeText(context, "成功", Toast.LENGTH_SHORT).show()
+                        } else {
+                            Toast.makeText(context, error, Toast.LENGTH_LONG).show()
+                        }
+                    }
+                },
+                enabled = !buttonBusy,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                )
+            ) {
+                Text(if (buttonBusy) "处理中…" else field.label)
             }
         }
     }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/PluginsSettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/PluginsSettingsScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.material.icons.twotone.Storefront
@@ -792,6 +793,7 @@ private fun getCategoryIcon(category: PluginCategory): ImageVector = when (categ
     PluginCategory.EMOJI -> Icons.Default.Face
     PluginCategory.ASR -> Icons.Default.Mic
     PluginCategory.PREDICTION -> Icons.Default.AutoAwesome
+    PluginCategory.CLIPBOARD_SYNC -> Icons.Default.Sync
     PluginCategory.UNKNOWN -> Icons.Default.Extension
 }
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsMainScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsMainScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.twotone.KeyboardAlt
 import androidx.compose.material.icons.twotone.Palette
 import androidx.compose.material.icons.twotone.Storefront
 import androidx.compose.material.icons.twotone.Straighten
+import androidx.compose.material.icons.twotone.Sync
 import androidx.compose.material.icons.twotone.TableChart
 import androidx.compose.material.icons.twotone.ToggleOn
 import androidx.compose.material.icons.twotone.TypeSpecimen
@@ -78,7 +79,8 @@ fun SettingsMainContent(
     onNavigateToSmartPrediction: () -> Unit,
     onNavigateToSpeechToText: () -> Unit,
     onNavigateToAbout: () -> Unit,
-    onNavigateToWebDav: () -> Unit = {}
+    onNavigateToWebDav: () -> Unit = {},
+    onNavigateToClipboardSync: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
@@ -330,12 +332,19 @@ fun SettingsMainContent(
             }
 
             item {
-                SettingsSection(title = "同步与备份", content = {
+                SettingsSection(                title = "同步与备份", content = {
                     SettingsItem(
                         icon = Icons.TwoTone.CloudSync,
                         title = "WebDAV 同步",
                         subtitle = "通过 WebDAV 备份和恢复输入方案与配置",
                         onClick = onNavigateToWebDav,
+                        showArrow = true
+                    )
+                    SettingsItem(
+                        icon = Icons.TwoTone.Sync,
+                        title = "剪贴板同步",
+                        subtitle = "通过插件将剪贴板与远端设备双向同步",
+                        onClick = onNavigateToClipboardSync,
                         showArrow = true
                     )
                 })

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsRoutes.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsRoutes.kt
@@ -23,6 +23,7 @@ object SettingsRoutes {
     const val Licenses = "licenses"
     const val LogViewer = "log_viewer"
     const val WebDav = "webdav"
+    const val ClipboardSync = "clipboard_sync"
     const val SchemaDictBrowser = "schema_dict_browser"
     const val RimeFileBrowser = "rime_file_browser"
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsScreen.kt
@@ -36,7 +36,8 @@ fun SettingsScreen(
                 onNavigateToSmartPrediction = { navController.navigate(SettingsRoutes.SmartPrediction) },
                 onNavigateToSpeechToText = { navController.navigate(SettingsRoutes.SpeechToText) },
                 onNavigateToAbout = { navController.navigate(SettingsRoutes.About) },
-                onNavigateToWebDav = { navController.navigate(SettingsRoutes.WebDav) }
+                onNavigateToWebDav = { navController.navigate(SettingsRoutes.WebDav) },
+                onNavigateToClipboardSync = { navController.navigate(SettingsRoutes.ClipboardSync) }
             )
         }
         composable(SettingsRoutes.Schema) {
@@ -185,6 +186,12 @@ fun SettingsScreen(
         composable(SettingsRoutes.WebDav) {
             WebDavSyncContent(
                 onBack = { navController.popBackStack() }
+            )
+        }
+        composable(SettingsRoutes.ClipboardSync) {
+            ClipboardSyncSettingsContent(
+                onBack = { navController.popBackStack() },
+                onNavigateToPlugins = { navController.navigate(SettingsRoutes.Plugins) }
             )
         }
         composable(SettingsRoutes.About) {

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/api/ClipboardSyncPlugin.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/api/ClipboardSyncPlugin.kt
@@ -1,0 +1,87 @@
+package com.kingzcheung.xime.plugin.core.api
+
+import com.kingzcheung.xime.plugin.core.config.IPluginConfigurable
+
+/**
+ * 剪贴板条目（同步用）。与 ximed `Profile` JSON 同构（snake_case 序列化）：
+ *
+ * ```json
+ * {
+ *   "type": "text",
+ *   "hash": "9f86d081884c7d65...",
+ *   "text": "完整文本内容",
+ *   "has_data": false,
+ *   "data_name": null,
+ *   "size": 12,
+ *   "source": "device-a"
+ * }
+ * ```
+ *
+ * @param type    类型（首版仅 "text"）
+ * @param hash    小写 hex SHA256(utf8(text))
+ * @param text    文本内容
+ * @param hasData 是否携带附件数据（图片/文件，首版 false）
+ * @param dataName 附件文件名（首版 null）
+ * @param size    内容字节大小
+ * @param source  来源设备标识
+ */
+data class ClipboardProfile(
+    val type: String = "text",
+    val hash: String,
+    val text: String,
+    val hasData: Boolean = false,
+    val dataName: String? = null,
+    val size: Long = 0,
+    val source: String? = null
+) {
+    companion object {
+        /** 由文本构造 text 类型 profile，自动计算 hash 与 size。 */
+        fun fromText(text: String, source: String? = null): ClipboardProfile {
+            return ClipboardProfile(
+                type = "text",
+                hash = sha256Hex(text.toByteArray(Charsets.UTF_8)),
+                text = text,
+                hasData = false,
+                dataName = null,
+                size = text.toByteArray(Charsets.UTF_8).size.toLong(),
+                source = source
+            )
+        }
+
+        fun sha256Hex(data: ByteArray): String {
+            val digest = java.security.MessageDigest.getInstance("SHA-256")
+            return digest.digest(data).joinToString("") { "%02x".format(it) }
+        }
+    }
+}
+
+/**
+ * 剪贴板同步插件能力接口（宿主侧，由 Lua 适配器实现，协议逻辑在 Lua）。
+ *
+ * 同步引擎（宿主 ClipboardSyncBridge）只依赖此接口做 push / pull / 连接测试，
+ * 具体传输协议（WebDAV / S3 / ximed HTTP）由插件 Lua 用 `host.http` + `host.crypto`
+ * 实现。
+ */
+interface ClipboardSyncPlugin : IPluginEntryClass, IPluginConfigurable {
+
+    /**
+     * 推送本地 profile 到远端（宿主在剪贴板变化时调用）。
+     *
+     * @param profile 本地剪贴板 profile（含 hash，引擎已做去重）
+     * @return 成功 true；失败 false（引擎记录错误并退避重试）
+     */
+    suspend fun push(profile: ClipboardProfile): Boolean
+
+    /**
+     * 拉取远端 profile（宿主轮询调用）。
+     *
+     * ETag / If-None-Match 条件请求由插件 Lua 内部用 `host.config` 自行缓存管理：
+     * 远端返回 304 或无变更时返回 null（宿主据此跳过写回）。
+     *
+     * @return 远端 profile；无变更/失败返回 null
+     */
+    suspend fun pull(): ClipboardProfile?
+
+    /** 校验配置可用性（连接测试），返回错误消息（null 表示成功）。 */
+    suspend fun testConnection(): String?
+}

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/config/IPluginConfigurable.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/config/IPluginConfigurable.kt
@@ -1,6 +1,6 @@
 package com.kingzcheung.xime.plugin.core.config
 
-enum class PluginFieldType { TEXT, SECRET, SELECT, MULTI_SELECT, SWITCH, NUMBER }
+enum class PluginFieldType { TEXT, SECRET, SELECT, MULTI_SELECT, SWITCH, NUMBER, BUTTON }
 
 data class PluginSettingField(
     val key: String,
@@ -11,7 +11,12 @@ data class PluginSettingField(
     val options: List<String> = emptyList(),
     val helpText: String? = null,
     val section: String? = null,
-    val required: Boolean = true
+    val required: Boolean = true,
+    /**
+     * 动作标识（仅 [PluginFieldType.BUTTON] 使用）：点击按钮时触发宿主动作，
+     * 通常为插件 Lua 导出的函数名（如 "testConnection"）。
+     */
+    val action: String? = null
 )
 
 interface IPluginConfigurable {
@@ -23,4 +28,14 @@ interface IPluginConfigurable {
      * 返回 null 表示无动态选项。
      */
     fun getOptions(key: String): List<String>? = null
+
+    /**
+     * 处理表单 BUTTON 字段点击（action 见 [PluginSettingField.action]）。
+     *
+     * 默认实现：把 [action] 当作插件 Lua 导出的函数名调用，返回其返回值
+     * （nil/空 = 成功，否则为错误消息）。
+     *
+     * @return null 表示成功；非 null 为错误消息（表单层提示用户）
+     */
+    suspend fun onAction(action: String): String? = null
 }

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/LuaClipboardSyncPluginAdapter.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/LuaClipboardSyncPluginAdapter.kt
@@ -1,0 +1,78 @@
+package com.kingzcheung.xime.plugin.core.lua
+
+import android.util.Log
+import com.kingzcheung.xime.plugin.core.api.ClipboardProfile
+import com.kingzcheung.xime.plugin.core.api.ClipboardSyncPlugin
+import com.kingzcheung.xime.plugin.core.model.PluginContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.luaj.vm2.LuaTable
+import org.luaj.vm2.LuaValue
+
+/**
+ * clipboard_sync 类型 Lua 插件的宿主侧适配器：实现 [ClipboardSyncPlugin] 接口。
+ *
+ * 协议逻辑（WebDAV / S3 / ximed HTTP）全部由插件 Lua 用 `host.http` + `host.crypto`
+ * 承载，本类只做接口桥接：
+ * - push(profile)     → Lua `push(profileTable)`，profile 字段转 snake_case
+ * - pull(lastEtag)    → Lua `pull(lastEtag)`，返回 profile 表（nil → 无变更）
+ * - testConnection()  → Lua `testConnection()`，返回错误消息（nil/空 → 成功）
+ */
+class LuaClipboardSyncPluginAdapter(
+    runtime: LuaScriptRuntime,
+    pluginContext: PluginContext
+) : LuaPluginAdapter(runtime, pluginContext), ClipboardSyncPlugin {
+
+    override suspend fun push(profile: ClipboardProfile): Boolean = withContext(Dispatchers.IO) {
+        try {
+            val table = LuaTable()
+            table.set("type", profile.type)
+            table.set("hash", profile.hash)
+            table.set("text", profile.text)
+            table.set("has_data", LuaValue.valueOf(profile.hasData))
+            if (profile.dataName != null) table.set("data_name", profile.dataName)
+            table.set("size", LuaValue.valueOf(profile.size.toDouble()))
+            if (profile.source != null) table.set("source", profile.source)
+            val result = runtime.call("push", table)
+            if (!result.toboolean()) {
+                Log.e("LuaClipboardSync", "push returned false")
+            }
+            result.toboolean()
+        } catch (e: Exception) {
+            Log.e("LuaClipboardSync", "push failed", e)
+            false
+        }
+    }
+
+    override suspend fun pull(): ClipboardProfile? = withContext(Dispatchers.IO) {
+        try {
+            val result = runtime.call("pull")
+            if (!result.istable()) return@withContext null
+            val map = LuaScriptRuntime.tableToMap(result)
+            val text = map["text"]?.tojstring()?.takeIf { it.isNotEmpty() } ?: return@withContext null
+            val hash = map["hash"]?.tojstring()?.takeIf { it.isNotEmpty() }
+                ?: ClipboardProfile.sha256Hex(text.toByteArray(Charsets.UTF_8))
+            ClipboardProfile(
+                type = map["type"]?.tojstring() ?: "text",
+                hash = hash,
+                text = text,
+                hasData = map["has_data"]?.toboolean() ?: false,
+                dataName = map["data_name"]?.tojstring(),
+                size = map["size"]?.tolong() ?: 0,
+                source = map["source"]?.tojstring()
+            )
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    override suspend fun testConnection(): String? = withContext(Dispatchers.IO) {
+        try {
+            val result = runtime.call("testConnection")
+            val msg = result.tojstring()
+            if (msg.isBlank() || result.isnil()) null else msg
+        } catch (e: Exception) {
+            e.message ?: "connection test failed"
+        }
+    }
+}

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/LuaPluginAdapter.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/LuaPluginAdapter.kt
@@ -34,9 +34,18 @@ open class LuaPluginAdapter(
                 options = stringList(map["options"] ?: LuaValue.NIL),
                 helpText = map["helpText"]?.tojstring(),
                 section = map["section"]?.tojstring(),
-                required = map["required"]?.toboolean() ?: true
+                required = map["required"]?.toboolean() ?: true,
+                action = map["action"]?.tojstring()
             )
         }
+    }
+
+    override suspend fun onAction(action: String): String? {
+        if (action.isBlank()) return "未知操作"
+        val result = runtime.call(action)
+        if (result.isnil()) return null
+        val msg = result.tojstring()
+        return if (msg.isBlank()) null else msg
     }
 
     override fun getOptions(key: String): List<String>? {
@@ -51,6 +60,7 @@ open class LuaPluginAdapter(
         "multi_select" -> PluginFieldType.MULTI_SELECT
         "switch" -> PluginFieldType.SWITCH
         "number" -> PluginFieldType.NUMBER
+        "button" -> PluginFieldType.BUTTON
         else -> PluginFieldType.TEXT
     }
 

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/LuaScriptRuntime.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/LuaScriptRuntime.kt
@@ -35,7 +35,9 @@ class LuaScriptRuntime(
     private val entryScript: String,
     private val configStore: PluginConfigStore,
     private val hostApi: LuaHostApi? = null,
-    private val wsHostApi: com.kingzcheung.xime.plugin.core.lua.ws.WsHostApi? = null
+    private val wsHostApi: com.kingzcheung.xime.plugin.core.lua.ws.WsHostApi? = null,
+    private val httpHostApi: com.kingzcheung.xime.plugin.core.lua.http.HttpHostApi? = null,
+    private val cryptoHostApi: com.kingzcheung.xime.plugin.core.lua.crypto.CryptoHostApi? = null
 ) {
 
     companion object {
@@ -304,6 +306,16 @@ class LuaScriptRuntime(
             host.set("ws", buildWsTable())
         }
 
+        // 通用 HTTP 白名单 API（协议无关，剪贴板同步等插件使用，见 HttpHostApi）
+        if (httpHostApi != null) {
+            host.set("http", buildHttpTable())
+        }
+
+        // 加密/编码原语（S3 SigV4 签名等，见 CryptoHostApi）
+        if (cryptoHostApi != null) {
+            host.set("crypto", buildCryptoTable())
+        }
+
         // ASR 结果回传桥：插件 Lua 解析结果后通知宿主后端（协议无关的接口桥）
         host.set("asr", buildAsrEmitTable())
 
@@ -351,6 +363,68 @@ class LuaScriptRuntime(
             CoerceJavaToLua.coerce(wsHostApi?.lastError())
         })
         return ws
+    }
+
+    private fun buildHttpTable(): LuaTable {
+        val http = LuaTable()
+
+        http.set("request", luaFunction { args ->
+            val method = args.arg1().tojstring()
+            val url = args.arg(2).tojstring()
+            val headers = HashMap<String, String>()
+            LuaScriptRuntime.tableToMap(args.arg(3)).forEach { (k, v) ->
+                headers[k] = v.tojstring()
+            }
+            val bodyArg = args.arg(4)
+            val body: ByteArray? = when {
+                bodyArg.isnil() -> null
+                bodyArg.isstring() -> bodyArg.tojstring().toByteArray(Charsets.UTF_8)
+                else -> luaToBytes(bodyArg)
+            }
+            val response = httpHostApi?.request(method, url, headers, body)
+            if (response == null) {
+                CoerceJavaToLua.coerce(null)
+            } else {
+                val table = LuaTable()
+                table.set("status", response.status)
+                val headerTable = LuaTable()
+                response.headers.forEach { (k, v) -> headerTable.set(k, v) }
+                table.set("headers", headerTable)
+                table.set("body", LuaString.valueOf(response.body))
+                table.set("text", response.body.toString(Charsets.UTF_8))
+                table
+            }
+        })
+        http.set("lastError", luaFunction { _ ->
+            CoerceJavaToLua.coerce(httpHostApi?.lastError())
+        })
+        return http
+    }
+
+    private fun buildCryptoTable(): LuaTable {
+        val crypto = LuaTable()
+
+        crypto.set("sha256", luaFunction { args ->
+            val data = luaToBytes(args.arg1()) ?: return@luaFunction LuaValue.NIL
+            LuaString.valueOf(cryptoHostApi?.sha256(data) ?: return@luaFunction LuaValue.NIL)
+        })
+        crypto.set("hmacSha256", luaFunction { args ->
+            val key = luaToBytes(args.arg1()) ?: return@luaFunction LuaValue.NIL
+            val data = luaToBytes(args.arg(2)) ?: return@luaFunction LuaValue.NIL
+            LuaString.valueOf(cryptoHostApi?.hmacSha256(key, data) ?: return@luaFunction LuaValue.NIL)
+        })
+        crypto.set("hex", luaFunction { args ->
+            val data = luaToBytes(args.arg1()) ?: return@luaFunction LuaValue.NIL
+            CoerceJavaToLua.coerce(cryptoHostApi?.hex(data))
+        })
+        crypto.set("base64", luaFunction { args ->
+            val data = luaToBytes(args.arg1()) ?: return@luaFunction LuaValue.NIL
+            CoerceJavaToLua.coerce(cryptoHostApi?.base64(data))
+        })
+        crypto.set("utcTime", luaFunction { args ->
+            CoerceJavaToLua.coerce(cryptoHostApi?.utcTime(args.arg1().tojstring()))
+        })
+        return crypto
     }
 
     private fun buildAsrEmitTable(): LuaTable {
@@ -443,6 +517,7 @@ class LuaScriptRuntime(
             }
         } catch (e: Exception) {
             Log.e(TAG, "Call '$name' failed for $pluginId: ${e.message}", e)
+            api.log("Call '$name' failed: ${e.message}")
             LuaValue.NIL
         }
     }

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/crypto/CryptoHostApi.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/crypto/CryptoHostApi.kt
@@ -1,0 +1,35 @@
+package com.kingzcheung.xime.plugin.core.lua.crypto
+
+/**
+ * 宿主提供的加密/编码白名单原语（S3 SigV4 签名等协议插件使用）。
+ *
+ * Lua 侧注入为 `host.crypto`：
+ *   host.crypto.sha256(data)        -- 二进制 → SHA256 摘要字节（Lua 字符串）
+ *   host.crypto.hmacSha256(key, data)
+ *   host.crypto.hex(data)           -- 字节 → 小写 hex 字符串
+ *   host.crypto.base64(data)        -- 字节 → Base64 字符串
+ *   host.crypto.utcTime(format)     -- 当前 UTC 时间，如 "YYYYMMDDTHHMMSSZ" / "YYYYMMDD"
+ *
+ * 字节在 Lua 中以字符串表示（与 host.bin / host.ws.sendBinary 的约定一致）。
+ */
+interface CryptoHostApi {
+
+    /** SHA-256 摘要（Lua 字符串字节 → Lua 字符串字节）。 */
+    fun sha256(data: ByteArray): ByteArray
+
+    /** HMAC-SHA256（key 与 data 均为字节）。 */
+    fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray
+
+    /** 字节 → 小写十六进制字符串。 */
+    fun hex(data: ByteArray): String
+
+    /** 字节 → Base64 字符串。 */
+    fun base64(data: ByteArray): String
+
+    /**
+     * 当前 UTC 时间格式化。支持占位符：
+     *   "YYYYMMDDTHHMMSSZ" → "20230811T120000Z"（SigV4 时间戳）
+     *   "YYYYMMDD"         → "20230811"（SigV4 日期戳）
+     */
+    fun utcTime(format: String): String
+}

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/http/HttpHostApi.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/http/HttpHostApi.kt
@@ -1,0 +1,59 @@
+package com.kingzcheung.xime.plugin.core.lua.http
+
+/**
+ * 宿主提供的通用 HTTP 白名单 API（协议无关，WebDAV / S3 / ximed 等同步插件使用）。
+ *
+ * 设计原则（与 [com.kingzcheung.xime.plugin.core.lua.ws.WsHostApi] 一致）：
+ * - 宿主只提供"发起请求 + 返回响应"原语，**不含任何业务协议逻辑**（PUT/GET 语义、
+ *   认证头、SigV4 签名、ETag 缓存全由插件 Lua 承载）
+ * - URL 必须命中宿主侧域名白名单（宿主实现强制校验），插件无法发起任意网络请求
+ * - 本 API 为**同步阻塞**调用：宿主实现在调用线程上同步执行 HTTP 请求。
+ *   宿主侧必须在 IO 线程调用（同步引擎在 Dispatchers.IO 运行），避免阻塞主线程。
+ *
+ * Lua 侧注入为 `host.http`：
+ *   host.http.request(method, url, headers, body) -> {status, headers, body}
+ *   host.http.lastError()
+ *
+ * @see com.kingzcheung.xime.plugin.core.lua.ws.WsHostApi
+ */
+interface HttpHostApi {
+
+    /**
+     * 发起同步 HTTP 请求。
+     *
+     * @param method  HTTP 方法（GET/PUT/POST/DELETE/HEAD，大写）
+     * @param url     完整 URL，宿主校验域名白名单（未授权返回 null）
+     * @param headers 请求头（如 Authorization、Content-Type、If-None-Match）
+     * @param body    请求体（文本转 UTF-8 字节，二进制原始字节；GET 可为 null）
+     * @return 响应；URL 被拒绝或请求失败时返回 null（用 [lastError] 读取原因）
+     */
+    fun request(
+        method: String,
+        url: String,
+        headers: Map<String, String> = emptyMap(),
+        body: ByteArray? = null
+    ): HttpResponse?
+
+    /** 最近一次拒绝/失败原因（request 返回 null 时 Lua 可读取提示用户）。 */
+    fun lastError(): String?
+}
+
+/**
+ * HTTP 响应。
+ *
+ * @param status  HTTP 状态码（200/304/401/404…）
+ * @param headers 响应头（含 ETag / Last-Modified 等，插件 Lua 用于条件拉取）
+ * @param body    响应体（文本按 UTF-8 解码，二进制原始字节）
+ */
+data class HttpResponse(
+    val status: Int,
+    val headers: Map<String, String> = emptyMap(),
+    val body: ByteArray = ByteArray(0)
+) {
+    /** 取响应头（大小写不敏感）。 */
+    fun header(name: String): String? {
+        return headers.entries.firstOrNull {
+            it.key.equals(name, ignoreCase = true)
+        }?.value
+    }
+}

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/model/PluginCategory.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/model/PluginCategory.kt
@@ -14,6 +14,7 @@ enum class PluginCategory(
     EMOJI("emoji", "表情", Activation.MULTI),
     ASR("speech", "语音转文本", Activation.SINGLE),
     PREDICTION("prediction", "智能预测", Activation.MULTI),
+    CLIPBOARD_SYNC("clipboard_sync", "剪贴板同步", Activation.SINGLE),
     UNKNOWN("unknown", "其他", Activation.NONE);
 
     companion object {

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/model/PluginInfo.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/model/PluginInfo.kt
@@ -30,7 +30,10 @@ data class PluginInfo(
     /** Lua 入口脚本路径（相对插件包目录）。插件逻辑全部由该脚本导出。 */
     val entryScript: String? = null,
     /** 插件声明需要访问的域名（manifest.network.hosts）。联网时需命中可信池或获用户授权。 */
-    val declaredHosts: List<String> = emptyList()
+    val declaredHosts: List<String> = emptyList(),
+    /** 是否接受用户自定义服务器地址（manifest.network.allowCustomHosts）。为 true 时，
+     *  插件配置中用户填写的 URL 域名自动获得联网授权（剪贴板同步等服务器地址场景）。 */
+    val allowCustomHosts: Boolean = false
 ) {
     val version: String get() = versionName
     val category: PluginCategory get() = PluginCategory.fromId(type)

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/PluginManager.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/PluginManager.kt
@@ -39,6 +39,17 @@ object PluginManager {
     @Volatile
     var wsHostApiFactory: ((pluginId: String) -> com.kingzcheung.xime.plugin.core.lua.ws.WsHostApi)? = null
 
+    /**
+     * 宿主 HTTP 白名单 API 提供者（app 层注入，剪贴板同步等插件使用）。
+     * 工厂参数为插件 id，宿主据此校验域名白名单与用户授权。
+     */
+    @Volatile
+    var httpHostApiFactory: ((pluginId: String) -> com.kingzcheung.xime.plugin.core.lua.http.HttpHostApi)? = null
+
+    /** 宿主加密/编码原语提供者（S3 SigV4 签名等，app 层注入）。 */
+    @Volatile
+    var cryptoHostApiFactory: (() -> com.kingzcheung.xime.plugin.core.lua.crypto.CryptoHostApi)? = null
+
     private var frameworkContext: PluginFrameworkContext? = null
     private val _loadedPluginsFlow = MutableStateFlow<Map<String, LoadedPluginInfo>>(emptyMap())
     private val _pluginInstancesFlow = MutableStateFlow<Map<String, IPluginEntryClass>>(emptyMap())

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/InstallerManager.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/InstallerManager.kt
@@ -28,7 +28,8 @@ internal data class PluginConfig(
     val minHostVersion: String?,
     val maxHostVersion: String?,
     val entryScript: String?,
-    val declaredHosts: List<String> = emptyList()
+    val declaredHosts: List<String> = emptyList(),
+    val allowCustomHosts: Boolean = false
 )
 
 /** manifest.yaml 的类型化模型，与宿主一起用 kaml 解析。 */
@@ -47,7 +48,8 @@ internal data class PluginManifest(
 
 @Serializable
 internal data class NetworkConfig(
-    val hosts: List<String> = emptyList()
+    val hosts: List<String> = emptyList(),
+    val allowCustomHosts: Boolean = false
 )
 
 /**
@@ -89,7 +91,8 @@ class InstallerManager(
                     minHostVersion = manifest.minHostVersion?.takeIf { it.isNotBlank() },
                     maxHostVersion = manifest.maxHostVersion?.takeIf { it.isNotBlank() },
                     entryScript = manifest.entry,
-                    declaredHosts = declaredHosts
+                    declaredHosts = declaredHosts,
+                    allowCustomHosts = manifest.network?.allowCustomHosts ?: false
                 )
             )
         } catch (e: Exception) {
@@ -189,7 +192,8 @@ class InstallerManager(
                 maxHostVersion = pluginConfig.maxHostVersion,
                 trustLevel = com.kingzcheung.xime.plugin.core.util.PluginSignatureUtil.classifyLuaPlugin(source),
                 entryScript = entryScript,
-                declaredHosts = pluginConfig.declaredHosts
+                declaredHosts = pluginConfig.declaredHosts,
+                allowCustomHosts = pluginConfig.allowCustomHosts
             )
 
             if (existingPlugin != null) {

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/XmlManager.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/XmlManager.kt
@@ -67,6 +67,9 @@ class XmlManager(private val context: Application) {
                     if (plugin.declaredHosts.isNotEmpty()) {
                         writer.write("    <networkHosts>${escapeXml(plugin.declaredHosts.joinToString(","))}</networkHosts>\n")
                     }
+                    if (plugin.allowCustomHosts) {
+                        writer.write("    <allowCustomHosts>true</allowCustomHosts>\n")
+                    }
                     writer.write("  </plugin>\n")
                 }
                 writer.write("</plugins>\n")
@@ -114,6 +117,7 @@ class XmlManager(private val context: Application) {
                 ?.map { it.trim() }
                 ?.filter { it.isNotBlank() }
                 ?: emptyList()
+            val allowCustomHosts = extractTag(pluginContent, "allowCustomHosts")?.toBoolean() ?: false
             val trustLevel = com.kingzcheung.xime.plugin.core.util.PluginSignatureUtil.classifyLuaPlugin(source)
 
             if (id != null && path != null) {
@@ -133,7 +137,8 @@ class XmlManager(private val context: Application) {
                     maxHostVersion = maxHostVersion,
                     trustLevel = trustLevel,
                     entryScript = entryScript,
-                    declaredHosts = networkHosts
+                    declaredHosts = networkHosts,
+                    allowCustomHosts = allowCustomHosts
                 )
             }
         }

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/lifecycle/PluginLifecycleManager.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/lifecycle/PluginLifecycleManager.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.util.Log
 import com.kingzcheung.xime.plugin.core.api.IPluginEntryClass
 import com.kingzcheung.xime.plugin.core.lua.LuaAsrPluginAdapter
+import com.kingzcheung.xime.plugin.core.lua.LuaClipboardSyncPluginAdapter
 import com.kingzcheung.xime.plugin.core.lua.LuaEmojiPluginAdapter
 import com.kingzcheung.xime.plugin.core.lua.LuaPluginAdapter
 import com.kingzcheung.xime.plugin.core.lua.LuaScriptRuntime
@@ -150,7 +151,9 @@ class PluginLifecycleManager(
                 pluginDir = pluginDir,
                 entryScript = plugin.entryScript ?: "main.lua",
                 configStore = PluginManager.configStoreFactory.create(application, plugin.id),
-                wsHostApi = PluginManager.wsHostApiFactory?.invoke(plugin.id)
+                wsHostApi = PluginManager.wsHostApiFactory?.invoke(plugin.id),
+                httpHostApi = PluginManager.httpHostApiFactory?.invoke(plugin.id),
+                cryptoHostApi = PluginManager.cryptoHostApiFactory?.invoke()
             )
             LoadedPluginInfo(pluginInfo = plugin, script = runtime)
         } catch (e: Exception) {
@@ -176,6 +179,11 @@ class PluginLifecycleManager(
                     )
                 PluginCategory.EMOJI ->
                     LuaEmojiPluginAdapter(
+                        runtime = loadedPlugin.script ?: return null,
+                        pluginContext = pluginContext
+                    )
+                PluginCategory.CLIPBOARD_SYNC ->
+                    LuaClipboardSyncPluginAdapter(
                         runtime = loadedPlugin.script ?: return null,
                         pluginContext = pluginContext
                     )

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaClipboardSyncPluginTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaClipboardSyncPluginTest.kt
@@ -1,0 +1,181 @@
+package com.kingzcheung.xime.plugin.core.lua
+
+import com.kingzcheung.xime.plugin.core.config.PluginConfigStore
+import com.kingzcheung.xime.plugin.core.lua.crypto.CryptoHostApi
+import com.kingzcheung.xime.plugin.core.lua.http.HttpHostApi
+import com.kingzcheung.xime.plugin.core.lua.http.HttpResponse
+import com.kingzcheung.xime.plugin.core.lua.sdk.LuaHostApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * 验证 ximed-clipboard-sync 插件：协议逻辑（HTTP 端点、Basic Auth、ETag 条件拉取）
+ * 全在 Lua，宿主只提供 host.http / host.crypto / host.config / host.json 原语。
+ */
+class LuaClipboardSyncPluginTest {
+
+    private class InMemoryConfigStore : PluginConfigStore {
+        private val map = HashMap<String, String>()
+        override fun get(key: String): String? = map[key]
+        override fun set(key: String, value: String) { map[key] = value }
+        override fun remove(key: String) { map.remove(key) }
+        override fun keys(): Set<String> = map.keys.toSet()
+    }
+
+    /** 记录请求、可编程响应的 mock HTTP 宿主。 */
+    private class MockHttpHostApi : HttpHostApi {
+        val requests = mutableListOf<Triple<String, String, Map<String, String>>>()
+        val responseQueue = ArrayDeque<HttpResponse>()
+        var lastErrorMsg: String? = null
+
+        override fun request(
+            method: String,
+            url: String,
+            headers: Map<String, String>,
+            body: ByteArray?
+        ): HttpResponse? {
+            requests.add(Triple(method, url, headers))
+            return responseQueue.removeFirstOrNull()
+        }
+
+        override fun lastError(): String? = lastErrorMsg
+    }
+
+    private class MockCryptoHostApi : CryptoHostApi {
+        override fun sha256(data: ByteArray): ByteArray = ByteArray(0)
+        override fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray = ByteArray(0)
+        override fun hex(data: ByteArray): String = ""
+        override fun base64(data: ByteArray): String =
+            java.util.Base64.getEncoder().encodeToString(data)
+        override fun utcTime(format: String): String = ""
+    }
+
+    /** 测试专用宿主 API：log 输出到 stdout（unit test 中 android.util.Log 是 stub）。 */
+    private class DebugHostApi(private val store: PluginConfigStore) : LuaHostApi {
+        override val sdkVersion = "0.1.0"
+        override fun log(message: String) { System.out.println("LUA_LOG: $message") }
+        override fun configGet(key: String) = store.get(key)
+        override fun configSet(key: String, value: String) { store.set(key, value) }
+        override fun configRemove(key: String) { store.remove(key) }
+        override fun configKeys() = store.keys()
+        override fun resourcePath(name: String) = null
+        override fun resourceList(dir: String) = emptyList<String>()
+        override fun jsonEncode(obj: Any?) = com.kingzcheung.xime.plugin.core.lua.sdk.SimpleJson.encode(obj)
+        override fun jsonDecode(json: String) = com.kingzcheung.xime.plugin.core.lua.sdk.SimpleJson.decode(json)
+        override fun uuid() = "uuid"
+    }
+
+    private fun newRuntime(store: PluginConfigStore, http: MockHttpHostApi): LuaScriptRuntime {
+        val dir = File("../plugins/ximed-clipboard-sync")
+        assertTrue("插件目录应存在: ${dir.absolutePath}", dir.exists())
+        val runtime = LuaScriptRuntime(
+            "com.kingzcheung.xime.plugin.ximed_sync",
+            dir,
+            "main.lua",
+            store,
+            hostApi = DebugHostApi(store),
+            httpHostApi = http,
+            cryptoHostApi = MockCryptoHostApi()
+        )
+        assertTrue("main.lua 应能加载", runtime.load())
+        return runtime
+    }
+
+    private fun profileTable(text: String, hash: String): org.luaj.vm2.LuaTable {
+        val table = org.luaj.vm2.LuaTable()
+        table.set("type", "text")
+        table.set("hash", hash)
+        table.set("text", text)
+        table.set("has_data", org.luaj.vm2.LuaValue.FALSE)
+        table.set("size", org.luaj.vm2.LuaValue.valueOf(text.length.toDouble()))
+        return table
+    }
+
+    @Test
+    fun `main lua loads and exposes sync contract`() {
+        val runtime = newRuntime(InMemoryConfigStore(), MockHttpHostApi())
+        val schema = runtime.call("getSettingsSchema")
+        assertTrue("应导出 getSettingsSchema", schema.istable())
+        assertEquals(4, LuaScriptRuntime.tableToList(schema).size)
+    }
+
+    @Test
+    fun `push sends PUT to ximed endpoint with basic auth`() {
+        val store = InMemoryConfigStore()
+        store.set("serverUrl", "https://192.168.1.50:8080")
+        store.set("username", "alice")
+        store.set("password", "secret")
+        val http = MockHttpHostApi()
+        http.responseQueue.addLast(HttpResponse(200))
+        val runtime = newRuntime(store, http)
+
+        val ok = runtime.call("push", profileTable("hello", "abc")).toboolean()
+
+        assertTrue("push 应成功", ok)
+        assertEquals(1, http.requests.size)
+        val (method, url, headers) = http.requests[0]
+        assertEquals("PUT", method)
+        assertEquals("https://192.168.1.50:8080/api/clipboard", url)
+        val expectedAuth = "Basic " + java.util.Base64.getEncoder()
+            .encodeToString("alice:secret".toByteArray())
+        assertEquals(expectedAuth, headers["Authorization"])
+    }
+
+    @Test
+    fun `pull returns profile on 200 and caches etag`() {
+        val store = InMemoryConfigStore()
+        store.set("serverUrl", "https://192.168.1.50:8080")
+        val http = MockHttpHostApi()
+        val profileJson = """{"type":"text","hash":"abc123","text":"远端内容","has_data":false,"data_name":null,"size":12,"source":"desktop"}"""
+        http.responseQueue.addLast(HttpResponse(200, mapOf("ETag" to "etag-1"), profileJson.toByteArray()))
+        val runtime = newRuntime(store, http)
+
+        val result = runtime.call("pull")
+
+        assertTrue("pull 应返回 table", result.istable())
+        val map = LuaScriptRuntime.tableToMap(result)
+        assertEquals("远端内容", map["text"]?.tojstring())
+        assertEquals("abc123", map["hash"]?.tojstring())
+        assertEquals("etag-1", store.get("lastEtag"))
+    }
+
+    @Test
+    fun `pull returns null on 304`() {
+        val store = InMemoryConfigStore()
+        store.set("serverUrl", "https://192.168.1.50:8080")
+        store.set("lastEtag", "etag-1")
+        val http = MockHttpHostApi()
+        http.responseQueue.addLast(HttpResponse(304))
+        val runtime = newRuntime(store, http)
+
+        val result = runtime.call("pull")
+
+        assertTrue("304 应返回 nil", result.isnil())
+        assertEquals(1, http.requests.size)
+        val headers = http.requests[0].third
+        assertEquals("etag-1", headers["If-None-Match"])
+    }
+
+    @Test
+    fun `testConnection reports auth failure`() {
+        val store = InMemoryConfigStore()
+        store.set("serverUrl", "https://192.168.1.50:8080")
+        val http = MockHttpHostApi()
+        http.responseQueue.addLast(HttpResponse(401))
+        val runtime = newRuntime(store, http)
+
+        val error = runtime.call("testConnection").tojstring()
+
+        assertTrue("应报告认证失败: $error", error.contains("认证失败"))
+    }
+
+    @Test
+    fun `testConnection reports missing config`() {
+        val runtime = newRuntime(InMemoryConfigStore(), MockHttpHostApi())
+        val error = runtime.call("testConnection").tojstring()
+        assertTrue("未配置时应报告错误: $error", error.contains("未配置"))
+    }
+}

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/runtime/installer/ManifestParseTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/runtime/installer/ManifestParseTest.kt
@@ -20,6 +20,7 @@ class ManifestParseTest {
             network:
               hosts:
                 - dashscope.aliyuncs.com
+              allowCustomHosts: true
         """.trimIndent()
 
         val result = InstallerManager.parseManifestContent(content)
@@ -32,6 +33,7 @@ class ManifestParseTest {
         assertEquals("2.6.0", config.minHostVersion)
         assertEquals("3.0.0", config.maxHostVersion)
         assertEquals(listOf("dashscope.aliyuncs.com"), config.declaredHosts)
+        assertTrue("allowCustomHosts 应解析为 true", config.allowCustomHosts)
     }
 
     @Test

--- a/plugins/ximed-clipboard-sync/main.lua
+++ b/plugins/ximed-clipboard-sync/main.lua
@@ -1,0 +1,168 @@
+-- ximed 剪贴板同步插件（Lua 脚本插件）
+--
+-- 对接 ximed 服务器的 HTTP 接口，实现文本双向同步。
+--
+-- 职责划分：
+--   Lua   = 协议逻辑（HTTP 端点拼装、Basic Auth、ETag 条件拉取、Profile JSON 组装/解析）
+--   宿主  = 同步引擎（轮询/去重/回声抑制）+ 通用原语：
+--     host.http        HTTP 白名单（request/lastError，域名经用户授权）
+--     host.json        JSON 编解码
+--     host.config      配置存储（含 ETag 缓存）
+--     host.crypto      sha256/hex（hash 计算，可选；宿主引擎已算好 hash 传入）
+--
+-- ximed HTTP 接口（参考 ximed crates/client/src/transport.rs HttpTransport）：
+--   端点   {server_url}/api/clipboard
+--   push   PUT {endpoint}，Authorization: Basic base64(user:pass)，body = Profile JSON
+--   pull   GET {endpoint}，Authorization: Basic；ETag 缓存到 host.config，
+--          拉取时发 If-None-Match，304 → 无变更（返回 nil）
+--   Profile JSON（snake_case）：
+--     { "type":"text", "hash":"...", "text":"...", "has_data":false,
+--       "data_name":null, "size":12, "source":null }
+
+local plugin = {}
+
+local KEY_SERVER_URL = "serverUrl"
+local KEY_USERNAME = "username"
+local KEY_PASSWORD = "password"
+local KEY_LAST_ETAG = "lastEtag"
+
+local ENDPOINT_SUFFIX = "/api/clipboard"
+
+-- ================= 工具函数 =================
+
+local function base64encode(str)
+    return host.crypto.base64(str)
+end
+
+local function basicAuthHeader(username, password)
+    local cred = username .. ":" .. password
+    return "Basic " .. base64encode(cred)
+end
+
+local function endpointUrl()
+    local base = host.config.get(KEY_SERVER_URL) or ""
+    base = base:gsub("/+$", "")
+    if base == "" then return nil end
+    return base .. ENDPOINT_SUFFIX
+end
+
+local function buildHeaders()
+    local headers = {}
+    local username = host.config.get(KEY_USERNAME) or ""
+    local password = host.config.get(KEY_PASSWORD) or ""
+    if username ~= "" then
+        headers["Authorization"] = basicAuthHeader(username, password)
+    end
+    headers["Accept"] = "application/json"
+    return headers
+end
+
+-- ================= 配置 schema（与 manifest 一致） =================
+
+function plugin.getSettingsSchema()
+    return {
+        {
+            key = KEY_SERVER_URL,
+            label = "服务器地址",
+            type = "text",
+            placeholder = "https://host:port",
+            helpText = "ximed 服务器地址（形如 https://192.168.1.50:8080）",
+        },
+        {
+            key = KEY_USERNAME,
+            label = "用户名",
+            type = "text",
+            required = false,
+        },
+        {
+            key = KEY_PASSWORD,
+            label = "密码",
+            type = "secret",
+            required = false,
+        },
+        {
+            key = "testConnection",
+            label = "测试连接",
+            type = "button",
+            action = "testConnection",
+            required = false,
+        },
+    }
+end
+
+-- ================= 生命周期 =================
+
+function plugin.onLoad()
+    return true
+end
+
+function plugin.onUnload()
+    return true
+end
+
+-- ================= 同步接口 =================
+
+-- 推送本地 profile 到远端（宿主剪贴板变化时调用）
+function plugin.push(profile)
+    local url = endpointUrl()
+    if url == nil then return false end
+    local headers = buildHeaders()
+    headers["Content-Type"] = "application/json"
+    local body = host.json.encode(profile)
+    if body == nil then return false end
+    local resp = host.http.request("PUT", url, headers, body)
+    if resp == nil then return false end
+    if resp.status >= 200 and resp.status < 300 then
+        -- 记录远端 etag，供下次条件拉取
+        local etag = resp.headers["ETag"]
+        if etag == nil then etag = resp.headers["etag"] end
+        if etag ~= nil then host.config.set(KEY_LAST_ETAG, etag) end
+        return true
+    end
+    return false
+end
+
+-- 拉取远端 profile（宿主轮询调用）；无变更返回 nil
+function plugin.pull()
+    local url = endpointUrl()
+    if url == nil then return nil end
+    local headers = buildHeaders()
+    local etag = host.config.get(KEY_LAST_ETAG)
+    if etag ~= nil and etag ~= "" then
+        headers["If-None-Match"] = etag
+    end
+    local resp = host.http.request("GET", url, headers, nil)
+    if resp == nil then return nil end
+    if resp.status == 304 then
+        -- Not Modified，无变更
+        return nil
+    end
+    if resp.status >= 200 and resp.status < 300 then
+        local etag = resp.headers["ETag"]
+        if etag == nil then etag = resp.headers["etag"] end
+        if etag ~= nil then host.config.set(KEY_LAST_ETAG, etag) end
+        local decoded = host.json.decode(resp.text)
+        if decoded == nil then return nil end
+        return decoded
+    end
+    return nil
+end
+
+-- 校验配置可用性（连接测试）；返回错误消息，nil 表示成功
+function plugin.testConnection()
+    local url = endpointUrl()
+    if url == nil then return "未配置服务器地址" end
+    local resp = host.http.request("GET", url, buildHeaders(), nil)
+    if resp == nil then
+        return host.http.lastError() or "连接失败"
+    end
+    if resp.status == 401 or resp.status == 403 then
+        return "认证失败（HTTP " .. resp.status .. "）"
+    end
+    if resp.status >= 200 and resp.status < 400 then
+        return nil
+    end
+    return "连接失败（HTTP " .. resp.status .. "）"
+end
+
+return plugin

--- a/plugins/ximed-clipboard-sync/manifest.yaml
+++ b/plugins/ximed-clipboard-sync/manifest.yaml
@@ -1,0 +1,57 @@
+# =============================================
+# Xime Lua 插件元数据（宿主用 YAML 解析）
+# =============================================
+
+# 插件唯一标识
+id: com.kingzcheung.xime.plugin.ximed_sync
+
+# 插件名称与描述
+name: ximed 剪贴板同步
+icon: "🔗"
+description: 对接 ximed HTTP 接口的双向剪贴板同步（文本）
+
+# 插件版本（字符串）
+version: 0.1.0
+
+# 插件分类：clipboard_sync 剪贴板同步（单选激活）
+type: clipboard_sync
+activation: single
+
+# 入口脚本
+entry: main.lua
+
+# 宿主最低版本要求
+minHostVersion: 2.6.0
+
+# 能力声明
+capabilities:
+  clipboard_sync:
+    protocols:
+      - ximed-http   # 对接 ximed 服务器的 /api/clipboard HTTP 接口
+
+# 网络访问声明：服务器地址由用户配置，域名不固定。
+# allowCustomHosts: 接受用户填写的服务器地址域名，经配置后自动授权联网
+network:
+  hosts: []
+  allowCustomHosts: true
+
+# 配置字段声明（插件中心直接渲染表单）
+configSchema:
+  - key: serverUrl
+    label: 服务器地址
+    type: text
+    placeholder: https://host:port
+    helpText: ximed 服务器地址（形如 https://192.168.1.50:8080）
+  - key: username
+    label: 用户名
+    type: text
+    required: false
+  - key: password
+    label: 密码
+    type: secret
+    required: false
+  - key: testConnection
+    label: 测试连接
+    type: button
+    action: testConnection
+    required: false


### PR DESCRIPTION
## 概述

# Xime 剪贴板同步体系说明

## 一、整体架构（三层）

```
┌─ 宿主引擎层（app 模块）─────────────────────────────┐
│ ClipboardSyncBridge    同步引擎：事件推送 + 轮询/按键拉取、去重    │
│ ClipboardManager       clipboardChanged 事件流、读写系统剪贴板    │
│ HttpHostApiImpl         HTTP 白名单执行 + 自定义域名自动授权        │
│ CryptoHostApiImpl        SHA256/Base64 等原语                     │
│ ExtensionManager        插件实例发现/启用查询                      │
├─ 插件契约层（plugin-core 模块）─────────────────────┐
│ ClipboardSyncPlugin     宿主↔插件能力接口（push/pull/testConnection）│
│ LuaClipboardSyncPluginAdapter  Lua↔接口桥接（Profile 表转换）        │
│ HttpHostApi / CryptoHostApi    宿主注入 Lua 的原语接口               │
│ LuaHostApi             config/json/uuid/log 等基础 API              │
│ NetworkPolicy           域名白名单纯函数校验                       │
├─ 插件内容层（Lua 脚本）─────────────────────────────┐
│ plugins/ximed-clipboard-sync/main.lua     协议逻辑（HTTP 端点/认证/ETag）│
│ manifest.yaml          插件元数据、configSchema 声明                 │
└──────────────────────────────────────────────────┘
```

## 二、核心数据模型 `ClipboardProfile`（`ClipboardSyncPlugin.kt`）

与 ximed 服务器 `Profile` JSON 同构（snake_case）：

```json
{ "type": "text", "hash": "<sha256 hex>", "text": "...",
  "has_data": false, "data_name": null, "size": 12, "source": null }
```

- `hash` = SHA256(utf8(text))，宿主与远端都以此做去重
- `fromText()` 工厂自动计算 hash/size

## 三、插件能力接口 `ClipboardSyncPlugin`（宿主↔插件契约）

| 接口 | 说明 |
|---|---|
| `suspend push(profile): Boolean` | 推送本地剪贴板到远端（剪贴板变化时调用） |
| `suspend pull(): ClipboardProfile?` | 拉取远端内容，无变更/失败返回 null |
| `suspend testConnection(): String?` | 连接测试，返回错误消息（null=成功） |
| `getSettingsSchema()`（继承 `IPluginConfigurable`） | 返回配置表单字段（宿主渲染表单） |
| `onAction(action)`（继承） | 表单 BUTTON 动作回调（如 `testConnection`） |

Lua 插件通过 `LuaClipboardSyncPluginAdapter` 自动桥接：`push(profile)` → 调 Lua `plugin.push(表)`，表字段转 snake_case；`pull()` → Lua `plugin.pull()` 返回表转回 `ClipboardProfile`。

## 四、宿主引擎 `ClipboardSyncBridge` 流程

**双通道同步 + 三通道去重**（`ClipboardSyncBridge.kt`）：

**通道 1 推送（事件驱动）**
```
系统剪贴板变化 → ClipboardManager 监听 → addItem → clipboardChanged 流 emit
   → 桥订阅流 → hash==selfWritten？(回声抑制，跳过) → plugin.push(profile)
   → 成功记 lastHash；失败退避 5s
```

**通道 2 拉取（两种模式，设置可切）**
- **轮询模式**（默认）：每 3s（省电 60s）`plugin.pull()` → 与本地 hash 及 selfWritten 比对 → 不同则 `copyToSystemClipboard` 写回并记 selfWritten
- **打开即拉取模式**（`pullOnOpen`）：`start()` 时拉一次；此后每次键盘弹出（`onWindowShown` → `pullOnce()`）拉一次，不轮询

**去重语义**：`lastHash`（已推送）、`selfWritten`（引擎写回的自写内容）、远端 hash 三者比对，避免循环推送和重复写回。

**启停**：`XimeInputMethodService` 监听同步开关（`KEY_CLIPBOARD_SYNC_ENABLED`）与插件实例流（`PluginManager.pluginInstancesFlow`），条件满足启动、不满足停止；模式切换时重建桥。

## 五、Lua 侧宿主注入 API（插件可用的全部能力）

**`host.http`（`HttpHostApi`）** — 剪贴板同步的主通道
```
host.http.request(method, url, headers, body) → {status, headers, text} | null
host.http.lastError() → string | nil
```

**`host.crypto`（`CryptoHostApi`）** — 认证/签名原语
```
sha256(data) / hmacSha256(key, data) / hex(data) / base64(data)
utcTime("YYYYMMDDTHHMMSSZ") / utcTime("YYYYMMDD")
```

**`host.config`** — 插件独立配置存储（`LuaHostApi`）
```
config.get(key) / config.set(key, value) / config.remove(key) / config.keys()
```

**`host.json`** — `json.encode(table)` / `json.decode(string)`

**其他**：`host.log`、`host.uuid`、`host.resource.path/list`、`host.bin.int32be/gzip/gunzip`、`host.sdkVersion`。沙箱内剥离了 `io/os/loadfile/luajava`，以上是插件唯一能力入口。

## 六、插件侧协议实现（`main.lua`）

对接 ximed `/api/clipboard` 端点：
- **push**：`PUT {server}/api/clipboard`，`Authorization: Basic base64(user:pass)`，body = Profile JSON；成功后缓存响应 `ETag` 到 `host.config`
- **pull**：`GET {server}/api/clipboard`，带 `If-None-Match`（缓存的 ETag）→ 304 返回 nil；200 则解析 Profile JSON
- **testConnection**：`GET` 探测，401/403 提示认证失败

## 七、网络白名单机制

`HttpHostApiImpl.request` 每次请求先过 `NetworkPolicy.check(url, trusted, declaredHosts, authorizedHosts)`：
1. manifest 声明 `network.hosts` 的域名需用户授权（`SettingsPreferences.getPluginAuthorizedHosts`）
2. 剪贴板同步插件声明 `allowCustomHosts: true`：若目标域名来自用户配置的 `serverUrl`，自动授权放行（对应日志里"自动授权用户配置的服务器域名"）

## 八、典型时序

**打开键盘拉取**：键盘弹出 → `onWindowShown` → `pullOnce` → Lua `pull()` → `GET /api/clipboard`(If-None-Match) → 200/新内容 → 写回系统剪贴板 → `selfWritten` 记录，避免回声推送。

**本地复制推送**：复制文本 → 系统剪贴板监听 → `clipboardChanged` → hash 非自写 → Lua `push()` → `PUT /api/clipboard` → 成功记 `lastHash`。

## 九、配置与发现 API

- `ExtensionManager.getClipboardSyncPlugins()` — 所有已加载剪贴板同步插件实例
- `ExtensionManager.getEnabledClipboardSyncPlugins(context)` — 已启用插件的 `(pluginId, instance)` 列表
- `SettingsPreferences.isClipboardSyncEnabled / setClipboardSyncEnabled` — 总开关
- `SettingsPreferences.isClipboardSyncPullOnOpen / setClipboardSyncPullOnOpen` — 拉取模式
- manifest `configSchema` + Lua `getSettingsSchema()` — 宿主渲染表单字段（服务器地址/账号/密码/测试连接）


## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] 新功能
- [ ] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
