### PR TITLE
chore(release): 更新版本号到2.6.0-beta6

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 20260812
-        versionName = "2.6.0-beta5"
+        versionCode = 20260815
+        versionName = "2.6.0-beta6"
 
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
更新应用版本号从2.6.0-beta5到2.6.0-beta6，versionCode从20260812更新到20260815。

同步更新rime子项目依赖，将librime-lua-deps标记为dirty状态以反映本地修改。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [x] CI / 构建
- [x] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
