### PR TITLE
fix(t9): 修复退格撤销左选后 history 残留导致右选错误 partial commit

### DIFF
--- a/app/src/main/jni/librime-t9/src/t9_processor.cc
+++ b/app/src/main/jni/librime-t9/src/t9_processor.cc
@@ -787,6 +787,13 @@ void T9Processor::DeriveStateMachineFromUndoModel() {
         return;
     }
     if (undo_model_.HasSelectableDigits()) {
+        // 无 selected 段 → 进入 INPUT 态，必须清空 selection_history。
+        // 修复（2026-08-11，设备实证）：退格撤销 LC 后若残留历史（如 [tiao]），
+        // 再次左选同一拼音会累积重复条目 [tiao, tiao] → HSLBC 的
+        // is_full_commit_without_boundaries（JoinPinyins(history)==selected_pinyin）
+        // 判定失败 → 右选错误 partial commit（预编辑"洮条tiao"）。
+        // 段模型是唯一真相源：无 selected 段时 history 必须为空。
+        state_machine_.ClearSelectionHistory();
         state_machine_.EnterInput();
         return;
     }

--- a/app/src/main/jni/librime-t9/test/t9_right_commit_handler_test.cc
+++ b/app/src/main/jni/librime-t9/test/t9_right_commit_handler_test.cc
@@ -1655,5 +1655,54 @@ TEST(T9RightCommitHandlerTest, LetterBufferExtraSyllablePartialCommit_54482_JieG
     EXPECT_TRUE(ctx.state_machine.is_input());
 }
 
+// ── 场景 [Bug-2026-08-11]: 退格撤销左选后再次左选，history 残留重复 → 右选错误 partial commit ──
+// 复现：输入 826 8426 → 左选 tao → 右选"洮"(partial commit) → 左选 tiao → 退格撤销 tiao
+//       → 再次左选 tiao（此时 digitSeq='8268426', consumed=7, unassigned=''）→ 空格选"条"(tiao)。
+// 根因：退格撤销 LC 后 DeriveStateMachineFromUndoModel 走 HasSelectableDigits 分支只调
+//       EnterInput()（不清 selection_history），再次左选 tiao 时 EnterSelection push_back
+//       累积出 [tiao, tiao]。HSLBC 中 JoinPinyins(history)="tiaotiao" != selectedPinyin="tiao"
+//       → is_full_commit_without_boundaries=0 → 错误 partial commit（预编辑"洮条tiao"）。
+// 本测试锚定"干净 history"（修复后状态）：history=[tiao] 时右选"条"应 full commit。
+TEST(T9RightCommitHandlerTest, LetterBufferFullCommit_8268426_Tiao_CleanHistory) {
+    std::vector<SyllableOption> sels{SyllableOption("tiao", 4)};
+    std::vector<SyllableOption> history{sels[0]};
+    auto ctx = MakeContext({
+        .digits = "8268426",
+        .selections = sels,
+        .consumed_count = 7,
+        .state = T9StateMachine::State::kSelection,
+        .selected_option = sels[0],
+        .selection_candidate_digits = std::optional<std::string>("8426"),
+        .confirmed_pinyin = "",
+        .selection_history = history
+    });
+    T9RightCommitHandler handler;
+    bool result = handler.HandleRightCommit(ctx, std::optional<std::string>("tiao"), 1);
+    EXPECT_TRUE(result);   // full commit — 干净 history 下完整消费 826 8426
+    EXPECT_TRUE(ctx.input_buffer.is_empty());
+    EXPECT_TRUE(ctx.state_machine.is_idle());
+}
+
+// ── 场景 [Bug-2026-08-11] 反向锚定：history 残留重复 [tiao, tiao] 时右选"条"错误 partial ──
+// 与上测试形成对比：仅 history 多一个重复 tiao，消费判定即从 full 退化为 partial。
+// 证明 bug 根因是 history 残留（DeriveStateMachineFromUndoModel 未清空），而非算法本身。
+TEST(T9RightCommitHandlerTest, LetterBufferPartialCommit_8268426_Tiao_DuplicatedHistory) {
+    std::vector<SyllableOption> sels{SyllableOption("tiao", 4)};
+    std::vector<SyllableOption> history{sels[0], sels[0]};  // 残留重复
+    auto ctx = MakeContext({
+        .digits = "8268426",
+        .selections = sels,
+        .consumed_count = 7,
+        .state = T9StateMachine::State::kSelection,
+        .selected_option = sels[0],
+        .selection_candidate_digits = std::optional<std::string>("8426"),
+        .confirmed_pinyin = "",
+        .selection_history = history
+    });
+    T9RightCommitHandler handler;
+    bool result = handler.HandleRightCommit(ctx, std::optional<std::string>("tiao"), 1);
+    EXPECT_FALSE(result);   // partial commit — history 重复导致 full commit 判定失败
+}
+
 }  // namespace
 }  // namespace rime

