### PR TITLE
fix(t9):  undo RC 回收失败时段回 unassigned，修复预编辑错误消费

### DIFF
--- a/app/src/main/jni/librime-t9/src/t9_undo_model.cc
+++ b/app/src/main/jni/librime-t9/src/t9_undo_model.cc
@@ -464,6 +464,16 @@ bool T9UndoModel::UndoOp(const T9SegmentOp& op) {
                     segments_[op.released_seg].digits.push_back(d);
                 }
             }
+            // 修复（2026-08-11，场景34 设备实证）：回收不完整（释放的数字已被删除，
+            // 如场景34 的 '26' 在 undo RC 前被 ⌫2/⌫3 删掉）时，被截短段的 digits 与
+            // option.digit_length 失配（tiao[4] 只剩 '84'）。此时段无法恢复完整拼音段，
+            // 若回 selected 会残留错误 option（预编辑"洮tiao/tian"而非"洮ti"）。
+            // 修复：该段回 unassigned（合并撤销 LC，与 merge_first 同语义），
+            // digits 保留待删 → 派生 unassigned 供 RIME 正确显示剩余数字。
+            bool release_incomplete = op.released_count > 0 && op.released_seg >= 0 &&
+                op.released_seg < static_cast<int>(segments_.size()) &&
+                static_cast<int>(segments_[op.released_seg].digits.size()) !=
+                segments_[op.released_seg].option.digit_length;
             // 2026-08-05 修复：仅单段 commit（size==1）的最早段（idx==0）合并撤销 LC
             // （场景13 undo 里：li 段回 unassigned，数字回退）。
             // 多段 commit（RC({0,1}) 如"价格"）是整体撤销：所有段回 selected（拼音），
