### PR TITLE
feat(t9): 九键输入后选词上屏后词典调频与简拼长词召回（Draft，待子仓库合并）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ app/src/main/jni/snappy/
 app/src/main/jni/boost*
 app/src/main/jni/onnxruntime/
 app/src/main/jniLibs/
+app/src/main/jni/librime-t9/build_test/
 app/release
 # Large archives
 *.tar.xz

--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
@@ -575,10 +575,11 @@ class RimeEngine {
     // ═══════════════════════════════════════════════════════════
 
     /**
-     * 右选候选：根据候选拼音注释和文本长度执行右侧选词。
+     * 右选候选：根据候选拼音注释与文本长度执行右侧选词（消费计算）。
      * 委托给 T9RightCommitHandler 三层消费算法，判断 full/partial commit。
-     * @param pinyin 候选词的拼音注释（如 "ji"）
-     * @param textLength 候选词字数（如 "计划" 为 2）
+     * 调频不在此进行——由 Kotlin 在 full commit 上屏后经 [t9Memorize] 单独调用。
+     * @param pinyin 候选词的拼音注释（如 "li hua"）
+     * @param textLength 候选词字数（如 "丽华" 为 2）
      */
     fun t9SelectCandidate(pinyin: String, textLength: Int): Boolean {
         if (!isInitialized) return false
@@ -587,6 +588,25 @@ class RimeEngine {
             nativeT9SelectCandidate(pinyin, textLength)
         }
     }
+
+    /** 用户词典写入/回滚公共实现：memorize=true → commits=+1；false → commits=-1。 */
+    private fun t9DictOp(text: String, pinyin: String, memorize: Boolean): Boolean {
+        if (!isInitialized || text.isEmpty() || pinyin.isEmpty()) return false
+        return tryLocked(false) {
+            if (!nativeHasSession() && !nativeCreateSession()) return@tryLocked false
+            if (memorize) nativeT9Memorize(text, pinyin) else nativeT9Forget(text, pinyin)
+        }
+    }
+
+    /**
+     * 用户词典调频写入：在 full commit（含 partial 拼接）上屏后调用，
+     * text 为上屏完整文本，pinyin 为空格分隔的拼音音节串（如 "ji hu a"）。
+     * C++ 构造 RIME 原生 DictEntry 写入（key 由 RIME 生成）。
+     */
+    fun t9Memorize(text: String, pinyin: String): Boolean = t9DictOp(text, pinyin, true)
+
+    /** 用户词典调频回滚（undo 联动）：撤销 right commit 段时调用，commits=-1。 */
+    fun t9Forget(text: String, pinyin: String): Boolean = t9DictOp(text, pinyin, false)
 
     // Native 方法声明
     private external fun nativeInitialize(userDataDir: String, sharedDataDir: String)
@@ -655,6 +675,8 @@ class RimeEngine {
     private external fun nativeSetPageSize(schemaId: String, pageSize: Int)
     private external fun nativeDestroy()
     private external fun nativeT9SelectCandidate(pinyin: String, textLength: Int): Boolean
+    private external fun nativeT9Memorize(text: String, pinyin: String): Boolean
+    private external fun nativeT9Forget(text: String, pinyin: String): Boolean
     private external fun nativeT9SelectPinyinDirect(pinyin: String, digitLength: Int): Boolean
     private external fun nativeT9GetLeftPanelState(): String?
     private external fun nativeT9ClearComposition(mode: Int)

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
@@ -306,6 +306,10 @@ class T9InputController(
      * 右选候选（保持同步返回值契约，供服务层判断 full/partial commit）。
      * 由服务层在 keyProcessingDispatcher（后台线程）调用。先等待后台队列排空再执行，
      * 避免 pending 覆盖导致消费计算错乱——阻塞的是该后台线程，不冻结主线程（方案 B）。
+     * 调频不在此进行——由服务层在 full commit 上屏后经 rimeEngine.t9Memorize 单独调用。
+     *
+     * @param candidatePinyin 候选词拼音注释（comment），null 表示无注释候选（如 emoji）
+     * @param candidateTextLength 候选词字数
      */
     fun onRightCandidateSelected(candidatePinyin: String? = null, candidateTextLength: Int = 0): Boolean {
         awaitT9Queue()

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
@@ -127,7 +127,7 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                             else -> inputFieldText + candState.inputText + candState.pendingEnglishText
                         }
                         // 清空 partial 累积，避免残留词被 buildT9DisplayState 拼进下一轮 preedit。
-                        service.t9PartialCommitTexts.clear()
+                        service.t9PartialSegments.clear()
                         service.rimeEngine.clearComposition()
                         service.candidateState.value = service.candidateState.value.copy(
                             candidates = emptyList(),
@@ -186,7 +186,7 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                         }
                         if (isT9) {
                             // 同步清空，避免异步 postRimeJob 延迟导致后续 backspace 拿到旧状态。
-                            service.t9PartialCommitTexts.clear()
+                            service.t9PartialSegments.clear()
                             service.rimeEngine.setInput("")
                             service.rimeEngine.clearComposition()
                         } else {
@@ -265,7 +265,7 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                                 // preedit中残留上一轮的提交内容（如"看"→下一轮"看jihua"）
                                 if (isT9Schema(state.currentSchemaId)) {
                                     withContext(Dispatchers.Main) {
-                                        service.t9PartialCommitTexts.clear()
+                                        service.t9PartialSegments.clear()
                                         service.uiState.value = service.uiState.value.copy(
                                             t9ResetSignal = service.uiState.value.t9ResetSignal + 1,
                                             t9RightCandidateSelectedCount = 0,
@@ -395,6 +395,8 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                                 needsUIUpdate = true
                             }
                         } else {
+                            // 注：T9 数字键不经过此处（T9KeyboardLayout 直接调
+                            // controller.onDigitPressed → applyComposition）。
                             val result = service.rimeEngine.processKeyAndGetResult(keyCode, mask)
                             if (result.processed) {
                                 if (isShiftedChinese && result.committedText != char) {
@@ -636,8 +638,8 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                     // T9 部分提交：剩余编码删完后，已上屏/ composing 的部分候选词无法用
                     // RIME 退格删除，会一直卡在候选栏。这里撤销最近一次部分提交：
                     // 清空 composing 区域（或删除上屏文本）并从累积列表移除。
-                    if (service.t9PartialCommitTexts.isNotEmpty()) {
-                        val len = service.t9PartialCommitTexts.last().length
+                    if (service.t9PartialSegments.isNotEmpty()) {
+                        val len = service.t9PartialSegments.last().text.length
                         withContext(Dispatchers.Main) {
                             if (SettingsPreferences.getInputTextLocation(service)
                                 == SettingsPreferences.INPUT_TEXT_INPUT_BOX) {
@@ -646,7 +648,11 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                                 service.currentInputConnection?.deleteSurroundingText(len, 0)
                             }
                         }
-                        service.t9PartialCommitTexts.removeLastOrNull()
+                        // undo 联动：撤销段时回滚用户词典调频。
+                        val undone = service.t9PartialSegments.removeLastOrNull()
+                        if (undone != null) {
+                            service.rimeEngine.t9Forget(undone.text, undone.pinyin)
+                        }
                     }
                 }
                 service.uiEventChannel.trySend {
@@ -757,22 +763,34 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                 selectedCandidate!!
             }
             // T9 full commit：partial commit 累积文本（未单独上屏，只存在于
-            // service.t9PartialCommitTexts 的 composing 区）与本次上屏文本是独立词，必须拼接，
+            // service.t9PartialSegments 的 composing 区）与本次上屏文本是独立词，必须拼接，
             // 不能去重（mergePartialCommitText 仅用于显示，会吞掉重复的词）。
             // 但若点击的是 partial 词本身（RIME 无菜单、候选栏显示的就是 partial 词，
             // 无拼音注释 candidatePinyin==null），则只提交累积的 partial 文本，避免重复。
-            val fullCommitText = if (isT9 && service.t9PartialCommitTexts.isNotEmpty()) {
+            val partialTexts = service.t9PartialSegments.map { it.text }
+            val fullCommitText = if (isT9 && partialTexts.isNotEmpty()) {
                 if (candidatePinyin == null) {
-                    service.t9PartialCommitTexts.joinToString("")
+                    partialTexts.joinToString("")
                 } else {
-                    service.t9PartialCommitTexts.joinToString("") + textToMerge
+                    partialTexts.joinToString("") + textToMerge
                 }
             } else {
                 textToMerge
             }
+            // 调频拼音与上屏文本同源：partial 累积拼音 + 当前候选拼音（如 "ji hu a"）。
+            val fullCommitPinyin = buildString {
+                service.t9PartialSegments.forEachIndexed { i, seg ->
+                    if (i > 0) append(' ')
+                    append(seg.pinyin)
+                }
+                if (candidatePinyin != null) {
+                    if (isNotEmpty()) append(' ')
+                    append(candidatePinyin)
+                }
+            }
             withContext(Dispatchers.Main) {
                 service.commitText(fullCommitText)
-                service.t9PartialCommitTexts.clear()
+                service.t9PartialSegments.clear()
                 service.candidateState.value = service.candidateState.value.copy(
                     inputText = "",
                     preeditText = "",
@@ -789,15 +807,19 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                     t9SelectedCandidatePinyin = ""
                 )
             }
+            // 用户词典调频：记忆实际上屏文本（后台线程，rimeLock 保护）。
+            if (isT9 && fullCommitText.isNotEmpty() && fullCommitPinyin.isNotEmpty()) {
+                service.rimeEngine.t9Memorize(fullCommitText, fullCommitPinyin)
+            }
             // T9 跳过了 service.rimeEngine.commit()，需显式清除 RIME composition，
             // 防止残留状态影响后续输入（在 service.keyProcessingDispatcher 上执行）。
             if (isT9) service.rimeEngine.clearComposition()
         } else {
             withContext(Dispatchers.Main) {
                 if (isT9) {
-                    // partial commit：把本次选中的候选文本追加到累积列表，供后续合并显示
+                    // partial commit：累积候选文本与拼音，供合并显示与 full commit 调频拼接。
                     if (selectedCandidate != null) {
-                        service.t9PartialCommitTexts.add(selectedCandidate)
+                        service.t9PartialSegments.add(T9PartialSegment(selectedCandidate, candidatePinyin ?: ""))
                     }
                     // 保留状态字段，供 UI 层感知右侧选词事件
                     service.uiState.value = service.uiState.value.copy(
@@ -830,7 +852,7 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
             candState.inputText.isNotEmpty() ||
             candState.preeditText.isNotEmpty() ||
             candState.pendingEnglishText.isNotEmpty() ||
-            service.t9PartialCommitTexts.isNotEmpty()
+            service.t9PartialSegments.isNotEmpty()
 
     /**
      * 清空输入态（预编辑/候选/联想/partial 累积/计算器），不动已上屏文本。
@@ -842,7 +864,7 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
     private suspend fun clearInputStateForKeys() {
         service.calculatorEngine.clear()
         updateCalculatorCandidates()
-        service.t9PartialCommitTexts.clear()
+        service.t9PartialSegments.clear()
         service.rimeEngine.clearComposition()
         service.candidateState.value = service.candidateState.value.copy(
             candidates = emptyList(),

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
@@ -242,7 +242,7 @@ internal fun rememberImeKeyboardCallbacks(
                             service.rimeEngine.clearComposition()
                         }
                         pinyin == T9InputController.CLEAR_ALL -> {
-                            service.t9PartialCommitTexts.clear()
+                            service.t9PartialSegments.clear()
                             service.rimeEngine.setInput("")
                             service.rimeEngine.clearComposition()
                         }
@@ -268,7 +268,13 @@ internal fun rememberImeKeyboardCallbacks(
                 } else {
                     service.currentInputConnection?.deleteSurroundingText(count, 0)
                 }
-                service.t9PartialCommitTexts.removeLastOrNull()
+                // undo 联动：撤销 right commit 段时回滚用户词典调频。
+                val undone = service.t9PartialSegments.removeLastOrNull()
+                if (undone != null) {
+                    service.serviceScope.launch(service.keyProcessingDispatcher) {
+                        service.rimeEngine.t9Forget(undone.text, undone.pinyin)
+                    }
+                }
             },
             onT9RefreshComposition = { composition ->
                 // composition 由 T9 控制器在 flush 后一次取回并传入，

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeSessionController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeSessionController.kt
@@ -54,7 +54,7 @@ internal class ImeSessionController(private val service: XimeInputMethodService)
             val rawPreedit = if (preeditText.isNotEmpty()) preeditText else inputText
             // preedit 转换由 C++ t9_filter 完成，Kotlin 侧直接使用引擎输出的 preedit
             val display = buildT9DisplayState(
-                service.t9PartialCommitTexts, rawPreedit, inputText, t9FilteredTexts, t9FilteredComments
+                service.t9PartialSegments.map { it.text }, rawPreedit, inputText, t9FilteredTexts, t9FilteredComments
             )
             displayText = display.displayText
             displayCandidates = display.displayCandidates
@@ -151,7 +151,7 @@ internal class ImeSessionController(private val service: XimeInputMethodService)
             val rawPreedit = if (result.preeditText.isNotEmpty()) result.preeditText else result.inputText
             // preedit 转换由 C++ t9_filter 完成，Kotlin 侧直接使用引擎输出的 preedit
             val display = buildT9DisplayState(
-                service.t9PartialCommitTexts, rawPreedit, result.inputText, t9FilteredTexts, t9FilteredComments
+                service.t9PartialSegments.map { it.text }, rawPreedit, result.inputText, t9FilteredTexts, t9FilteredComments
             )
             displayText = display.displayText
             displayCandidates = display.displayCandidates
@@ -356,7 +356,7 @@ internal class ImeSessionController(private val service: XimeInputMethodService)
                 t9RightCandidateSelectedCount = 0,
                 t9SelectedCandidatePinyin = ""
             )
-            service.t9PartialCommitTexts.clear()
+            service.t9PartialSegments.clear()
             service.candidateState.value = service.candidateState.value.copy(
                 inputText = "",
                 preeditText = "",

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -135,6 +135,12 @@ object QuickSendFormEditTextHolder {
     var editText: android.widget.EditText? = null
 }
 
+/**
+ * T9 九键 partial commit 段：右选部分提交时累积的（文本, 拼音）对。
+ * 文本用于 preedit 拼接与上屏，拼音用于用户词典调频/回滚，两者同源同步维护。
+ */
+data class T9PartialSegment(val text: String, val pinyin: String)
+
 class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateRegistryOwner, ViewModelStoreOwner, ActionExecutor {
 
     companion object {
@@ -224,8 +230,8 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     private var pendingVoiceAction: (() -> Unit)? = null
     internal var composeViewRef: View? = null
     internal var lastClearedText: String = ""
-    /** 累积的 partial commit 文本列表（多段选词场景下逐段追加） */
-    internal val t9PartialCommitTexts = mutableListOf<String>()
+    /** 累积的 partial commit 段列表（多段选词场景下逐段追加，文本+拼音同源，供调频/回滚） */
+    internal val t9PartialSegments = mutableListOf<T9PartialSegment>()
     /** 键盘回调引用，用于在 RIME selectCandidate 前同步通知 T9 控制器 */
     internal var keyboardCallbacks: KeyboardCallbacks? = null
     internal var isChineseMode = true
@@ -1150,7 +1156,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         // 新输入会话清空 partial commit 累积：外部 UI（如设置页输入框"清除"按钮仅清 Compose
         // state）会触发 restartInput → 此处重建 T9，若残留累积会被 buildT9DisplayState 拼进
         // preedit 回灌输入框（2026-08-07 日志实证：清除后 testText 从 '' 回灌为 '几乎'）。
-        t9PartialCommitTexts.clear()
+        t9PartialSegments.clear()
         debugLog("onStartInput: cleared lastCommittedText")
 
         // 跨进程同步文件日志开关（开关在主进程设置页切换）
@@ -1488,7 +1494,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     private fun clearInputState() {
         calculatorEngine.clear()
         rimeEngine.clearComposition()
-        t9PartialCommitTexts.clear()
+        t9PartialSegments.clear()
         // 输入法隐藏/结束输入：静默停止语音会话，丢弃未识别文本，避免迟到结果写入新输入框
         if (uiState.value.isVoiceMode || voiceRecordingStarted) {
             voiceRecognitionHandler.abandonSession()

--- a/app/src/main/jni/librime-t9/src/t9_processor.cc
+++ b/app/src/main/jni/librime-t9/src/t9_processor.cc
@@ -7,13 +7,18 @@
 #include <rime/engine.h>
 #include <rime/key_event.h>
 #include <rime/key_table.h>
+#include <rime/language.h>
 #include <rime/menu.h>
 #include <rime/schema.h>
+#include <rime/ticket.h>
+#include <rime/dict/dictionary.h>
+#include <rime/dict/user_dictionary.h>
 #include <algorithm>
 #include <atomic>
 #include <set>
 
 #include "t9_log.h"
+#include "t9_right_commit_utils.h"  // ParseSyllables
 
 namespace rime {
 
@@ -75,8 +80,24 @@ T9Processor::T9Processor(const Ticket& ticket) : Processor(ticket) {
         }
     }
 
-    T9LOG("T9Processor created (integrated T1-T6), manual_delimiter='%c', leftPanelMode=%d",
-          manual_delimiter_, static_cast<int>(left_panel_mode_));
+    // 用户词典调频（对齐全键盘 Memory::Memorize 机制）：
+    // 与主翻译器（script_translator）使用同一 name_space "translator"，
+    // 通过组件池共享 Table/Prism/db（dict_name=rime_frost, prism_name=t9）。
+    // 仅在右选候选时写入；创建失败（非拼音方案/未部署）时置空，调频自动跳过。
+    if (auto dictionary = Dictionary::Require("dictionary")) {
+        dict_.reset(dictionary->Create(Ticket(engine_, "translator")));
+        if (dict_) dict_->Load();
+    }
+    if (auto user_dictionary = UserDictionary::Require("user_dictionary")) {
+        user_dict_.reset(user_dictionary->Create(Ticket(engine_, "translator")));
+        if (user_dict_) {
+            user_dict_->Load();
+            if (dict_) user_dict_->Attach(dict_->primary_table(), dict_->prism());
+        }
+    }
+    T9LOG("T9Processor created (integrated T1-T6), manual_delimiter='%c', leftPanelMode=%d, userDict=%s",
+          manual_delimiter_, static_cast<int>(left_panel_mode_),
+          (user_dict_ && user_dict_->loaded()) ? "on" : "off");
 }
 
 T9Processor::~T9Processor() {
@@ -463,7 +484,10 @@ bool T9Processor::SelectCandidate(const std::string& candidate_pinyin,
     bool full_commit = right_commit_handler_.HandleRightCommit(
         ctx, candidate_pinyin, candidate_text_length, rime_consumed);
 
+    // 必须先把 handler 消费结果回写 input_buffer_（consumed/unassigned 更新）。
     ApplyHandlerContext(ctx);
+
+    // 调频不在此进行：由 Kotlin 在 full commit 上屏后经 MemorizeEntry 显式调用。
 
     // ── 诊断日志：出口状态 ──
     T9LOG(">> SelectCandidate EXIT: full_commit=%d", full_commit ? 1 : 0);
@@ -478,6 +502,76 @@ bool T9Processor::SelectCandidate(const std::string& candidate_pinyin,
           static_cast<int>(state_machine_.state()));
 
     return full_commit;
+}
+
+// ════════════════════════════════════════
+// MemorizeEntry / ForgetEntry — 用户词典调频（Kotlin 上屏路径为唯一真相源）
+// ════════════════════════════════════════
+// pinyin 拆音节转原生 Code（key 由 RIME 生成，避免手拼字符串依赖内部格式）；
+// 撤销段时 Kotlin 调 ForgetEntry（commits=-1）回滚。
+
+bool T9Processor::BuildEntryForPinyin(const std::string& text,
+                                      const std::string& pinyin,
+                                      DictEntry* entry) {
+    if (!entry || text.empty() || pinyin.empty())
+        return false;
+    // 惰性构建 音节→SyllableId 映射（与 UserDictionary 的 RecruitEntry 一致：
+    // GetSyllabary 返回按 id 排序的音节集合，遍历顺序即 id）。
+    if (syllabary_map_.empty() && dict_ && dict_->primary_table()) {
+        Syllabary syllabary;
+        if (dict_->primary_table()->GetSyllabary(&syllabary)) {
+            SyllableId sid = 0;
+            for (const auto& s : syllabary)
+                syllabary_map_[s] = sid++;
+        }
+    }
+    if (syllabary_map_.empty())
+        return false;
+    auto syllables = ParseSyllables(pinyin);
+    if (syllables.empty())
+        return false;
+    Code code;
+    for (const auto& syl : syllables) {
+        auto it = syllabary_map_.find(syl);
+        if (it == syllabary_map_.end())
+            return false;  // 音节不在词典（如英文/符号），放弃调频
+        code.push_back(it->second);
+    }
+    entry->text = text;
+    entry->code = code;
+    return true;
+}
+
+bool T9Processor::UpdateDictEntry(const std::string& text,
+                                  const std::string& pinyin,
+                                  int commits) {
+    if (!user_dict_ || !user_dict_->loaded() || user_dict_->readonly())
+        return false;
+    if (text.empty() || pinyin.empty())
+        return false;
+    DictEntry entry;
+    if (!BuildEntryForPinyin(text, pinyin, &entry))
+        return false;
+    // 刷新 tick：与主翻译器的 UserDictionary 共享 db（db_pool_），
+    // 但各实例独立缓存 tick_，写前同步防 tick 倒退（UpdateEntry 依赖 tick 计算权重）。
+    user_dict_->Load();
+    const char* op = commits > 0 ? "Memorize" : "Forget";
+    if (user_dict_->UpdateEntry(entry, commits)) {
+        T9LOG(">> %sEntry OK: '%s' pinyin='%s'", op, text.c_str(), pinyin.c_str());
+        return true;
+    }
+    T9LOG(">> %sEntry FAIL: '%s' pinyin='%s'", op, text.c_str(), pinyin.c_str());
+    return false;
+}
+
+bool T9Processor::MemorizeEntry(const std::string& text,
+                                const std::string& pinyin) {
+    return UpdateDictEntry(text, pinyin, 1);
+}
+
+bool T9Processor::ForgetEntry(const std::string& text,
+                              const std::string& pinyin) {
+    return UpdateDictEntry(text, pinyin, -1);
 }
 
 int T9Processor::QueryRimeConsumedDigits(

--- a/app/src/main/jni/librime-t9/src/t9_processor.h
+++ b/app/src/main/jni/librime-t9/src/t9_processor.h
@@ -3,8 +3,10 @@
 
 #include <rime/processor.h>
 #include <rime/component.h>
+#include <rime/dict/vocabulary.h>  // DictEntry / Code / SyllableId / Syllabary
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "t9_buffer.h"
@@ -15,6 +17,10 @@
 #include "t9_panel_state.h"  // LeftPanelStateData, T9PanelStateContext, t9_panel_state::*
 
 namespace rime {
+
+// 前向声明（用户词典调频：对齐全键盘 Memorize 机制）
+class Dictionary;
+class UserDictionary;
 
 // 九键拼音输入处理器（RIME Processor 组件）。
 //
@@ -50,10 +56,16 @@ public:
 
     // 右侧候选选词，返回 true = 完整消费（full commit）
     // 委托给 T9RightCommitHandler 三层消费算法
-    // 注：传入候选拼音注释（comment）和候选词字数，而非索引；
+    // 注：传入候选拼音注释（comment）与候选词字数，而非索引；
     //     RIME Menu::GetCandidateAt 使用绝对索引，而 Kotlin 层持有的是当前页
     //     相对索引，直接传拼音可避免翻页后索引错位导致消费计算错误。
     bool SelectCandidate(const std::string& candidate_pinyin, int candidate_text_length);
+
+    // ── 用户词典调频（Kotlin 上屏路径为唯一真相源）──
+    // 调频文本与拼音由 Kotlin 在 full commit（含 partial 拼接）时传入，
+    // C++ 构造 RIME 原生 DictEntry 写入（key 由 RIME 生成）；撤销段时 ForgetEntry 回滚。
+    bool MemorizeEntry(const std::string& text, const std::string& pinyin);
+    bool ForgetEntry(const std::string& text, const std::string& pinyin);
 
     // 获取 partial commit 后剩余的数字串
     std::string GetRemainingDigits() const;
@@ -132,6 +144,11 @@ private:
 
     // ── 辅助 ──
     void LogPreeditState();
+    // 构造 DictEntry（text + 拼音音节 code）；音节不在词典 syllabary 时返回 false。
+    bool BuildEntryForPinyin(const std::string& text, const std::string& pinyin,
+                             DictEntry* entry);
+    // 调频写入/回滚公共实现（MemorizeEntry/ForgetEntry 共用）：commits=+1 记忆 / -1 回滚。
+    bool UpdateDictEntry(const std::string& text, const std::string& pinyin, int commits);
 
     // 方案 A（消费算法优化）：查询 RIME 候选的实际匹配结束位置，
     // 换算为 T9 应消费的数字位数（RIME input[0:end) 中数字字符数，跳过分隔符）。
@@ -162,6 +179,17 @@ private:
     // kNone（英文/词级预测方案）：左栏返回 IDLE、首音节候选为空、左选 no-op。
     t9_panel_state::LeftPanelMode left_panel_mode_ =
         t9_panel_state::LeftPanelMode::kPinyin;
+
+    // ── 用户词典调频（对齐全键盘 Memorize 机制，2026-08-11）──
+    // 通过组件池与主翻译器（script_translator）共享 Table/Prism/db：
+    //   dict_      dictionary: rime_frost + prism: t9
+    //   user_dict_ user_dict:  rime_frost（enable_user_dict 默认 true）
+    // 由 Kotlin 在 full commit 时调用 MemorizeEntry/ForgetEntry 写入（UpdateEntry）。
+    the<Dictionary> dict_;
+    the<UserDictionary> user_dict_;
+    // 音节→SyllableId 映射（惰性构建，与 UserDictionary::Lookup 的 RecruitEntry
+    // 构造方式一致：GetSyllabary 返回顺序即 id）。用于把拼音音节转为原生 Code。
+    std::unordered_map<std::string, SyllableId> syllabary_map_;
 
     // ── 异步 flush 状态（SendToRime 标记，FlushRimeInput 消费）──
     // pending_action_ / pending_input_ 的读写都发生在 RimeEngine.rimeLock

--- a/app/src/main/jni/librime_jni/rime_jni.cc
+++ b/app/src/main/jni/librime_jni/rime_jni.cc
@@ -1355,232 +1355,273 @@ static bool T9PackTableBinMissing(const std::string& user_data_dir,
     return true;
 }
 
-// 确保 T9 方案的 schema 补丁已注入（核心实现，接受显式路径）。
-// 供两个 JNI 入口使用：
-//   - nativeEnsureT9SchemaPatches：引擎已初始化，路径取自 Rime::Instance()
-//   - nativeEnsureT9SchemaPatchesWithDir：启动早期（引擎未初始化）由 Kotlin 传入路径，
-//     保证 T9 补丁先于 deployment hash 计算就位，避免 main 版 PersonalDictManager
-//     在引擎未初始化时写入畸形 packs（如 user_""）导致 custom.yaml 每启动被改写 →
-//     deployment hash 抖动 → 每次启动全量部署 → rimeLock 长阻塞 → 呼出键盘 ANR
-//     （2026-08-07 日志实证）。
-//
-// Phase 1: 判断是否 T9 方案
-//   依据：JNI schema_id 含 "t9"，或 schema.yaml 中 schema_id 字段含 "t9"
-// Phase 2: 检查 T9 三要素（t9_processor, t9_filter, t9/isDisplayOriginalPreedit）
-//   缺什么补什么。注意 isDisplayOriginalPreedit 只看是否存在，不关心 true/false，
-//   避免覆盖第三方方案（如万象拼音使用 true）的配置。
-// Phase 3: 检查 custom.yaml 已有补丁，避免重复写入
-// Phase 4: 计算缺失 → 末尾追加到 custom.yaml（不破坏已有条目）
+// 从文本中解析布尔开关（如 "enable_abbrev_recall: false"）。
+// 找不到关键字或值无法识别时返回 default_val；支持 "true/false" 与 "1/0"。
+static bool ParseBoolSetting(const std::string& text,
+                             const std::string& key,
+                             bool default_val) {
+    auto pos = text.find(key);
+    if (pos == std::string::npos)
+        return default_val;
+    auto colon = text.find(':', pos);
+    auto nl = text.find('\n', pos);
+    if (colon == std::string::npos)
+        return default_val;
+    if (nl != std::string::npos && colon >= nl)
+        return default_val;
+    std::string val = text.substr(
+        colon + 1, (nl == std::string::npos ? text.size() : nl) - colon - 1);
+    if (val.find("false") != std::string::npos || val.find('0') != std::string::npos)
+        return false;
+    if (val.find("true") != std::string::npos || val.find('1') != std::string::npos)
+        return true;
+    return default_val;
+}
+
+// 读取文件全文到 out（文件不存在或读取失败返回 false）。
+static bool ReadFileToString(const std::string& path, std::string& out) {
+    FILE* f = fopen(path.c_str(), "r");
+    if (!f) return false;
+    char buf[8192];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof(buf), f)) > 0) {
+        out.append(buf, n);
+    }
+    fclose(f);
+    return true;
+}
+
+// 从文本中剔除含任一 needle 的行（用于移除已注入的 derive 简拼补丁）。
+static std::string StripLinesContaining(const std::string& text,
+                                        const std::vector<std::string>& needles) {
+    std::string result;
+    size_t start = 0;
+    while (start < text.size()) {
+        size_t nl = text.find('\n', start);
+        if (nl == std::string::npos) nl = text.size();
+        std::string line = text.substr(start, nl - start);
+        bool drop = false;
+        for (const auto& needle : needles) {
+            if (line.find(needle) != std::string::npos) {
+                drop = true;
+                break;
+            }
+        }
+        if (!drop) {
+            result += line;
+            result += '\n';
+        }
+        if (nl == text.size()) break;
+        start = nl + 1;
+    }
+    return result;
+}
+
+// 确保 T9 方案 schema 补丁已注入到 custom.yaml（幂等）。
+//   - 判定 T9 方案：schema_id 含 "t9"，或 schema.yaml 的 schema_id 字段含 "t9"。
+//   - 补齐缺失组件：t9_processor / t9_filter / t9_date_translator /
+//     t9/isDisplayOriginalPreedit / t9/enable_date_translator（schema 已有则尊重）。
+//   - 拼音方案（含 script_translator）按 t9/enable_abbrev_recall 注入/移除 derive 简拼长词。
+//   - 修复畸形 translator/packs（个人词库），合法补丁尊重、缺失交由 PersonalDictManager。
+// 返回 true 表示写入后词库/补丁尚未编译，调用方可据此触发部署。
 static jboolean DoEnsureT9SchemaPatches(
     JNIEnv* env,
     const char* schema,
     const std::string& user_data_dir,
     const std::string& shared_data_dir) {
-    // ====== Phase 1 + 2: 读 schema.yaml，判断 T9 方案 + 检查三要素 ======
-    bool is_t9_schema = false;
-    bool has_t9_processor = false;
-    bool has_t9_filter = false;
-    bool has_display_setting = false;
-    bool has_t9_date = false;
-
-    {
-        // Phase 1 第一步：JNI schema_id 含 "t9" 直接判定为 T9
-        std::string sid(schema);
-        for (auto& c : sid) c = static_cast<char>(tolower(c));
-        if (sid.find("t9") != std::string::npos) {
-            is_t9_schema = true;
+    // 读 schema.yaml（先 user_data_dir 后 shared_data_dir，兼容 .schema.yaml/.yaml）。
+    std::string schema_content;
+    for (const auto& ext : {".schema.yaml", ".yaml"}) {
+        if (ReadFileToString(user_data_dir + "/" + schema + ext, schema_content) ||
+            ReadFileToString(shared_data_dir + "/" + schema + ext, schema_content)) {
+            break;
         }
-
-        // 读取 schema.yaml（同时服务 Phase 1 的 schema_id 校验 和 Phase 2 的三要素检查）
-        std::string udd(user_data_dir);
-        std::string sdd(shared_data_dir);
-        std::string schema_content;
-        for (const auto& ext : {".schema.yaml", ".yaml"}) {
-            std::string path = udd + "/" + schema + ext;
-            FILE* f = fopen(path.c_str(), "r");
-            if (!f) { path = sdd + "/" + schema + ext; f = fopen(path.c_str(), "r"); }
-            if (f) {
-                char buf[8192];
-                size_t n;
-                while ((n = fread(buf, 1, sizeof(buf), f)) > 0) {
-                    schema_content.append(buf, n);
-                }
-                fclose(f);
-                LOGI("T9Patches: read schema file '%s'", path.c_str());
-                break;
-            }
-        }
-
-        // Phase 1 第二步：JNI id 不含 "t9" 时，从文件 schema_id 字段确认
-        if (!is_t9_schema && !schema_content.empty()) {
-            auto pos = schema_content.find("schema_id:");
-            if (pos != std::string::npos) {
-                auto line_end = schema_content.find('\n', pos);
-                auto line = schema_content.substr(pos, line_end - pos);
-                std::string lower(line);
-                for (auto& c : lower) c = static_cast<char>(tolower(c));
-                if (lower.find("t9") != std::string::npos) {
-                    is_t9_schema = true;
-                }
-            }
-        }
-
-        if (!is_t9_schema) {
-            LOGI("T9Patches: '%s' is not a T9 schema, skip", schema);
-            return JNI_FALSE;
-        }
-
-        // Phase 2: 从已读内容中提取 T9 三要素
-        if (!schema_content.empty()) {
-            if (schema_content.find("t9_processor") != std::string::npos) has_t9_processor = true;
-            if (schema_content.find("t9_filter") != std::string::npos) has_t9_filter = true;
-            if (schema_content.find("isDisplayOriginalPreedit") != std::string::npos) {
-                has_display_setting = true;
-            }
-            if (schema_content.find("t9_date_translator") != std::string::npos) has_t9_date = true;
-        }
-
-        LOGI("T9Patches: schema='%s' is_t9=1 (proc=%d,filter=%d,disp=%d,date=%d)",
-             schema,
-             has_t9_processor ? 1 : 0, has_t9_filter ? 1 : 0,
-             has_display_setting ? 1 : 0, has_t9_date ? 1 : 0);
-
-        // Guard: 未找到 schema 文件 → 方案可能已卸载，不写补丁
-        // 仅靠 JNI id 含 "t9" 不足以确认方案仍在磁盘上（如 t9_pinyin 被卸载后）
-        if (schema_content.empty()) {
-            LOGI("T9Patches: schema file for '%s' not found on disk, skip (uninstalled?)", schema);
-            return JNI_FALSE;
-        }
+        schema_content.clear();
     }
 
-    // ====== Phase 3: 检查 custom.yaml 已有补丁 ======
+    // 判定 T9 方案：JNI schema_id 含 "t9"，或 schema.yaml 的 schema_id 字段含 "t9"。
+    bool is_t9_schema = false;
+    std::string sid(schema);
+    for (auto& c : sid) c = static_cast<char>(tolower(c));
+    if (sid.find("t9") != std::string::npos) {
+        is_t9_schema = true;
+    }
+    if (!is_t9_schema && !schema_content.empty()) {
+        auto pos = schema_content.find("schema_id:");
+        if (pos != std::string::npos) {
+            auto line_end = schema_content.find('\n', pos);
+            auto line = schema_content.substr(
+                pos, line_end == std::string::npos ? line_end : line_end - pos);
+            for (auto& c : line) c = static_cast<char>(tolower(c));
+            if (line.find("t9") != std::string::npos) {
+                is_t9_schema = true;
+            }
+        }
+    }
+    if (!is_t9_schema) {
+        return JNI_FALSE;
+    }
+    // 未找到 schema 文件 → 方案可能已卸载，不写补丁。
+    if (schema_content.empty()) {
+        LOGI("T9Patches: schema file for '%s' not found on disk, skip", schema);
+        return JNI_FALSE;
+    }
+
+    // 读 custom.yaml 已有补丁。
     std::string custom_path = user_data_dir + "/" + schema + ".custom.yaml";
     std::string existing_content;
-    {
-        FILE* f = fopen(custom_path.c_str(), "r");
-        if (f) {
-            char buf[8192];
-            size_t n;
-            while ((n = fread(buf, 1, sizeof(buf), f)) > 0) {
-                existing_content.append(buf, n);
-            }
-            fclose(f);
+    ReadFileToString(custom_path, existing_content);
+
+    // 收集需要追加的补丁行（幂等：schema 或 custom 已含该组件则跳过）。
+    std::vector<std::string> patch_lines;
+    if (schema_content.find("t9_processor") == std::string::npos &&
+        existing_content.find("t9_processor") == std::string::npos) {
+        patch_lines.push_back("  \"engine/processors/@before 0\": t9_processor");
+    }
+    if (schema_content.find("t9_filter") == std::string::npos &&
+        existing_content.find("t9_filter") == std::string::npos) {
+        patch_lines.push_back("  \"engine/filters/@before 0\": t9_filter");
+    }
+    if (schema_content.find("isDisplayOriginalPreedit") == std::string::npos &&
+        existing_content.find("isDisplayOriginalPreedit") == std::string::npos) {
+        patch_lines.push_back("  \"t9/isDisplayOriginalPreedit\": false");
+    }
+    if (schema_content.find("t9_date_translator") == std::string::npos &&
+        existing_content.find("t9_date_translator") == std::string::npos) {
+        patch_lines.push_back("  \"engine/translators/@before 0\": t9_date_translator");
+        patch_lines.push_back("  \"t9/enable_date_translator\": true");
+    }
+
+    // 简拼长词召回（t9/enable_abbrev_recall）：作为 t9 段一等开关，与
+    // isDisplayOriginalPreedit / enable_date_translator 对齐——schema 未声明时写入 custom。
+    // 仅拼音方案（含 script_translator）支持；英文 T9 方案剥离简拼召回。
+    //
+    // 为什么默认 true：九键输入的是数字序列，用户期望短序列命中长词（如输入 54482
+    // 打出"几乎把"）。若只靠完整拼音匹配，"几乎把"（ji hu ba = 544822）必须输完 6 位
+    // 才出现，5 位输入时在 RIME 原生 SyllableGraph 中不可达，体验差。注入 derive 简拼
+    // 让完整拼音词派生首字母（j h b）与 zh/ch/sh 双字母简拼，使 54482 即可召回这类长词。
+    //
+    // 如何工作：向 speller/algebra 注入两条 derive 规则，派生编码经方案既有的九宫格
+    // 数字映射（derive/[abc]/2/ 等）可被数字序列输入命中；Script::Merge 对同 spelling
+    // 取更优类型（normal 优先），简拼边不遮蔽正常拼写。
+    //
+    // 开启表现：54482 候选含"几乎把/几乎从/连环画"等简拼长词，右选后可调频置顶。
+    // 关闭表现：仅全拼词组与单字（输入序列 = 完整拼音数字序列）出现，且仍可正常调频；
+    // 但"几乎吧"（544822，序列长于 54482）这类简拼长词不会出现，无法右选调频——
+    // 调频仅对"输入序列完整覆盖其编码"的词生效。
+    const bool is_pinyin_schema = schema_content.find("script_translator") != std::string::npos;
+    const bool has_abbrev_schema = schema_content.find("enable_abbrev_recall") != std::string::npos;
+    const bool has_abbrev_custom = existing_content.find("enable_abbrev_recall") != std::string::npos;
+    const bool has_derive = existing_content.find("derive/^([a-z])") != std::string::npos;
+
+    bool enable_abbrev_recall = false;
+    if (is_pinyin_schema) {
+        enable_abbrev_recall = ParseBoolSetting(schema_content, "enable_abbrev_recall", true);
+        enable_abbrev_recall =
+            ParseBoolSetting(existing_content, "enable_abbrev_recall", enable_abbrev_recall);
+        if (!has_abbrev_schema && !has_abbrev_custom) {
+            patch_lines.push_back(std::string("  \"t9/enable_abbrev_recall\": ") +
+                                  (enable_abbrev_recall ? "true" : "false"));
         }
     }
 
-    bool has_patch_processor = existing_content.find("t9_processor") != std::string::npos;
-    bool has_patch_filter = existing_content.find("t9_filter") != std::string::npos;
-    bool has_patch_t9 = existing_content.find("isDisplayOriginalPreedit") != std::string::npos;
-    bool has_patch_date = existing_content.find("t9_date_translator") != std::string::npos;
+    // derive 简拼长词补丁的注入/移除：开关 true 且未注入 → 注入；false 且已注入 → 移除。
+    bool need_remove_derive = false;
+    bool abbrev_patch_changed = false;  // derive 注入或移除，需重新编译 speller
+    if (enable_abbrev_recall) {
+        if (!has_derive) {
+            // 两条 derive 必须用不同 @before 索引（YAML map key 不能重复），
+            // 否则后者覆盖前者导致普通简拼 derive 丢失。
+            patch_lines.push_back("  \"speller/algebra/@before 0\": \"derive/^([a-z]).+$/$1/\"");
+            patch_lines.push_back("  \"speller/algebra/@before 1\": \"derive/^([zcs]h).+$/$1/\"");
+            abbrev_patch_changed = true;
+        }
+    } else if (has_derive) {
+        need_remove_derive = true;
+        abbrev_patch_changed = true;
+    }
 
-    // packs 个人词库补丁状态：合法保留 / 畸形修复 / 缺失补充。
-    // PersonalDictManager 写入的合法补丁（如 user_pinyin_simp）一律尊重，不干预；
-    // 只有畸形（旧跨块正则产物 user_"" 等）或无补丁时才由本管线兜底，
-    // 包名确定性派生自 schemaId（SanitizePackName 仅保留 [A-Za-z0-9_]）。
+    // translator/packs 个人词库：合法保留 / 畸形修复 / 缺失交由 PersonalDictManager。
     const std::string packs_name = "user_" + rime::t9_patch_utils::SanitizePackName(schema);
     bool need_packs_patch = false;
-    std::string actual_pack_name;  // 本方案实际生效的个人词库名（用于词库编译判定）
+    std::string actual_pack_name;  // 实际生效的个人词库名（用于词库编译判定）
     if (!packs_name.empty()) {
         switch (rime::t9_patch_utils::EvaluatePacksState(existing_content, &actual_pack_name)) {
           case rime::t9_patch_utils::PacksState::kKeep:
-            // 已有合法补丁 → 尊重，不干预（与上方针 1 注释语义一致）。
-            // 历史实现曾强制收敛为确定性 user_<schemaId>，但 PersonalDictManager
-            // 每次冷启动（引擎未初始化）都会按 user_<dictionary> 重写同一行，
-            // 两边互相覆盖 → custom.yaml 字节每轮必变 → deployment hash 抖动 →
-            // 每启动全量部署持 rimeLock → 呼出键盘 ANR（2026-08-07 实证）。
-            // 尊重已有合法名后，PDM 写入与补丁判定幂等，hash 稳定。
+          case rime::t9_patch_utils::PacksState::kMissing:
             break;
           case rime::t9_patch_utils::PacksState::kRepair:
-            // 畸形行 → 先剔除，随后写入合法补丁
             existing_content = rime::t9_patch_utils::StripPacksLines(existing_content);
             need_packs_patch = true;
             break;
-          case rime::t9_patch_utils::PacksState::kMissing:
-            // 缺失 → 不补写。packs 统一由 PersonalDictManager 治理（启用方案
-            // ensureSchemaPacks 必然写入合法名）；此处若补写 user_<schemaId>，
-            // 会与 PDM 冷启动写入的 user_<dictionary> 在多线程交错覆盖，
-            // 文件字节每轮必变 → deployment hash 抖动 → 全量部署持 rimeLock
-            // → 呼出键盘 ANR（2026-08-07 实证）。仅 kRepair 保留畸形兜底。
-            break;
         }
     }
-    LOGI("T9Patches: packs state for '%s' (name=%s, need_write=%d)",
-         schema, packs_name.c_str(), need_packs_patch ? 1 : 0);
+    if (need_packs_patch) {
+        patch_lines.push_back("  \"translator/packs\": [\"" + packs_name + "\"]");
+    }
 
-    // ====== Phase 4: 计算补丁 → 末尾追加到 custom.yaml ======
-    bool need_processor = !has_t9_processor && !has_patch_processor;
-    bool need_filter = !has_t9_filter && !has_patch_filter;
-    bool need_t9 = !has_display_setting && !has_patch_t9;
-    bool need_date = !has_t9_date && !has_patch_date;
-
-    if (need_processor || need_filter || need_t9 || need_date || need_packs_patch) {
-        std::string patch_content;
-        if (need_processor) patch_content += "  \"engine/processors/@before 0\": t9_processor\n";
-        if (need_filter) patch_content += "  \"engine/filters/@before 0\": t9_filter\n";
-        if (need_t9) patch_content += "  \"t9/isDisplayOriginalPreedit\": false\n";
-        if (need_date) {
-            patch_content += "  \"engine/translators/@before 0\": t9_date_translator\n";
-            patch_content += "  \"t9/enable_date_translator\": true\n";
-        }
-        if (need_packs_patch) patch_content += "  \"translator/packs\": [\"" + packs_name + "\"]\n";
-
-        // 剥离末尾 ... 标记及空白（否则追加内容会被 RIME 忽略）
-        std::string base = existing_content;
-        while (!base.empty() && (base.back() == '\n' || base.back() == '\r' || base.back() == ' ')) {
-            base.pop_back();
-        }
-        if (base.size() >= 3 && base.substr(base.size() - 3) == "...") {
-            base.resize(base.size() - 3);
-            while (!base.empty() && (base.back() == '\n' || base.back() == '\r' || base.back() == ' ')) {
-                base.pop_back();
-            }
-        }
-
-        std::string new_content;
-        bool has_patch = base.find("\npatch:") != std::string::npos ||
-                         base.find("patch:") == 0;
-        if (base.empty()) {
-            new_content = "patch:\n" + patch_content;
-        } else if (has_patch) {
-            new_content = base;
-            if (!new_content.empty() && new_content.back() != '\n') new_content += '\n';
-            new_content += patch_content;
-        } else {
-            new_content = base;
-            if (!new_content.empty() && new_content.back() != '\n') new_content += '\n';
-            new_content += "\n\npatch:\n" + patch_content;
-        }
-
-        FILE* f = fopen(custom_path.c_str(), "w");
-        bool ok = false;
-        if (f) {
-            fwrite(new_content.c_str(), 1, new_content.size(), f);
-            fclose(f);
-            ok = true;
-            // 写入合法 packs 补丁后，确保对应个人词库文件存在（librime 编译时引用，
-            // 否则 pack 源缺失导致用户词典不生效）
-            if (need_packs_patch) {
-                EnsureT9PackDictFile(user_data_dir, packs_name);
-                actual_pack_name = packs_name;
-            }
-        }
-
-        LOGI("T9Patches: %s for '%s' (has:[p%d,f%d,d%d,dt%d] patch:[p%d,f%d,t%d,dt%d] need:[p%d,f%d,t%d,dt%d])",
-             ok ? "applied" : "FAILED", schema,
-             has_t9_processor ? 1 : 0, has_t9_filter ? 1 : 0, has_display_setting ? 1 : 0, has_t9_date ? 1 : 0,
-             has_patch_processor ? 1 : 0, has_patch_filter ? 1 : 0, has_patch_t9 ? 1 : 0, has_patch_date ? 1 : 0,
-             need_processor ? 1 : 0, need_filter ? 1 : 0, need_t9 ? 1 : 0, need_date ? 1 : 0);
-
-        // 返回值语义：该 T9 方案个人词库已就位（写入成功）但尚未编译 → 需要部署，
-        // 由调用方触发一次部署编译词库表。
-        const bool need_deploy = ok && T9PackTableBinMissing(user_data_dir, actual_pack_name);
+    // 无改动 → 仅判断词库是否仍需编译。
+    if (patch_lines.empty() && !need_remove_derive) {
+        const bool need_deploy = T9PackTableBinMissing(user_data_dir, actual_pack_name);
         return need_deploy ? JNI_TRUE : JNI_FALSE;
     }
 
-    // 四要素与 packs 均已就位（无新写入）。若个人词库仍未编译 → 需要部署。
-    const bool need_deploy = T9PackTableBinMissing(user_data_dir, actual_pack_name);
-    LOGI("T9Patches: all components present, skip for '%s' (need_deploy=%d)",
-         schema, need_deploy ? 1 : 0);
+    // 开关关闭时移除已注入的 derive 行。
+    std::string base = existing_content;
+    if (need_remove_derive) {
+        base = StripLinesContaining(base, {"derive/^([a-z])", "derive/^([zcs]h)"});
+    }
+
+    // 剥离末尾 "..." 与空白，使追加的 patch 被 RIME 正常解析。
+    while (!base.empty() && (base.back() == '\n' || base.back() == '\r' || base.back() == ' ')) {
+        base.pop_back();
+    }
+    if (base.size() >= 3 && base.substr(base.size() - 3) == "...") {
+        base.resize(base.size() - 3);
+        while (!base.empty() && (base.back() == '\n' || base.back() == '\r' || base.back() == ' ')) {
+            base.pop_back();
+        }
+    }
+
+    std::string patch_content;
+    for (const auto& line : patch_lines) {
+        patch_content += line;
+        patch_content += '\n';
+    }
+
+    std::string new_content;
+    if (base.empty()) {
+        new_content = "patch:\n" + patch_content;
+    } else if (base.find("\npatch:") != std::string::npos || base.find("patch:") == 0) {
+        new_content = base;
+        if (new_content.back() != '\n') new_content += '\n';
+        new_content += patch_content;
+    } else {
+        new_content = base;
+        if (new_content.back() != '\n') new_content += '\n';
+        new_content += "\n\npatch:\n" + patch_content;
+    }
+
+    FILE* f = fopen(custom_path.c_str(), "w");
+    if (!f) {
+        LOGE("T9Patches: failed to write custom.yaml '%s'", custom_path.c_str());
+        return JNI_FALSE;
+    }
+    fwrite(new_content.c_str(), 1, new_content.size(), f);
+    fclose(f);
+
+    // 写入合法 packs 补丁后，确保对应个人词库文件存在（否则 librime 编译时 pack 源缺失）。
+    if (need_packs_patch) {
+        EnsureT9PackDictFile(user_data_dir, packs_name);
+        actual_pack_name = packs_name;
+    }
+
+    LOGI("T9Patches: applied '%s' (abbrev=%d, packs=%s)", schema,
+         enable_abbrev_recall ? 1 : 0, actual_pack_name.c_str());
+
+    // 返回 true 表示词库/补丁尚未编译，调用方可据此触发部署。
+    const bool need_deploy =
+        T9PackTableBinMissing(user_data_dir, actual_pack_name) || abbrev_patch_changed;
     return need_deploy ? JNI_TRUE : JNI_FALSE;
 }
 
@@ -1889,10 +1930,10 @@ Java_com_kingzcheung_xime_rime_RimeEngine_nativeIsModuleRegistered(
 // T9 Processor JNI 接口
 // ═══════════════════════════════════════════════════════════
 
-// 右选候选：根据候选拼音和文本长度执行右侧选词。
+// 右选候选：根据候选拼音与文本长度执行右侧选词（消费计算）。
 // 委托给 T9RightCommitHandler 三层消费算法（设计稿 §6.2）。
-// 注：传入候选拼音注释（comment）和候选词字数，而非索引，
-// 避免翻页后索引错位导致消费计算错误。
+// 注：传入候选拼音注释（comment）与候选词字数，而非索引，避免翻页后索引错位。
+// 用户词典调频不在此处进行——由 Kotlin 在 full commit 上屏后经 nativeT9Memorize 单独调用。
 JNIEXPORT jboolean JNICALL
 Java_com_kingzcheung_xime_rime_RimeEngine_nativeT9SelectCandidate(
     JNIEnv* env,
@@ -1910,6 +1951,50 @@ Java_com_kingzcheung_xime_rime_RimeEngine_nativeT9SelectCandidate(
     bool result = proc->SelectCandidate(std::string(p), text_length);
     env->ReleaseStringUTFChars(pinyin, p);
     return result ? JNI_TRUE : JNI_FALSE;
+}
+
+// T9 用户词典写入/回滚公共实现（memorize=true → commits=+1；false → commits=-1）。
+// 调频文本与拼音由 Kotlin 在 full commit 上屏后传入（Kotlin 上屏路径为唯一真相源）。
+static jboolean T9DictUpdate(JNIEnv* env, jstring text, jstring pinyin, bool memorize) {
+    rime::T9Processor* proc = rime::T9ProcessorRequire();
+    if (!proc) {
+        LOGE("T9DictUpdate: no active T9Processor");
+        return JNI_FALSE;
+    }
+    const char* t = env->GetStringUTFChars(text, nullptr);
+    if (!t) return JNI_FALSE;
+    std::string p;
+    if (pinyin) {
+        const char* pp = env->GetStringUTFChars(pinyin, nullptr);
+        if (pp) {
+            p.assign(pp);
+            env->ReleaseStringUTFChars(pinyin, pp);
+        }
+    }
+    bool result = memorize ? proc->MemorizeEntry(std::string(t), p)
+                           : proc->ForgetEntry(std::string(t), p);
+    env->ReleaseStringUTFChars(text, t);
+    return result ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_kingzcheung_xime_rime_RimeEngine_nativeT9Memorize(
+    JNIEnv* env,
+    jobject thiz,
+    jstring text,
+    jstring pinyin
+) {
+    return T9DictUpdate(env, text, pinyin, true);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_kingzcheung_xime_rime_RimeEngine_nativeT9Forget(
+    JNIEnv* env,
+    jobject thiz,
+    jstring text,
+    jstring pinyin
+) {
+    return T9DictUpdate(env, text, pinyin, false);
 }
 
 // 直接选择拼音（替代 SelectSyllable 的候选索引方式）


### PR DESCRIPTION
@kingzcheung 当前功能已经实现完毕，请协助审阅，若有需要调整内容，请@我，我会及时回复。

另外，需要先协助合并另外仓库中：九键方案文件调整。

## 概述

优化九键输入体验，支持选词上屏后，再次输入时动态调整候选词排序，让最近输入优先排在首位候选词。具体设计方案，详见关联 issue 中内容。里面有完整描述。

## 关联 Issue

Closes #627 

## 改动类型

- [ ] 新功能
- [x] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