--- a/app/src/main/jni/librime-t9/test/t9_undo_model_test.cc
+++ b/app/src/main/jni/librime-t9/test/t9_undo_model_test.cc
@@ -1661,3 +1661,41 @@ TEST(T9UndoModelTest, Scenario32_JGGTB_JiuGongGe_Tang) {
     // undo 汤 + undo 九宫格 各 1 个 commit
     EXPECT_EQ(2, m.ConsumeUndoneCommitCount());
 }
+
+// ── 场景 [Bug-2026-08-11]: 826 8426 退格撤销左选 tiao 后，段模型进入"无 selected + 有可分配数字"态 ──
+// 复现：输入 8268426 → 左选 tao(826) → 右选"洮"(commit tao 段) → 左选 tiao(8426)
+//       → 退格撤销 tiao。退格后 undo_model 应：tao 段 committed、tiao 段 unassigned，
+//       HasSelectedSegment()=false、HasSelectableDigits()=true —— 即
+//       DeriveStateMachineFromUndoModel 走 HasSelectableDigits 分支（修复点：进入
+//       INPUT 前必须 ClearSelectionHistory，否则再次左选 tiao 累积 [tiao,tiao] 残留）。
+TEST(T9UndoModelTest, Scenario8268426_Tao_Tiao_UndoLC_NoSelectedSegment) {
+    T9UndoModel m;
+    for (char d : std::string("8268426")) m.DigitPressed(d);
+    m.LeftChoice(SyllableOption("tao", 3));
+    // 右选"洮"(tao)：commit tao 段（partial，剩 8426 unassigned）
+    m.SyncRightCommit(
+        T9Buffer("8268426", {SyllableOption("tao", 3)}, 3, 7),
+        T9Buffer("8426", {}, 0, 7));
+    ASSERT_EQ(1u, m.segments().size());
+    EXPECT_EQ(T9Segment::kCommitted, m.segments()[0].phase);
+    EXPECT_EQ("8426", m.tail_digits());
+    // 左选 tiao：从 tail 消费 8426
+    m.LeftChoice(SyllableOption("tiao", 4));
+    ASSERT_EQ(2u, m.segments().size());
+    EXPECT_EQ(T9Segment::kSelected, m.segments()[1].phase);
+    EXPECT_EQ("8426", m.segments()[1].digits);
+    EXPECT_TRUE(m.tail_digits().empty());
+    // 退格撤销 tiao（undo LC）
+    EXPECT_TRUE(m.Backspace());
+    EXPECT_EQ(T9Segment::kUnassigned, m.segments()[1].phase);
+    EXPECT_EQ("8426", m.segments()[1].digits);
+    // 段模型状态：无 selected 段 + 有可分配数字 → DeriveStateMachine 走修复分支
+    EXPECT_FALSE(m.HasSelectedSegment());
+    EXPECT_TRUE(m.HasSelectableDigits());
+    // 派生 buffer：consumed=3（tao committed），unassigned='8426'
+    T9Buffer buf = m.ToBuffer();
+    EXPECT_EQ("8268426", buf.digit_sequence);
+    EXPECT_EQ(3, buf.consumed_count);
+    EXPECT_EQ("8426", buf.unassigned());
+    EXPECT_TRUE(buf.selections.empty());
+}


### PR DESCRIPTION

## 概述
输入 826 8426 → 左选 tao → 右选"洮"(partial commit) → 左选 tiao → 退格撤销 tiao → 再次左选 tiao → 空格选"条"。预期完整消费 8268426，实际预编辑错误变为"洮条tiao"（"条"后残留 "tiao"）。

## 关联 Issue 

Closes #624 

## 根因
退格撤销左选走 t9_processor.cc DeriveStateMachineFromUndoModel 的 HasSelectableDigits() 分支，只调 EnterInput() 不清 selection_history_（EnterInput 不清 history 是刻意设计，供 RestorePrevState 场景保留）。残留 history=[tiao] 再次左选累积为 [tiao, tiao] → 右选"条"的 is_full_commit_without_boundaries 判定（JoinPinyins(history)==selected_pinyin）失败 → 错误 partial commit。全局排查确认该分支是唯一残留窗口。

## 修复
HasSelectableDigits() 分支进入 INPUT 前显式 ClearSelectionHistory()（段模型是回退唯一真相源，无 selected 段时 history 必须为空）。新增 3 个单测锚定（干净 history full commit / 重复 history partial / undo_model 层状态验证）。

## 验证
- C++ 单测 270 全绿；assembleDebug 通过
- 设备复测通过

## 涉及修改
- app/src/main/jni/librime-t9/src/t9_processor.cc（+7 行）
- app/src/main/jni/librime-t9/test/t9_right_commit_handler_test.cc（+49）
- app/src/main/jni/librime-t9/test/t9_undo_model_test.cc（+38）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