@@ -491,12 +501,19 @@ bool T9UndoModel::UndoOp(const T9SegmentOp& op) {
             }
             for (size_t i = 0; i < op.commit_indices.size(); ++i) {
                 auto& seg = segments_[op.commit_indices[i]];
-                if (merge_first && seg.has_lc) {
+                // 场景34：release_incomplete（回收失败，digits 与 option 失配）时
+                // 该段回 unassigned（合并撤销 LC），与 merge_first 同语义——
+                // 否则残留 option='tiao'(4) 与 digits='84' 失配，预编辑错误显示
+                // "洮tiao/tian"而非"洮ti"（设备实证 2026-08-11）。
+                bool merge_lc = merge_first ||
+                    (release_incomplete && static_cast<int>(op.commit_indices[i]) ==
+                        op.released_seg);
+                if (merge_lc && seg.has_lc) {
                     // 被替换段（selections[0] = 最早段）：合并撤销 LC，段回 unassigned。
                     // 同时移除 ops_ 中该段的 LC op（对应命令模式 merge_lc 的 Pop）。
                     for (size_t j = ops_.size(); j-- > 0;) {
                         if (ops_[j].kind == T9SegmentOp::kLC &&
-                            ops_[j].segment_index == op.commit_indices[0]) {
+                            ops_[j].segment_index == op.commit_indices[i]) {
                             ops_.erase(ops_.begin() + static_cast<ptrdiff_t>(j));
                             break;
                         }

--- a/app/src/main/jni/librime-t9/test/t9_undo_model_test.cc
+++ b/app/src/main/jni/librime-t9/test/t9_undo_model_test.cc
@@ -1661,3 +1661,76 @@ TEST(T9UndoModelTest, Scenario32_JGGTB_JiuGongGe_Tang) {
     // undo 汤 + undo 九宫格 各 1 个 commit
     EXPECT_EQ(2, m.ConsumeUndoneCommitCount());
 }
+
+// ── 场景34 [Bug-2026-08-11]: 826 8426 右选"提"后回退，undo RC 回收失败 → 段回 unassigned ──
+// 复现：输入 8268426 → 左选 tao(826) → 右选"洮"(commit 段0) → 左选 tiao(8426) → 右选"提"(ti=84)
+//       → 左选 an(26) → ⌫1 undo an → ⌫2 删 6 → ⌫3 删 2（'26' 全部删除）→ ⌫4 undo RC(提)。
+// 根因：右选"提"时 tiao 段被 commit 且截短为 '84'、释放 '26' 到 tail（SyncRightCommit release）。
+//       undo RC(提) 时回收 '26' 失败（已被 ⌫2/⌫3 删除）→ 原实现段1 回 selected，
+//       option='tiao'(4) 与 digits='84'(2) 失配 → 预编辑错误显示 "洮tiao/tian"（应为 "洮ti"）。
+// 修复：回收不完整（digits 长度 != option.digit_length）时，段回 unassigned（合并撤销 LC），
+//       digits 保留待删 → 派生 unassigned='84' → RIME 显示 'ti'，后续 ⌫5 删 4、⌫6 删 8。
+TEST(T9UndoModelTest, Scenario34_8268426_TiaoTi_UndoRC_ReleaseLost_GoesUnassigned) {
+    T9UndoModel m;
+    for (char d : std::string("8268426")) m.DigitPressed(d);
+    m.LeftChoice(SyllableOption("tao", 3));  // 段0: tao(826)
+    // 右选"洮"：commit 段0（partial，剩 8426 unassigned）
+    m.SyncRightCommit(
+        T9Buffer("8268426", {SyllableOption("tao", 3)}, 3, 7),
+        T9Buffer("8426", {}, 0, 7));
+    ASSERT_EQ(1u, m.segments().size());
+    EXPECT_EQ(T9Segment::kCommitted, m.segments()[0].phase);
+    EXPECT_EQ("8426", m.tail_digits());
+    // 左选 tiao(8426)：段1
+    m.LeftChoice(SyllableOption("tiao", 4));
+    ASSERT_EQ(2u, m.segments().size());
+    EXPECT_EQ(T9Segment::kSelected, m.segments()[1].phase);
+    EXPECT_EQ("8426", m.segments()[1].digits);
+    // 右选"提"(ti=84)：commit 段1 + 截短 digits '8426'→'84'，释放 '26' 回 tail
+    m.SyncRightCommit(
+        T9Buffer("8426", {SyllableOption("tiao", 4)}, 4, 7),
+        T9Buffer("26", {}, 0, 7));
+    ASSERT_EQ(2u, m.segments().size());
+    EXPECT_EQ(T9Segment::kCommitted, m.segments()[1].phase);
+    EXPECT_EQ("84", m.segments()[1].digits);
+    EXPECT_EQ("26", m.tail_digits());
+    // 左选 an(26)：段2
+    m.LeftChoice(SyllableOption("an", 2));
+    ASSERT_EQ(3u, m.segments().size());
+    EXPECT_EQ(T9Segment::kSelected, m.segments()[2].phase);
+    EXPECT_EQ("26", m.segments()[2].digits);
+    EXPECT_TRUE(m.tail_digits().empty());
+    // ⌫1: undo an（段2 回 unassigned，digits 保留）
+    EXPECT_TRUE(m.Backspace());
+    EXPECT_EQ(T9Segment::kUnassigned, m.segments()[2].phase);
+    EXPECT_EQ("26", m.segments()[2].digits);
+    // ⌫2: 删 '6'
+    EXPECT_TRUE(m.Backspace());
+    EXPECT_EQ("2", m.segments()[2].digits);
+    // ⌫3: 删 '2'（'26' 全部删除）
+    EXPECT_TRUE(m.Backspace());
+    EXPECT_EQ("", m.segments()[2].digits);
+    // ⌫4: undo RC(提) → 回收 '26' 失败 → 段1 回 unassigned（合并撤销 LC）
+    EXPECT_TRUE(m.Backspace());
+    EXPECT_EQ(T9Segment::kUnassigned, m.segments()[1].phase);
+    EXPECT_FALSE(m.segments()[1].has_lc);
+    EXPECT_EQ("84", m.segments()[1].digits);
+    // 派生 buffer：consumed=3（段0 committed），unassigned='84' → RIME 显示 'ti'
+    T9Buffer buf = m.ToBuffer();
+    EXPECT_EQ(3, buf.consumed_count);
+    EXPECT_EQ("84", buf.unassigned());
+    EXPECT_TRUE(buf.selections.empty());
+    // ⌫5: 删 '4'
+    EXPECT_TRUE(m.Backspace());
+    EXPECT_EQ("8", m.segments()[1].digits);
+    // ⌫6: 删 '8'
+    EXPECT_TRUE(m.Backspace());
+    EXPECT_EQ("", m.segments()[1].digits);
+    // ⌫7: undo RC(洮) → 段0 满足 merge_first（单段commit+逻辑首段+完整拼音+无活跃段+tail空）
+    //     合并撤销 LC → 段0 回 unassigned（digits 保留待删），与场景13 undo 里 行为一致
+    EXPECT_TRUE(m.Backspace());
+    EXPECT_EQ(T9Segment::kUnassigned, m.segments()[0].phase);
+    EXPECT_EQ("826", m.segments()[0].digits);
+    // 撤销"提"+"洮"两个 commit
+    EXPECT_EQ(2, m.ConsumeUndoneCommitCount());
+}


### PR DESCRIPTION
@kingzcheung 已经按照最新要求，将：6个问题分拆了独立PR，目前：backspace手势语义和英文键盘下滑撤回重复拼接有相关性，放在一个PR中，两个独立commits便于审阅，另外：2个T9问题还是分拆为两个独立PR，便于审阅。最后剩余：两个问题，还需要深入分析下，尽量让修复方案更严谨，会在稍后提交。

## 概述

输入 826 8426 → 左选 tao → 右选"洮"(partial) → 左选 tiao → 右选"提"(ti) → 左选 an → 回退：⌫1 undo an → ⌫2 删 6 → ⌫3 删 2 → ⌫4 undo RC(提)。预期 ⌫4 后预编辑"洮ti"（剩余 '84'），实际"洮tiao/tian"。

## 根因
右选"提"(ti=84) 时 SyncRightCommit 将 tiao 段截短为 '84'、释放 '26' 到 tail。⌫4 UndoOp(kRC) 回收 '26' 失败（⌫2/⌫3 已删）→ 原实现段回 selected，option='tiao'(4) 与 digits='84' 失配 → 预编辑错误。

## 修复
UndoOp(kRC) 回收不完整（digits.size() != option.digit_length）时，该段回 unassigned（合并撤销 LC，与 merge_first 同语义），digits 保留待删 → 派生 unassigned='84' → RIME 显示 'ti'。新增单测 Scenario34_8268426_TiaoTi_UndoRC_ReleaseLost_GoesUnassigned。

## 验证
- C++ 单测 268 全绿；assembleDebug 通过
- 设备复测通过

## 涉及修改
- app/src/main/jni/librime-t9/src/t9_undo_model.cc（+15 行）
- app/src/main/jni/librime-t9/test/t9_undo_model_test.cc（+73）
- 注：C++ 实现需同步到 librime/plugins/librime-t9（submodule，gitignored）后构建生效


## 关联 Issue

Closes #641 

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。