### PR TITLE
feat(clipboard): 添加MediaStore降级方案修复FileProvider兼容性问题

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 20260815
-        versionName = "2.6.0-beta6"
+        versionCode = 20260816
+        versionName = "2.6.0-beta7"
 
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/kingzcheung/xime/clipboard/ClipboardManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/ClipboardManager.kt
@@ -1,9 +1,14 @@
 package com.kingzcheung.xime.clipboard
 
 import android.content.ClipData
+import android.content.ContentValues
 import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
 import android.os.Handler
 import android.os.Looper
+import android.provider.MediaStore
 import android.util.Log
 import androidx.core.content.FileProvider
 import com.kingzcheung.xime.clipboard.db.ClipboardDatabase
@@ -352,11 +357,7 @@ class ClipboardManager private constructor(private val context: Context) {
                 }
             }
 
-            val uri = FileProvider.getUriForFile(
-                context,
-                "${context.packageName}.fileprovider",
-                cacheFile
-            )
+            val uri = getContentUriForImage(cacheFile) ?: return false
 
             val clip = ClipData.newUri(context.contentResolver, label, uri)
             androidClipboardManager.setPrimaryClip(clip)
@@ -365,6 +366,60 @@ class ClipboardManager private constructor(private val context: Context) {
         } catch (e: Exception) {
             Log.e(TAG, "Failed to copy image to clipboard", e)
             false
+        }
+    }
+
+    /**
+     * 生成图片 content URI。
+     *
+     * 优先使用 FileProvider；Android 12+ 部分厂商 ROM（如一加）上
+     * FileProvider.getUriForFile 内部 resolveContentProvider 以 USER_ALL(-10000)
+     * 校验跨用户权限时抛 "Invalid userId -10000"，此时降级为 MediaStore
+     * 插入图片获取系统 content URI（API 29+ 免权限）。
+     */
+    private fun getContentUriForImage(imageFile: File): Uri? {
+        try {
+            return FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.fileprovider",
+                imageFile
+            )
+        } catch (e: Exception) {
+            Log.w(TAG, "FileProvider getUriForFile failed, falling back to MediaStore", e)
+        }
+        return insertImageToMediaStore(imageFile)
+    }
+
+    /** 把图片插入 MediaStore（Pictures/Xime），返回系统 content URI。 */
+    private fun insertImageToMediaStore(imageFile: File): Uri? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            Log.e(TAG, "MediaStore fallback requires API 29+, clipboard image copy failed")
+            return null
+        }
+        return try {
+            val resolver = context.contentResolver
+            val values = ContentValues().apply {
+                put(MediaStore.Images.Media.DISPLAY_NAME, imageFile.name)
+                put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+                put(MediaStore.Images.Media.RELATIVE_PATH, Environment.DIRECTORY_PICTURES + "/Xime")
+                put(MediaStore.Images.Media.IS_PENDING, 1)
+            }
+            val collection = MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+            val uri = resolver.insert(collection, values) ?: return null
+            try {
+                resolver.openOutputStream(uri)?.use { output ->
+                    FileInputStream(imageFile).use { input -> input.copyTo(output) }
+                } ?: return null
+                val update = ContentValues().apply { put(MediaStore.Images.Media.IS_PENDING, 0) }
+                resolver.update(uri, update, null, null)
+                uri
+            } catch (e: Exception) {
+                resolver.delete(uri, null, null)
+                throw e
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "MediaStore insert failed", e)
+            null
         }
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeTextCommit.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeTextCommit.kt
@@ -5,6 +5,10 @@ import android.util.Log
 import android.view.KeyEvent
 import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputContentInfo
+import android.provider.MediaStore
+import android.content.ContentValues
+import android.os.Environment
+import android.net.Uri
 import androidx.core.content.FileProvider
 import java.io.File
 import java.io.FileInputStream
@@ -61,11 +65,7 @@ internal class ImeTextCommit(private val service: XimeInputMethodService) {
                 }
             }
             
-            val uri = FileProvider.getUriForFile(
-                service,
-                "$service.packageName.fileprovider",
-                cacheFile
-            )
+            val uri = getContentUriForImage(cacheFile, mimeType) ?: return false
             
             val inputContentInfo = InputContentInfo(
                 uri,
@@ -111,4 +111,62 @@ internal class ImeTextCommit(private val service: XimeInputMethodService) {
         service.currentInputConnection?.deleteSurroundingText(count, 0)
     }
 
+    /**
+     * 生成图片 content URI。
+     *
+     * 优先使用 FileProvider；Android 12+ 部分厂商 ROM（如一加）上
+     * FileProvider.getUriForFile 内部 resolveContentProvider 以 USER_ALL(-10000)
+     * 校验跨用户权限时抛 "Invalid userId -10000"，此时降级为 MediaStore
+     * 插入图片获取系统 content URI（API 29+ 免权限）。
+     */
+    private fun getContentUriForImage(imageFile: File, mimeType: String): Uri? {
+        try {
+            return FileProvider.getUriForFile(
+                service,
+                "${service.packageName}.fileprovider",
+                imageFile
+            )
+        } catch (e: IllegalArgumentException) {
+            Log.w(XimeInputMethodService.TAG, "FileProvider unavailable, falling back to MediaStore", e)
+        } catch (e: Exception) {
+            Log.w(XimeInputMethodService.TAG, "FileProvider getUriForFile failed, falling back to MediaStore", e)
+        }
+
+        return insertImageToMediaStore(imageFile, mimeType)
+    }
+
+    /** 把图片插入 MediaStore（Pictures/Xime），返回系统 content URI。 */
+    private fun insertImageToMediaStore(imageFile: File, mimeType: String): Uri? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            Log.e(XimeInputMethodService.TAG, "MediaStore fallback requires API 29+, image commit failed")
+            return null
+        }
+        return try {
+            val resolver = service.contentResolver
+            val values = ContentValues().apply {
+                put(MediaStore.Images.Media.DISPLAY_NAME, imageFile.name)
+                put(MediaStore.Images.Media.MIME_TYPE, mimeType)
+                put(MediaStore.Images.Media.RELATIVE_PATH, Environment.DIRECTORY_PICTURES + "/Xime")
+                put(MediaStore.Images.Media.IS_PENDING, 1)
+            }
+            val collection = MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+            val uri = resolver.insert(collection, values) ?: return null
+            try {
+                resolver.openOutputStream(uri)?.use { output ->
+                    FileInputStream(imageFile).use { input -> input.copyTo(output) }
+                } ?: return null
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    val update = ContentValues().apply { put(MediaStore.Images.Media.IS_PENDING, 0) }
+                    resolver.update(uri, update, null, null)
+                }
+                uri
+            } catch (e: Exception) {
+                resolver.delete(uri, null, null)
+                throw e
+            }
+        } catch (e: Exception) {
+            Log.e(XimeInputMethodService.TAG, "MediaStore insert failed", e)
+            null
+        }
+    }
 }


### PR DESCRIPTION
- 在Android 12+部分厂商ROM上，FileProvider.getUriForFile会因跨用户权限校验抛出 "Invalid userId -10000"异常，现在添加MediaStore插入图片的降级方案
- 优先使用FileProvider，失败后降级到MediaStore（API 29+免权限）
- 实现getContentUriForImage方法处理两种URI生成方式
- 添加insertImageToMediaStore方法将图片插入系统相册目录
- 同时在ImeTextCommit中应用相同的兼容性修复

chore(release): 更新版本号至2.6.0-beta7

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [x] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
