### PR TITLE
feat(clipboard-sync): 添加多插件支持和首选插件选择功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/clipboard/sync/ClipboardSyncBridge.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/sync/ClipboardSyncBridge.kt
@@ -34,7 +34,8 @@ class ClipboardSyncBridge(
     private val context: Context,
     private val clipboardManager: ClipboardManager,
     private val plugin: ClipboardSyncPlugin,
-    private val pullOnOpen: Boolean = false
+    private val pullOnOpen: Boolean = false,
+    val pluginId: String = ""
 ) {
     companion object {
         private const val TAG = "ClipboardSync"

--- a/app/src/main/java/com/kingzcheung/xime/plugin/http/HttpHostApiImpl.kt
+++ b/app/src/main/java/com/kingzcheung/xime/plugin/http/HttpHostApiImpl.kt
@@ -59,8 +59,11 @@ class HttpHostApiImpl(
             // 视为用户意图连接该服务器，自动授权并放行。
             val host = NetworkPolicy.extractHost(url)
             if (pluginInfo?.allowCustomHosts == true && host != null && isConfiguredUrlHost(host)) {
-                SettingsPreferences.authorizePluginHost(context, pluginId, host)
-                Log.d(TAG, "[$pluginId] 自动授权用户配置的服务器域名: $host")
+                // 仅首次授权，避免每 3 秒轮询刷屏（授权后 authorizedHosts 命中即放行）
+                if (host !in authorizedHosts) {
+                    SettingsPreferences.authorizePluginHost(context, pluginId, host)
+                    Log.d(TAG, "[$pluginId] 自动授权用户配置的服务器域名: $host")
+                }
             } else {
                 lastErrorMsg = reason
                 Log.w(TAG, "[$pluginId] 联网被拒绝: $reason")
@@ -80,6 +83,8 @@ class HttpHostApiImpl(
                 "PUT" -> requestBuilder.put(requestBody)
                 "POST" -> requestBuilder.post(requestBody)
                 "PATCH" -> requestBuilder.patch(requestBody)
+                "MKCOL" -> requestBuilder.method("MKCOL", null)
+                "PROPFIND" -> requestBuilder.method("PROPFIND", null)
                 else -> requestBuilder.get()
             }
             client.newCall(requestBuilder.build()).execute().use { response ->

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -355,6 +355,10 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 }
                 SettingsPreferences.KEY_SMART_PREDICTION_ENABLED -> onPredictionSettingChanged()
                 SettingsPreferences.KEY_CLIPBOARD_SYNC_ENABLED -> updateClipboardSync()
+                SettingsPreferences.KEY_CLIPBOARD_SYNC_PLUGIN_ID -> {
+                    stopClipboardSync()
+                    updateClipboardSync()
+                }
                 SettingsPreferences.KEY_CLIPBOARD_SYNC_PULL_ON_OPEN -> {
                     stopClipboardSync()
                     updateClipboardSync()
@@ -622,21 +626,24 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     private fun startClipboardSyncIfEnabled() {
         if (clipboardSyncBridge != null) return
         try {
-            val enabled = ExtensionManager.getEnabledClipboardSyncPlugins(this)
-            val first = enabled.firstOrNull() ?: return
-            val plugin = first.second
             if (!SettingsPreferences.isClipboardSyncEnabled(this)) {
                 Log.d(TAG, "Clipboard sync disabled in settings")
                 return
             }
+            val enabled = ExtensionManager.getEnabledClipboardSyncPlugins(this)
+            if (enabled.isEmpty()) return
+            val preferredId = SettingsPreferences.getClipboardSyncPluginId(this)
+            val selected = enabled.firstOrNull { it.first == preferredId } ?: enabled.first()
+            val plugin = selected.second
             clipboardSyncBridge = ClipboardSyncBridge(
                 this,
                 clipboardManager,
                 plugin,
-                pullOnOpen = SettingsPreferences.isClipboardSyncPullOnOpen(this)
+                pullOnOpen = SettingsPreferences.isClipboardSyncPullOnOpen(this),
+                pluginId = selected.first
             )
             clipboardSyncBridge?.start()
-            Log.d(TAG, "Clipboard sync started: ${first.first}")
+            Log.d(TAG, "Clipboard sync started: ${selected.first}")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start clipboard sync", e)
         }
@@ -652,11 +659,24 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         if (!::clipboardManager.isInitialized) return
         if (clipboardSyncBridge == null) {
             startClipboardSyncIfEnabled()
-        } else if (
+            return
+        }
+        if (
             !SettingsPreferences.isClipboardSyncEnabled(this) ||
             ExtensionManager.getEnabledClipboardSyncPlugins(this).isEmpty()
         ) {
             stopClipboardSync()
+            return
+        }
+        // 当前 bridge 使用的插件与偏好选中的插件不一致时，重启切换到偏好插件
+        val enabled = ExtensionManager.getEnabledClipboardSyncPlugins(this)
+        val preferredId = SettingsPreferences.getClipboardSyncPluginId(this)
+        val shouldUse = (if (preferredId.isNotEmpty()) {
+            enabled.firstOrNull { it.first == preferredId }
+        } else null) ?: enabled.first()
+        if (shouldUse.first != clipboardSyncBridge?.pluginId) {
+            stopClipboardSync()
+            startClipboardSyncIfEnabled()
         }
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
@@ -592,6 +592,7 @@ object SettingsPreferences {
 
     const val KEY_CLIPBOARD_SYNC_ENABLED = "clipboard_sync_enabled"
     const val KEY_CLIPBOARD_SYNC_PULL_ON_OPEN = "clipboard_sync_pull_on_open"
+    const val KEY_CLIPBOARD_SYNC_PLUGIN_ID = "clipboard_sync_plugin_id"
 
     fun isClipboardSyncEnabled(context: Context): Boolean {
         return getPrefs(context).getBoolean(KEY_CLIPBOARD_SYNC_ENABLED, false)
@@ -607,5 +608,13 @@ object SettingsPreferences {
 
     fun setClipboardSyncPullOnOpen(context: Context, enabled: Boolean) {
         getPrefs(context).edit().putBoolean(KEY_CLIPBOARD_SYNC_PULL_ON_OPEN, enabled).apply()
+    }
+
+    fun getClipboardSyncPluginId(context: Context): String {
+        return getPrefs(context).getString(KEY_CLIPBOARD_SYNC_PLUGIN_ID, "") ?: ""
+    }
+
+    fun setClipboardSyncPluginId(context: Context, pluginId: String) {
+        getPrefs(context).edit().putString(KEY_CLIPBOARD_SYNC_PLUGIN_ID, pluginId).apply()
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/ClipboardSyncSettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/ClipboardSyncSettingsScreen.kt
@@ -26,12 +26,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.kingzcheung.xime.plugin.ExtensionManager
+import com.kingzcheung.xime.plugin.core.model.PluginCategory
 import com.kingzcheung.xime.settings.SettingsPreferences
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -40,6 +44,7 @@ fun ClipboardSyncSettingsContent(
     onNavigateToPlugins: () -> Unit
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     var enabled by remember {
         mutableStateOf(SettingsPreferences.isClipboardSyncEnabled(context))
     }
@@ -47,7 +52,22 @@ fun ClipboardSyncSettingsContent(
         mutableStateOf(SettingsPreferences.isClipboardSyncPullOnOpen(context))
     }
     val syncPlugins = remember { ExtensionManager.getEnabledClipboardSyncPlugins(context) }
+    // 偏好未设置时，自动选中第一个已启用的插件（与服务端 fallback 一致）
+    var selectedPluginId by remember {
+        mutableStateOf(
+            SettingsPreferences.getClipboardSyncPluginId(context).ifEmpty {
+                syncPlugins.firstOrNull()?.first ?: ""
+            }
+        )
+    }
+    // 当前选中的插件实例（切换时在 IO 协程里 launch 完成后更新，驱动表单立即渲染新插件）
+    var activePlugin by remember {
+        mutableStateOf(
+            syncPlugins.firstOrNull { it.first == selectedPluginId } ?: syncPlugins.firstOrNull()
+        )
+    }
     val installedPlugins = remember { ExtensionManager.getAllInstalledPlugins() }
+    val clipboardPlugins = remember { installedPlugins.filter { it.category == PluginCategory.CLIPBOARD_SYNC } }
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.surface,
@@ -131,15 +151,74 @@ fun ClipboardSyncSettingsContent(
                         }
                     )
                 } else {
-                    val pluginId = plugin.first
-                    val pluginName = installedPlugins.find { it.id == pluginId }?.name ?: pluginId
-                    PluginConfigFormScreen(
-                        pluginId = pluginId,
-                        plugin = plugin.second,
-                        pluginName = pluginName,
-                        onBack = {},
-                        embedded = true
+                    SettingsSection(
+                        title = "同步服务",
+                        content = {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                if (clipboardPlugins.isEmpty()) {
+                                    Text(
+                                        text = "未安装剪贴板同步插件，请先在插件中心安装后再配置。",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                    Button(
+                                        onClick = onNavigateToPlugins,
+                                        modifier = Modifier.fillMaxWidth()
+                                    ) {
+                                        Text("前往插件中心")
+                                    }
+                                } else {
+                                    clipboardPlugins.forEach { plugin ->
+                                        val pluginId = plugin.id
+                                        val isActive = pluginId == selectedPluginId
+                                        SettingsToggleItem(
+                                            icon = Icons.TwoTone.Sync,
+                                            title = plugin.name,
+                                            subtitle = plugin.description,
+                                            checked = isActive,
+                                            onCheckedChange = { checked ->
+                                                if (checked && !isActive) {
+                                                    selectedPluginId = pluginId
+                                                    SettingsPreferences.setClipboardSyncPluginId(context, pluginId)
+                                                    scope.launch(Dispatchers.IO) {
+                                                        // 单选激活：同一时间只能运行 1 个剪贴板同步插件
+                                                        clipboardPlugins
+                                                            .filter { it.id != pluginId }
+                                                            .forEach {
+                                                                SettingsPreferences.setPluginEnabled(context, it.id, false)
+                                                                com.kingzcheung.xime.plugin.core.runtime.PluginManager.unloadPlugin(it.id)
+                                                            }
+                                                        SettingsPreferences.setPluginEnabled(context, pluginId, true)
+                                                        com.kingzcheung.xime.plugin.core.runtime.PluginManager.launchPlugin(pluginId)
+                                                        // 重新获取已启用实例，驱动表单切换到新插件
+                                                        val instance = ExtensionManager.getEnabledClipboardSyncPlugins(context)
+                                                            .firstOrNull { it.first == pluginId }
+                                                        activePlugin = instance
+                                                    }
+                                                }
+                                            }
+                                        )
+                                    }
+                                }
+                            }
+                        }
                     )
+                    activePlugin?.let { selected ->
+                        val pluginId = selected.first
+                        val pluginName = installedPlugins.find { it.id == pluginId }?.name ?: pluginId
+                        PluginConfigFormScreen(
+                            pluginId = pluginId,
+                            plugin = selected.second,
+                            pluginName = pluginName,
+                            onBack = {},
+                            embedded = true
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/PluginsSettingsViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/PluginsSettingsViewModel.kt
@@ -157,6 +157,9 @@ class PluginsSettingsViewModel(application: Application) : AndroidViewModel(appl
         if (SettingsPreferences.getSttOnlinePluginId(context) == pluginId) {
             SettingsPreferences.setSttOnlinePluginId(context, "")
         }
+        if (SettingsPreferences.getClipboardSyncPluginId(context) == pluginId) {
+            SettingsPreferences.setClipboardSyncPluginId(context, "")
+        }
         
         viewModelScope.launch {
             withContext(Dispatchers.IO) {

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/LuaScriptRuntime.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/LuaScriptRuntime.kt
@@ -205,6 +205,10 @@ class LuaScriptRuntime(
             api.log(args.tojstring())
             LuaValue.NIL
         })
+        host.set("logError", luaFunction { args ->
+            api.logError(args.tojstring())
+            LuaValue.NIL
+        })
 
         val config = LuaTable()
         config.set("get", luaFunction { args ->

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/sdk/LuaHostApi.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/sdk/LuaHostApi.kt
@@ -17,6 +17,9 @@ interface LuaHostApi {
     /** 输出日志（转到宿主 Logcat，tag 含插件 id）。 */
     fun log(message: String)
 
+    /** 输出错误日志（Log.e 级别，关键失败用，避免被日志配额丢弃）。 */
+    fun logError(message: String)
+
     /** 读取插件配置（不存在返回 null）。 */
     fun configGet(key: String): String?
 
@@ -68,6 +71,10 @@ class LuaHostApiImpl(
 
     override fun log(message: String) {
         android.util.Log.d("LuaPlugin", "[$pluginId] $message")
+    }
+
+    override fun logError(message: String) {
+        android.util.Log.e("LuaPlugin", "[$pluginId] $message")
     }
 
     override fun configGet(key: String): String? = configStore.get(key)

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaClipboardSyncPluginTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaClipboardSyncPluginTest.kt
@@ -57,6 +57,7 @@ class LuaClipboardSyncPluginTest {
     private class DebugHostApi(private val store: PluginConfigStore) : LuaHostApi {
         override val sdkVersion = "0.1.0"
         override fun log(message: String) { System.out.println("LUA_LOG: $message") }
+        override fun logError(message: String) { System.err.println("LUA_ERROR: $message") }
         override fun configGet(key: String) = store.get(key)
         override fun configSet(key: String, value: String) { store.set(key, value) }
         override fun configRemove(key: String) { store.remove(key) }

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaWebdavClipboardSyncPluginTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaWebdavClipboardSyncPluginTest.kt
@@ -1,0 +1,332 @@
+package com.kingzcheung.xime.plugin.core.lua
+
+import com.kingzcheung.xime.plugin.core.config.PluginConfigStore
+import com.kingzcheung.xime.plugin.core.lua.crypto.CryptoHostApi
+import com.kingzcheung.xime.plugin.core.lua.http.HttpHostApi
+import com.kingzcheung.xime.plugin.core.lua.http.HttpResponse
+import com.kingzcheung.xime.plugin.core.lua.sdk.LuaHostApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * 验证 webdav-clipboard-sync 插件：WebDAV 协议（PUT/GET/MKCOL、Basic Auth、ETag
+ * 条件拉取、409 目录不存在时自动 MKCOL）全在 Lua，宿主只提供 host.http / host.crypto
+ * / host.config 原语。
+ */
+class LuaWebdavClipboardSyncPluginTest {
+
+    private class InMemoryConfigStore : PluginConfigStore {
+        private val map = HashMap<String, String>()
+        override fun get(key: String): String? = map[key]
+        override fun set(key: String, value: String) { map[key] = value }
+        override fun remove(key: String) { map.remove(key) }
+        override fun keys(): Set<String> = map.keys.toSet()
+    }
+
+    /** 记录请求、可编程响应的 mock HTTP 宿主。 */
+    private class MockHttpHostApi : HttpHostApi {
+        val requests = mutableListOf<Triple<String, String, Map<String, String>>>()
+        val requestBodies = mutableListOf<String>()
+        val responseQueue = ArrayDeque<HttpResponse>()
+        var lastErrorMsg: String? = null
+
+        override fun request(
+            method: String,
+            url: String,
+            headers: Map<String, String>,
+            body: ByteArray?
+        ): HttpResponse? {
+            requests.add(Triple(method, url, headers))
+            requestBodies.add(body?.toString(Charsets.UTF_8) ?: "")
+            return responseQueue.removeFirstOrNull()
+        }
+
+        override fun lastError(): String? = lastErrorMsg
+    }
+
+    private class MockCryptoHostApi : CryptoHostApi {
+        override fun sha256(data: ByteArray): ByteArray = ByteArray(0)
+        override fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray = ByteArray(0)
+        override fun hex(data: ByteArray): String = ""
+        override fun base64(data: ByteArray): String =
+            java.util.Base64.getEncoder().encodeToString(data)
+        override fun utcTime(format: String): String = ""
+    }
+
+    /** 测试专用宿主 API：log 输出到 stdout（unit test 中 android.util.Log 是 stub）。 */
+    private class DebugHostApi(private val store: PluginConfigStore) : LuaHostApi {
+        override val sdkVersion = "0.1.0"
+        override fun log(message: String) { System.out.println("LUA_LOG: $message") }
+        override fun logError(message: String) { System.err.println("LUA_ERROR: $message") }
+        override fun configGet(key: String) = store.get(key)
+        override fun configSet(key: String, value: String) { store.set(key, value) }
+        override fun configRemove(key: String) { store.remove(key) }
+        override fun configKeys() = store.keys()
+        override fun resourcePath(name: String) = null
+        override fun resourceList(dir: String) = emptyList<String>()
+        override fun jsonEncode(obj: Any?) = com.kingzcheung.xime.plugin.core.lua.sdk.SimpleJson.encode(obj)
+        override fun jsonDecode(json: String) = try {
+            com.kingzcheung.xime.plugin.core.lua.sdk.SimpleJson.decode(json)
+        } catch (_: Exception) {
+            null
+        }
+        override fun uuid() = "uuid"
+    }
+
+    private fun newRuntime(store: PluginConfigStore, http: MockHttpHostApi): LuaScriptRuntime {
+        val dir = File("../plugins/webdav-clipboard-sync")
+        assertTrue("插件目录应存在: ${dir.absolutePath}", dir.exists())
+        val runtime = LuaScriptRuntime(
+            "com.kingzcheung.xime.plugin.webdav_clipboard_sync",
+            dir,
+            "main.lua",
+            store,
+            hostApi = DebugHostApi(store),
+            httpHostApi = http,
+            cryptoHostApi = MockCryptoHostApi()
+        )
+        assertTrue("main.lua 应能加载", runtime.load())
+        return runtime
+    }
+
+    private fun profileTable(text: String, hash: String): org.luaj.vm2.LuaTable {
+        val table = org.luaj.vm2.LuaTable()
+        table.set("type", "text")
+        table.set("hash", hash)
+        table.set("text", text)
+        table.set("has_data", org.luaj.vm2.LuaValue.FALSE)
+        table.set("size", org.luaj.vm2.LuaValue.valueOf(text.length.toDouble()))
+        return table
+    }
+
+    @Test
+    fun `main lua loads and exposes sync contract`() {
+        val runtime = newRuntime(InMemoryConfigStore(), MockHttpHostApi())
+        val schema = runtime.call("getSettingsSchema")
+        assertTrue("应导出 getSettingsSchema", schema.istable())
+        assertEquals(5, LuaScriptRuntime.tableToList(schema).size)
+    }
+
+    @Test
+    fun `push sends PUT to webdav clipboard json with basic auth`() {
+        val store = InMemoryConfigStore()
+        store.set("davUrl", "https://192.168.1.50:8080/dav/")
+        store.set("username", "alice")
+        store.set("password", "secret")
+        val http = MockHttpHostApi()
+        http.responseQueue.addLast(HttpResponse(201))
+        val runtime = newRuntime(store, http)
+
+        val ok = runtime.call("push", profileTable("hello", "abc")).toboolean()
+
+        assertTrue("push 应成功", ok)
+        assertEquals(1, http.requests.size)
+        val (method, url, headers) = http.requests[0]
+        assertEquals("PUT", method)
+        assertEquals("https://192.168.1.50:8080/dav/clipboard/current.json", url)
+        val expectedAuth = "Basic " + java.util.Base64.getEncoder()
+            .encodeToString("alice:secret".toByteArray())
+        assertEquals(expectedAuth, headers["Authorization"])
+    }
+
+    @Test
+    fun `push creates missing directories via MKCOL on 409 then retries`() {
+        val store = InMemoryConfigStore()
+        store.set("davUrl", "https://192.168.1.50:8080/dav/")
+        store.set("remotePath", "xime")
+        val http = MockHttpHostApi()
+        // PUT → 409（目录不存在），随后 MKCOL 从 davUrl 之后逐级创建（/xime、/xime/clipboard，
+        // 405=已存在、201=创建），再 PUT → 201
+        http.responseQueue.addLast(HttpResponse(409))
+        http.responseQueue.addLast(HttpResponse(405))
+        http.responseQueue.addLast(HttpResponse(201))
+        http.responseQueue.addLast(HttpResponse(201))
+        val runtime = newRuntime(store, http)
+
+        val ok = runtime.call("push", profileTable("hello", "abc")).toboolean()
+
+        assertTrue("push 应成功", ok)
+        assertEquals(4, http.requests.size)
+        val methods = http.requests.map { it.first }
+        assertEquals(listOf("PUT", "MKCOL", "MKCOL", "PUT"), methods)
+        // 验证 MKCOL 从 davUrl 之后开始，不触碰服务器根
+        val mkcolUrls = http.requests.filter { it.first == "MKCOL" }.map { it.second }
+        assertEquals(
+            listOf(
+                "https://192.168.1.50:8080/dav/xime",
+                "https://192.168.1.50:8080/dav/xime/clipboard"
+            ),
+            mkcolUrls
+        )
+    }
+
+    @Test
+    fun `push honors remotePath in url`() {
+        val store = InMemoryConfigStore()
+        store.set("davUrl", "https://192.168.1.50:8080/dav/")
+        store.set("remotePath", "xime")
+        val http = MockHttpHostApi()
+        http.responseQueue.addLast(HttpResponse(201))
+        val runtime = newRuntime(store, http)
+
+        val ok = runtime.call("push", profileTable("hello", "abc")).toboolean()
+
+        assertTrue("push 应成功", ok)
+        assertEquals(1, http.requests.size)
+        val (method, url) = http.requests[0]
+        assertEquals("PUT", method)
+        assertEquals("https://192.168.1.50:8080/dav/xime/clipboard/current.json", url)
+    }
+
+    @Test
+    fun `push sends JSON profile body`() {
+        val store = InMemoryConfigStore()
+        store.set("davUrl", "https://192.168.1.50:8080/dav/")
+        val http = MockHttpHostApi()
+        http.responseQueue.addLast(HttpResponse(201))
+        val runtime = newRuntime(store, http)
+
+        val ok = runtime.call("push", profileTable("hello", "abc")).toboolean()
+
+        assertTrue("push 应成功", ok)
+        val body = http.requestBodies[0]
+        assertTrue("body 应为 JSON", body.startsWith("{"))
+        assertTrue("body 应含 text", body.contains("\"hello\""))
+        assertTrue("body 应含 hash", body.contains("\"abc\""))
+    }
+
+    @Test
+    fun `pull returns profile on 200 json and caches etag`() {
+        val store = InMemoryConfigStore()
+        store.set("davUrl", "https://192.168.1.50:8080/dav/")
+        val http = MockHttpHostApi()
+        val profileJson = """{"type":"text","hash":"abc123","text":"远端内容","has_data":false,"data_name":null,"size":12,"source":"desktop"}"""
+        http.responseQueue.addLast(
+            HttpResponse(200, mapOf("ETag" to "webdav-etag-1"), profileJson.toByteArray())
+        )
+        val runtime = newRuntime(store, http)
+
+        val result = runtime.call("pull")
+
+        assertTrue("pull 应返回 table", result.istable())
+        val map = LuaScriptRuntime.tableToMap(result)
+        assertEquals("远端内容", map["text"]?.tojstring())
+        assertEquals("abc123", map["hash"]?.tojstring())
+        assertEquals("desktop", map["source"]?.tojstring())
+        assertEquals("webdav-etag-1", store.get("lastEtag"))
+    }
+
+    @Test
+    fun `pull falls back to plain text for legacy file`() {
+        val store = InMemoryConfigStore()
+        store.set("davUrl", "https://192.168.1.50:8080/dav/")
+        val http = MockHttpHostApi()
+        http.responseQueue.addLast(HttpResponse(200, mapOf("ETag" to "etag-2"), "旧版纯文本".toByteArray()))
+        val runtime = newRuntime(store, http)
+
+        val result = runtime.call("pull")
+
+        assertTrue("pull 应返回 table", result.istable())
+        val map = LuaScriptRuntime.tableToMap(result)
+        assertEquals("旧版纯文本", map["text"]?.tojstring())
+    }
+
+    @Test
+    fun `pull returns null on 304`() {
+        val store = InMemoryConfigStore()
+        store.set("davUrl", "https://192.168.1.50:8080/dav/")
+        store.set("lastEtag", "webdav-etag-1")
+        val http = MockHttpHostApi()
+        http.responseQueue.addLast(HttpResponse(304))
+        val runtime = newRuntime(store, http)
+
+        val result = runtime.call("pull")
+
+        assertTrue("304 应返回 nil", result.isnil())
+        assertEquals(1, http.requests.size)
+        val headers = http.requests[0].third
+        assertEquals("webdav-etag-1", headers["If-None-Match"])
+    }
+
+    @Test
+    fun `pull returns null on 404`() {
+        val store = InMemoryConfigStore()
+        store.set("davUrl", "https://192.168.1.50:8080/dav/")
+        val http = MockHttpHostApi()
+        http.responseQueue.addLast(HttpResponse(404))
+        val runtime = newRuntime(store, http)
+
+        val result = runtime.call("pull")
+
+        assertTrue("404 应返回 nil", result.isnil())
+    }
+
+    @Test
+    fun `testConnection uses PROPFIND on clipboard directory`() {
+        val store = InMemoryConfigStore()
+        store.set("davUrl", "https://192.168.1.50:8080/dav/")
+        val http = MockHttpHostApi()
+        http.responseQueue.addLast(HttpResponse(207))
+        val runtime = newRuntime(store, http)
+
+        val error = runtime.call("testConnection").tojstring()
+
+        assertFalse("207 视为连接成功: $error", error.contains("失败"))
+        assertEquals(1, http.requests.size)
+        val (method, url, headers) = http.requests[0]
+        assertEquals("PROPFIND", method)
+        assertEquals("https://192.168.1.50:8080/dav/clipboard", url)
+        assertEquals("0", headers["Depth"])
+    }
+
+    @Test
+    fun `testConnection reports auth failure`() {
+        val store = InMemoryConfigStore()
+        store.set("davUrl", "https://192.168.1.50:8080/dav/")
+        val http = MockHttpHostApi()
+        http.responseQueue.addLast(HttpResponse(401))
+        val runtime = newRuntime(store, http)
+
+        val error = runtime.call("testConnection").tojstring()
+
+        assertTrue("应报告认证失败: $error", error.contains("认证失败"))
+    }
+
+    @Test
+    fun `testConnection reports missing config`() {
+        val runtime = newRuntime(InMemoryConfigStore(), MockHttpHostApi())
+        val error = runtime.call("testConnection").tojstring()
+        assertTrue("未配置时应报告错误: $error", error.contains("未配置"))
+    }
+
+    @Test
+    fun `testConnection succeeds on 404 (server reachable, file not yet created)`() {
+        val store = InMemoryConfigStore()
+        store.set("davUrl", "https://192.168.1.50:8080/dav/")
+        val http = MockHttpHostApi()
+        http.responseQueue.addLast(HttpResponse(404))
+        val runtime = newRuntime(store, http)
+
+        val error = runtime.call("testConnection").tojstring()
+
+        assertFalse("404 视为连接成功", error.contains("失败"))
+    }
+
+    @Test
+    fun `push returns false when url not configured`() {
+        val runtime = newRuntime(InMemoryConfigStore(), MockHttpHostApi())
+        val ok = runtime.call("push", profileTable("hello", "abc")).toboolean()
+        assertFalse("未配置时应失败", ok)
+    }
+
+    @Test
+    fun `pull returns nil when url not configured`() {
+        val runtime = newRuntime(InMemoryConfigStore(), MockHttpHostApi())
+        val result = runtime.call("pull")
+        assertTrue("未配置时应返回 nil", result.isnil())
+    }
+}

--- a/plugins/webdav-clipboard-sync/main.lua
+++ b/plugins/webdav-clipboard-sync/main.lua
@@ -1,0 +1,289 @@
+-- ximed WebDAV 剪贴板同步插件（Lua 脚本插件）
+--
+-- 对接 ximed 的 WebDAV 直连适配器（crates/client/src/direct/webdav.rs）：
+-- 通过 WebDAV 服务器上的单个 JSON 文件实现剪贴板双向同步。
+--
+-- 职责划分：
+--   Lua   = 协议逻辑（WebDAV PUT/GET/MKCOL、Basic Auth、ETag 条件拉取、Profile JSON）
+--   宿主  = 同步引擎（轮询/去重/回声抑制）+ 通用原语：
+--     host.http        请求原语（PUT/GET/PROPFIND/MKCOL，域名经用户授权）
+--     host.json        JSON 编解码
+--     host.config      配置存储（含 ETag 缓存）
+--
+-- WebDAV 交互模型（对齐 ximed WebDavTransport 的 JSON Profile 协议）：
+--   文件   {davUrl}/{remotePath}/clipboard/current.json
+--          davUrl = 服务器根（如 https://dav.jianguoyun.com/dav/）
+--          remotePath = 远程目录（如 xime，留空为根目录）
+--   push   PUT 文件，body = Profile JSON（Content-Type: application/json）
+--          目录不存在（409）→ 逐级 MKCOL 创建后重试
+--   pull   GET 文件，If-None-Match（ETag 缓存，ximed 无此优化，插件增强保留），
+--          304 → 无变更；404 → 远端尚无文件；200 → 解析 Profile JSON
+--   兼容   远端若为旧版纯文本（无 JSON 结构），按纯文本 profile 处理
+--   认证   Authorization: Basic base64(user:pass)
+
+local plugin = {}
+
+local KEY_DAV_URL = "davUrl"
+local KEY_REMOTE_PATH = "remotePath"
+local KEY_USERNAME = "username"
+local KEY_PASSWORD = "password"
+local KEY_LAST_ETAG = "lastEtag"
+
+local CLIPBOARD_KEY = "clipboard/current.json"
+
+-- ================= 工具函数 =================
+
+local function basicAuthHeader(username, password)
+    local cred = username .. ":" .. password
+    return "Basic " .. host.crypto.base64(cred)
+end
+
+local function buildHeaders()
+    local headers = {}
+    local username = host.config.get(KEY_USERNAME) or ""
+    local password = host.config.get(KEY_PASSWORD) or ""
+    if username ~= "" then
+        headers["Authorization"] = basicAuthHeader(username, password)
+    end
+    return headers
+end
+
+-- 远端剪贴板文件 URL：{davUrl}/{remotePath}/clipboard/current.json
+local function fileUrl()
+    local base = host.config.get(KEY_DAV_URL) or ""
+    base = base:gsub("/+$", "")
+    if base == "" then return nil end
+    local path = host.config.get(KEY_REMOTE_PATH) or ""
+    path = path:gsub("^/+", ""):gsub("/+$", "")
+    if path ~= "" then base = base .. "/" .. path end
+    return base .. "/" .. CLIPBOARD_KEY
+end
+
+-- 远端剪贴板目录 URL（{davUrl}/{remotePath}/clipboard，用于连接测试的 PROPFIND 探测）
+local function remoteDirUrl()
+    local url = fileUrl()
+    if url == nil then return nil end
+    return url:gsub("/[^/]+$", "")
+end
+
+-- 从文件 URL 里解析出目录层级（不含文件名），逐级 MKCOL 创建。
+-- 从用户配置的 davUrl（通常已存在）之后开始创建，避免 MKCOL 服务器根/WebDAV 根被拒。
+-- 已存在（405/201/重定向）视为成功，权限不足/网络失败返回 false。
+local function ensureDirectories(fileUrl)
+    local base = host.config.get(KEY_DAV_URL) or ""
+    base = base:gsub("/+$", "")
+    if base == "" then return false end
+    local dirPart = fileUrl:gsub("^https?://[^/]+", "")
+    dirPart = dirPart:gsub("/[^/]+$", "") or ""
+    local basePath = base:gsub("^https?://[^/]+", ""):gsub("/+$", "")
+    -- 去掉 davUrl 已有路径前缀，只创建剩余层级
+    if basePath ~= "" then
+        dirPart = dirPart:gsub("^" .. basePath, "")
+    end
+    dirPart = dirPart:gsub("^/+", "")
+    local parts = {}
+    for part in dirPart:gmatch("([^/]+)") do
+        table.insert(parts, part)
+    end
+    local current = base
+    for _, part in ipairs(parts) do
+        current = current .. "/" .. part
+        local resp = host.http.request("MKCOL", current, buildHeaders(), nil)
+        if resp == nil then
+            host.logError("MKCOL 失败（网络/拒绝）: " .. current .. " " .. (host.http.lastError() or ""))
+            return false
+        end
+        local s = resp.status
+        if s >= 200 and s < 300 then
+            -- 已创建（201）或已存在（200）
+        elseif s == 405 or s == 301 or s == 302 or s == 307 or s == 308 then
+            -- 已存在 / 重定向：视为目录可用
+        else
+            host.logError("MKCOL 失败: " .. current .. " -> HTTP " .. s)
+            return false
+        end
+    end
+    return true
+end
+
+local function cacheEtag(resp)
+    if resp == nil or resp.headers == nil then return end
+    local etag = resp.headers["ETag"]
+    if etag == nil then etag = resp.headers["etag"] end
+    if etag ~= nil and etag ~= "" then
+        host.config.set(KEY_LAST_ETAG, etag)
+    end
+end
+
+-- ================= 配置 schema（与 manifest 一致） =================
+
+function plugin.getSettingsSchema()
+    return {
+        {
+            key = KEY_DAV_URL,
+            label = "WebDAV 服务器",
+            type = "text",
+            placeholder = "https://host:port/dav/",
+            helpText = "WebDAV 服务地址（形如 https://192.168.1.50:8080/dav/）",
+        },
+        {
+            key = KEY_REMOTE_PATH,
+            label = "远程目录",
+            type = "text",
+            placeholder = "xime",
+            required = false,
+            helpText = "剪贴板文件所在目录（留空为根目录，如 xime → dav/xime/clipboard/current.json）",
+        },
+        {
+            key = KEY_USERNAME,
+            label = "用户名",
+            type = "text",
+            required = false,
+        },
+        {
+            key = KEY_PASSWORD,
+            label = "密码",
+            type = "secret",
+            required = false,
+        },
+        {
+            key = "testConnection",
+            label = "测试连接",
+            type = "button",
+            action = "testConnection",
+            required = false,
+        },
+    }
+end
+
+-- ================= 生命周期 =================
+
+function plugin.onLoad()
+    return true
+end
+
+function plugin.onUnload()
+    return true
+end
+
+-- ================= 同步接口 =================
+
+-- 推送本地 profile 到远端 WebDAV 文件（宿主剪贴板变化时调用）
+function plugin.push(profile)
+    local url = fileUrl()
+    if url == nil then
+        host.logError("push failed: 未配置服务器地址")
+        return false
+    end
+    local headers = buildHeaders()
+    headers["Content-Type"] = "application/json"
+    local body = host.json.encode(profile)
+    if body == nil then
+        host.logError("push failed: Profile JSON 序列化失败")
+        return false
+    end
+    local resp = host.http.request("PUT", url, headers, body)
+    if resp == nil then
+        host.logError("push failed: 请求失败 " .. (host.http.lastError() or ""))
+        return false
+    end
+    if resp.status >= 200 and resp.status < 300 then
+        cacheEtag(resp)
+        host.log("push ok: PUT " .. url .. " -> " .. resp.status)
+        return true
+    end
+    -- 409 Conflict：目录不存在，逐级 MKCOL 后重试一次
+    if resp.status == 409 then
+        host.log("push: 409 目录不存在，尝试 MKCOL 创建")
+        if ensureDirectories(url) then
+            local retry = host.http.request("PUT", url, headers, body)
+            if retry ~= nil and retry.status >= 200 and retry.status < 300 then
+                cacheEtag(retry)
+                host.log("push ok: MKCOL 后重试成功 " .. url .. " -> " .. retry.status)
+                return true
+            end
+            host.logError("push failed: MKCOL 后重试失败 " .. (retry ~= nil and retry.status or "无响应"))
+        else
+            host.logError("push failed: MKCOL 创建目录失败")
+        end
+        return false
+    end
+    host.logError("push failed: PUT " .. url .. " -> HTTP " .. resp.status)
+    return false
+end
+
+-- 拉取远端 profile（宿主轮询调用）；无变更/无文件返回 nil
+function plugin.pull()
+    local url = fileUrl()
+    if url == nil then
+        host.log("pull: 未配置服务器地址")
+        return nil
+    end
+    local headers = buildHeaders()
+    local etag = host.config.get(KEY_LAST_ETAG)
+    if etag ~= nil and etag ~= "" then
+        headers["If-None-Match"] = etag
+    end
+    local resp = host.http.request("GET", url, headers, nil)
+    if resp == nil then
+        host.logError("pull failed: 请求失败 " .. (host.http.lastError() or ""))
+        return nil
+    end
+    if resp.status == 304 then
+        -- Not Modified，无变更
+        return nil
+    end
+    if resp.status == 404 then
+        -- 远端尚无文件，视为无变更
+        return nil
+    end
+    if resp.status >= 200 and resp.status < 300 then
+        cacheEtag(resp)
+        local text = resp.text
+        if text == nil or text == "" then
+            host.log("pull: 远端文件为空")
+            return nil
+        end
+        local decoded = host.json.decode(text)
+        if decoded ~= nil and type(decoded) == "table" and decoded.text ~= nil then
+            -- 新版 JSON Profile（与 ximed Profile 同构）
+            return decoded
+        end
+        -- 兼容旧版纯文本文件：按纯文本构造 profile，hash 留空让宿主计算
+        host.log("pull: 远端非 JSON，按纯文本兼容处理")
+        return {
+            type = "text",
+            hash = "",
+            text = text,
+            has_data = false,
+            data_name = nil,
+            size = #text,
+            source = nil,
+        }
+    end
+    host.logError("pull failed: GET " .. url .. " -> HTTP " .. resp.status)
+    return nil
+end
+
+-- 校验配置可用性（连接测试）；返回错误消息，nil 表示成功
+function plugin.testConnection()
+    local url = remoteDirUrl()
+    if url == nil then return "未配置服务器地址" end
+    -- 用 PROPFIND（Depth: 0）探测目录而非 HEAD：部分 WebDAV 服务（如坚果云）对 HEAD 返回 503
+    local headers = buildHeaders()
+    headers["Depth"] = "0"
+    local resp = host.http.request("PROPFIND", url, headers, nil)
+    if resp == nil then
+        return host.http.lastError() or "连接失败"
+    end
+    if resp.status == 401 or resp.status == 403 then
+        return "认证失败（HTTP " .. resp.status .. "）"
+    end
+    -- 207 Multi-Status / 2xx / 404（目录尚不存在，可创建）均视为连接成功
+    if resp.status >= 200 and resp.status < 300 or resp.status == 404 or resp.status == 405 then
+        return nil
+    end
+    return "连接失败（HTTP " .. resp.status .. "）"
+end
+
+return plugin

--- a/plugins/webdav-clipboard-sync/manifest.yaml
+++ b/plugins/webdav-clipboard-sync/manifest.yaml
@@ -1,0 +1,63 @@
+# =============================================
+# Xime Lua 插件元数据（宿主用 YAML 解析）
+# =============================================
+
+# 插件唯一标识
+id: com.kingzcheung.xime.plugin.webdav_clipboard_sync
+
+# 插件名称与描述
+name: WebDAV 剪贴板同步
+icon: "☁️"
+description: 通过 WebDAV 文件同步剪贴板（文本，多设备）
+
+# 插件版本（字符串）
+version: 0.1.0
+
+# 插件分类：clipboard_sync 剪贴板同步（单选激活）
+type: clipboard_sync
+activation: single
+
+# 入口脚本
+entry: main.lua
+
+# 宿主最低版本要求
+minHostVersion: 2.6.0
+
+# 能力声明
+capabilities:
+  clipboard_sync:
+    protocols:
+      - webdav   # 通过 WebDAV 同步剪贴板（与 ximed WebDavTransport 协议一致）
+
+# 网络访问声明：服务器地址由用户配置，域名不固定。
+# allowCustomHosts: 接受用户填写的服务器地址域名，经配置后自动授权联网
+network:
+  hosts: []
+  allowCustomHosts: true
+
+# 配置字段声明（插件中心直接渲染表单）
+configSchema:
+  - key: davUrl
+    label: WebDAV 服务器
+    type: text
+    placeholder: https://host:port/dav/
+    helpText: WebDAV 服务地址（形如 https://192.168.1.50:8080/dav/，需支持 Basic Auth 的 PUT/GET）
+  - key: remotePath
+    label: 远程目录
+    type: text
+    placeholder: xime
+    required: false
+    helpText: 剪贴板文件所在目录（留空为根目录，同步到 {地址}/{目录}/clipboard/current.json）
+  - key: username
+    label: 用户名
+    type: text
+    required: false
+  - key: password
+    label: 密码
+    type: secret
+    required: false
+  - key: testConnection
+    label: 测试连接
+    type: button
+    action: testConnection
+    required: false


### PR DESCRIPTION
- 在ClipboardSyncBridge中添加pluginId参数以标识当前使用的插件
- 实现插件切换逻辑，支持用户选择首选的剪贴板同步插件
- 添加设置项KEY_CLIPBOARD_SYNC_PLUGIN_ID用于保存用户选择
- 更新UI界面显示可用插件列表，支持单选激活机制
- 优化HttpHostApiImpl避免轮询时重复授权日志刷屏
- 增加WebDAV相关HTTP方法(MKCOL, PROPFIND)支持
- 添加Lua脚本环境的logError函数供插件使用错误日志记录

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] 新功能
- [ ] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
