### PR TITLE
feat(clipboard): 添加剪贴板项消费状态管理功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/clipboard/ClipboardManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/ClipboardManager.kt
@@ -24,7 +24,8 @@ data class ClipboardItem(
     val text: String,
     val timestamp: Long = System.currentTimeMillis(),
     val isPinned: Boolean = false,
-    val isQuickSend: Boolean = false
+    val isQuickSend: Boolean = false,
+    val consumed: Boolean = false
 )
 
 class ClipboardManager private constructor(private val context: Context) {
@@ -199,7 +200,8 @@ class ClipboardManager private constructor(private val context: Context) {
             text = text,
             timestamp = timestamp,
             isPinned = isPinned,
-            isQuickSend = isQuickSend
+            isQuickSend = isQuickSend,
+            consumed = consumed
         )
     }
 
@@ -209,7 +211,8 @@ class ClipboardManager private constructor(private val context: Context) {
             text = text,
             timestamp = timestamp,
             isPinned = isPinned,
-            isQuickSend = isQuickSend
+            isQuickSend = isQuickSend,
+            consumed = consumed
         )
     }
 
@@ -312,7 +315,21 @@ class ClipboardManager private constructor(private val context: Context) {
     fun getRecentItems(seconds: Int = 30): List<ClipboardItem> {
         val now = System.currentTimeMillis()
         val cutoff = now - seconds * 1000L
-        return _clipboardItems.value.filter { it.timestamp >= cutoff }
+        // 候选栏只展示未消费的最近剪贴板项（用户点选上屏后标记 consumed 不再显示）
+        return _clipboardItems.value.filter { it.timestamp >= cutoff && !it.consumed }
+    }
+
+    /**
+     * 标记指定文本的剪贴板条目为"已消费"（候选栏不再显示）。
+     * 匹配最近一条未消费的相同文本，避免影响历史重复条目。
+     */
+    fun markConsumed(text: String) {
+        scope.launch {
+            val item = _clipboardItems.value
+                .filter { it.text == text && !it.consumed }
+                .maxByOrNull { it.timestamp } ?: return@launch
+            dao.markConsumed(item.id)
+        }
     }
 
     fun copyImageToSystemClipboard(imagePath: String, label: String = "emoji_image"): Boolean {

--- a/app/src/main/java/com/kingzcheung/xime/clipboard/db/ClipboardDao.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/db/ClipboardDao.kt
@@ -52,6 +52,9 @@ interface ClipboardDao {
     @Query("UPDATE clipboard_entries SET text = :text, timestamp = :now WHERE id = :id")
     suspend fun updateText(id: Long, text: String, now: Long)
 
+    @Query("UPDATE clipboard_entries SET consumed = 1 WHERE id = :id")
+    suspend fun markConsumed(id: Long)
+
     @Query("DELETE FROM clipboard_entries")
     suspend fun deleteAll()
 

--- a/app/src/main/java/com/kingzcheung/xime/clipboard/db/ClipboardDatabase.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/db/ClipboardDatabase.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.room3.Database
 import androidx.room3.Room
 import androidx.room3.RoomDatabase
+import androidx.room3.migration.Migration
+import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.driver.AndroidSQLiteDriver
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -11,7 +13,7 @@ import kotlinx.coroutines.SupervisorJob
 
 @Database(
     entities = [ClipboardEntry::class],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 abstract class ClipboardDatabase : RoomDatabase() {
@@ -19,6 +21,15 @@ abstract class ClipboardDatabase : RoomDatabase() {
 
     companion object {
         private const val DATABASE_NAME = "clipboard.db"
+
+        /** v1 → v2：新增 consumed 列（候选栏"已消费"剪贴板项过滤）。 */
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override suspend fun migrate(connection: SQLiteConnection) {
+                connection.prepare(
+                    "ALTER TABLE clipboard_entries ADD COLUMN consumed INTEGER NOT NULL DEFAULT 0"
+                ).step()
+            }
+        }
 
         @Volatile
         private var instance: ClipboardDatabase? = null
@@ -31,6 +42,7 @@ abstract class ClipboardDatabase : RoomDatabase() {
                 )
                     .setDriver(AndroidSQLiteDriver())
                     .setQueryCoroutineContext(Dispatchers.IO)
+                    .addMigrations(MIGRATION_1_2)
                     .build()
                     .also { instance = it }
             }

--- a/app/src/main/java/com/kingzcheung/xime/clipboard/db/ClipboardEntry.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/db/ClipboardEntry.kt
@@ -14,5 +14,6 @@ data class ClipboardEntry(
     val text: String,
     @ColumnInfo(defaultValue = "0") val timestamp: Long = System.currentTimeMillis(),
     @ColumnInfo(defaultValue = "0") val isPinned: Boolean = false,
-    @ColumnInfo(defaultValue = "0") val isQuickSend: Boolean = false
+    @ColumnInfo(defaultValue = "0") val isQuickSend: Boolean = false,
+    @ColumnInfo(defaultValue = "0") val consumed: Boolean = false
 )

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeTextCommit.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeTextCommit.kt
@@ -97,6 +97,8 @@ internal class ImeTextCommit(private val service: XimeInputMethodService) {
                 }
             }
         }
+        // 标记为已消费：候选栏/剪贴板点选上屏后不再重复出现在候选栏
+        service.clipboardManager.markConsumed(text)
         service.commitText(text)
         service.clipboardManager.copyToSystemClipboard(text)
     }


### PR DESCRIPTION
- 在ClipboardItem中新增consumed字段用于标记是否已被消费
- 实现markConsumed方法来标记指定文本的剪贴板条目为已消费状态
- 修改数据库结构，从v1升级到v2，添加consumed列并提供迁移脚本
- 更新候选栏逻辑，只显示未消费的最近剪贴板项
- 在输入法提交文本时自动标记对应剪贴板项为已消费状态
- 避免已上屏的文本重复出现在候选栏中

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] 新功能
- [ ] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
