### PR TITLE
feat(clipboard): 增强剪贴板功能并优化UI界面 

### DIFF
--- a/app/src/androidTest/java/com/kingzcheung/xime/clipboard/ClipboardManagerTest.kt
+++ b/app/src/androidTest/java/com/kingzcheung/xime/clipboard/ClipboardManagerTest.kt
@@ -230,6 +230,63 @@ class ClipboardManagerTest {
     }
 
     @Test
+    fun removeItemsRemovesMultipleClipboardItems() {
+        clipboardManager.addItem("First")
+        awaitCondition({ clipboardManager.clipboardItems.value.size == 1 })
+        clipboardManager.addItem("Second")
+        awaitCondition({ clipboardManager.clipboardItems.value.size == 2 })
+        clipboardManager.addItem("Third")
+        awaitCondition({ clipboardManager.clipboardItems.value.size == 3 })
+        val ids = clipboardManager.clipboardItems.value.map { it.id }
+
+        clipboardManager.removeItems(ids)
+
+        awaitCondition({ clipboardManager.clipboardItems.value.isEmpty() })
+    }
+
+    @Test
+    fun removeItemsKeepsQuickSendIntact() {
+        clipboardManager.addItem("Shared text")
+        awaitCondition({ clipboardManager.clipboardItems.value.isNotEmpty() })
+        val itemId = clipboardManager.clipboardItems.value[0].id
+        clipboardManager.addToQuickSend(itemId)
+        awaitCondition({ clipboardManager.quickSendItems.value.isNotEmpty() })
+        clipboardManager.addItem("Clipboard only")
+        awaitCondition({ clipboardManager.clipboardItems.value.size == 2 })
+        val clipboardIds = clipboardManager.clipboardItems.value.map { it.id }
+
+        clipboardManager.removeItems(clipboardIds)
+
+        awaitCondition({ clipboardManager.clipboardItems.value.isEmpty() })
+        assertEquals(
+            "Quick send items must survive clipboard batch delete",
+            1,
+            clipboardManager.quickSendItems.value.size
+        )
+        assertEquals("Shared text", clipboardManager.quickSendItems.value[0].text)
+    }
+
+    @Test
+    fun clearClipboardClearsOnlyClipboardItems() {
+        clipboardManager.addItem("Clipboard A")
+        awaitCondition({ clipboardManager.clipboardItems.value.isNotEmpty() })
+        clipboardManager.addItem("Clipboard B")
+        awaitCondition({ clipboardManager.clipboardItems.value.size == 2 })
+        clipboardManager.addQuickSendItem("Quick A")
+        awaitCondition({ clipboardManager.quickSendItems.value.isNotEmpty() })
+
+        clipboardManager.clearClipboard()
+
+        awaitCondition({ clipboardManager.clipboardItems.value.isEmpty() })
+        assertEquals(
+            "Quick send items must survive clipboard clear",
+            1,
+            clipboardManager.quickSendItems.value.size
+        )
+        assertEquals("Quick A", clipboardManager.quickSendItems.value[0].text)
+    }
+
+    @Test
     fun addQuickSendItemAddsTextDirectly() {
         clipboardManager.addQuickSendItem("Direct quick")
 

--- a/app/src/main/java/com/kingzcheung/xime/clipboard/ClipboardManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/ClipboardManager.kt
@@ -244,14 +244,29 @@ class ClipboardManager private constructor(private val context: Context) {
 
     fun removeItem(id: Long) {
         scope.launch {
-            dao.deleteById(id)
+            dao.deleteClipboardById(id)
+        }
+    }
+
+    /** 批量删除剪贴板条目（仅 isQuickSend = 0，不影响快捷发送）。 */
+    fun removeItems(ids: List<Long>) {
+        if (ids.isEmpty()) return
+        scope.launch {
+            dao.deleteClipboardByIds(ids)
+        }
+    }
+
+    /** 清空剪贴板（仅 isQuickSend = 0，不影响快捷发送）。 */
+    fun clearClipboard() {
+        scope.launch {
+            dao.clearAllClipboard()
         }
     }
 
     fun splitItem(id: Long) {
         scope.launch {
             val item = _clipboardItems.value.find { it.id == id } ?: return@launch
-            dao.deleteById(id)
+            dao.deleteClipboardById(id)
             val now = System.currentTimeMillis()
             item.text.forEachIndexed { index, char ->
                 dao.insert(
@@ -278,7 +293,7 @@ class ClipboardManager private constructor(private val context: Context) {
 
     fun removeFromQuickSend(id: Long) {
         scope.launch {
-            dao.deleteById(id)
+            dao.deleteQuickSendById(id)
         }
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/clipboard/db/ClipboardDao.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/db/ClipboardDao.kt
@@ -34,8 +34,17 @@ interface ClipboardDao {
     @Query("UPDATE clipboard_entries SET timestamp = :timestamp WHERE id = :id")
     suspend fun updateTimestamp(id: Long, timestamp: Long)
 
-    @Query("DELETE FROM clipboard_entries WHERE id = :id")
-    suspend fun deleteById(id: Long)
+    @Query("DELETE FROM clipboard_entries WHERE isQuickSend = 0 AND id = :id")
+    suspend fun deleteClipboardById(id: Long)
+
+    @Query("DELETE FROM clipboard_entries WHERE isQuickSend = 1 AND id = :id")
+    suspend fun deleteQuickSendById(id: Long)
+
+    @Query("DELETE FROM clipboard_entries WHERE isQuickSend = 0 AND id IN (:ids)")
+    suspend fun deleteClipboardByIds(ids: List<Long>)
+
+    @Query("DELETE FROM clipboard_entries WHERE isQuickSend = 0")
+    suspend fun clearAllClipboard()
 
     @Query("DELETE FROM clipboard_entries WHERE isPinned = 0")
     suspend fun clearUnpinned()

--- a/app/src/main/java/com/kingzcheung/xime/keyboard/ToolbarButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/keyboard/ToolbarButton.kt
@@ -1,6 +1,7 @@
 package com.kingzcheung.xime.keyboard
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.twotone.Assignment
 import androidx.compose.material.icons.automirrored.twotone.LastPage
 import androidx.compose.material.icons.twotone.ContentCopy
 import androidx.compose.material.icons.twotone.ContentPaste
@@ -16,7 +17,6 @@ import androidx.compose.material.icons.filled.Create
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.PictureInPicture
 import androidx.compose.material.icons.outlined.Gesture
-import androidx.compose.material.icons.twotone.ContentPasteGo
 import androidx.compose.material.icons.twotone.Edit
 import androidx.compose.material.icons.twotone.Mic
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -27,7 +27,7 @@ enum class ToolbarButton(
     val icon: ImageVector
 ) {
     EMOJI("emoji", "表情", Icons.TwoTone.EmojiEmotions),
-    CLIPBOARD("clipboard", "剪贴板", Icons.TwoTone.ContentPasteGo),
+    CLIPBOARD("clipboard", "剪贴板", Icons.AutoMirrored.TwoTone.Assignment),
     SCHEMA("schema", "方案选择", Icons.TwoTone.KeyboardAlt),
     QUICK_PHRASE("quick_phrase", "快捷发送", Icons.TwoTone.Quickreply),
     SYMBOL("symbol", "符号", Icons.TwoTone.Paid),

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -867,6 +867,7 @@ fun KeyboardView(
                         selectedTab = p.route.tab,
                         backgroundColor = keyboardBgColor,
                         keyTextColor = keyTextColor,
+                        keyBgColor = keyBgColor,
                         viewModel = viewModel,
                         onSelectItem = { text ->
                             callbacks.onClipboardSelect?.invoke(text)

--- a/app/src/main/java/com/kingzcheung/xime/ui/menubar/ClipboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/menubar/ClipboardView.kt
@@ -1,37 +1,47 @@
 package com.kingzcheung.xime.ui.menubar
 
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCut
+import androidx.compose.material.icons.filled.Create
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.DeleteSweep
+import androidx.compose.material.icons.filled.DoneAll
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -43,22 +53,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.ui.unit.sp
 import com.kingzcheung.xime.clipboard.ClipboardItem
 import com.kingzcheung.xime.viewmodel.KeyboardViewModel
 import kotlin.math.max
-import kotlin.math.roundToInt
 
 @Composable
 fun ClipboardView(
@@ -67,6 +71,7 @@ fun ClipboardView(
     selectedTab: Int,
     backgroundColor: Color,
     keyTextColor: Color,
+    keyBgColor: Color,
     viewModel: KeyboardViewModel,
     onSelectItem: (String) -> Unit,
     onSplitWords: (String, Long) -> Unit,
@@ -77,7 +82,8 @@ fun ClipboardView(
     onQuickSendAddClick: (() -> Unit)? = null,
     onQuickSendEditItem: ((Long, String) -> Unit)? = null,
 ) {
-    val itemBgColor = MaterialTheme.colorScheme.surfaceContainerLow
+    // 卡片/格子背景：与菜单项背景一致（keyBgColor，浅色纯白、深色跟随 keyboard.colors）
+    val itemBgColor = keyBgColor
     val textColor = keyTextColor
     val subTextColor = keyTextColor.copy(alpha = 0.65f)
     val accentColor = MaterialTheme.colorScheme.primary
@@ -90,6 +96,16 @@ fun ClipboardView(
     val configuration = LocalConfiguration.current
     val isLandscape =
         configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+
+    var menuAnchor by remember { mutableStateOf<MenuAnchor?>(null) }
+    var isMultiSelect by remember { mutableStateOf(false) }
+    var selectedIds by remember { mutableStateOf<Set<Long>>(emptySet()) }
+    var showClearConfirm by remember { mutableStateOf(false) }
+
+    fun exitMultiSelect() {
+        isMultiSelect = false
+        selectedIds = emptySet()
+    }
 
     Column(
         modifier = modifier
@@ -170,6 +186,42 @@ fun ClipboardView(
 
             Spacer(modifier = Modifier.weight(1f))
 
+            if (selectedTab == 0) {
+                if (isMultiSelect) {
+                    Box(
+                        modifier = Modifier
+                            .size(28.dp)
+                            .clip(CircleShape)
+                            .background(iconButtonContainer)
+                            .clickable { exitMultiSelect() },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = "退出多选",
+                            tint = accentColor,
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+                } else if (clipboardItems.isNotEmpty()) {
+                    Box(
+                        modifier = Modifier
+                            .size(28.dp)
+                            .clip(CircleShape)
+                            .background(iconButtonContainer)
+                            .clickable { showClearConfirm = true },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.DeleteSweep,
+                            contentDescription = "清空剪贴板",
+                            tint = accentColor,
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+                }
+            }
+
             if (selectedTab == 1 && onQuickSendAddClick != null) {
                 Box(
                     modifier = Modifier
@@ -220,7 +272,16 @@ fun ClipboardView(
                     onSelect = onSelectItem,
                     onRemove = { id -> viewModel.removeClipboardItem(id) },
                     onAddToQuickSend = { id -> viewModel.addToQuickSend(id) },
-                    onSplitWords = onSplitWords
+                    onSplitWords = onSplitWords,
+                    onLongPressItem = { item, isLeftColumn ->
+                        menuAnchor = MenuAnchor(item, isLeftColumn, tab = 0)
+                    },
+                    isMultiSelect = isMultiSelect,
+                    selectedIds = selectedIds,
+                    onToggleSelect = { id ->
+                        selectedIds = if (id in selectedIds) selectedIds - id else selectedIds + id
+                    },
+                    onExitMultiSelect = { exitMultiSelect() }
                 )
             } else {
                 QuickSendTabContent(
@@ -233,14 +294,242 @@ fun ClipboardView(
                     onSelect = onSelectItem,
                     onQuickSendAddClick = onQuickSendAddClick,
                     onQuickSendEditItem = onQuickSendEditItem,
+                    onLongPressItem = { item, isLeftColumn ->
+                        menuAnchor = MenuAnchor(item, isLeftColumn, tab = 1)
+                    }
                 )
             }
         }
 
+        if (isMultiSelect) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "已选 ${selectedIds.size} 项",
+                    color = textColor,
+                    fontSize = 13.sp
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(
+                            if (selectedIds.isNotEmpty()) MaterialTheme.colorScheme.error
+                            else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                        )
+                        .clickable(enabled = selectedIds.isNotEmpty()) {
+                            viewModel.removeClipboardItems(selectedIds.toList())
+                            exitMultiSelect()
+                        }
+                        .padding(horizontal = 14.dp, vertical = 7.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = null,
+                            tint = Color.White,
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = "删除",
+                            color = Color.White,
+                            fontSize = 12.sp
+                        )
+                    }
+                }
+            }
+        }
+
         Spacer(modifier = Modifier.height(if (isLandscape) 15.dp else maxOf(bottomPaddingDp.dp, with(LocalDensity.current) { WindowInsets.navigationBars.getBottom(this).toDp() })))
+
+        menuAnchor?.let { anchor ->
+            val menuItems = if (anchor.tab == 0) {
+                listOf(
+                    LongPressMenuEntry(
+                        icon = Icons.Default.ContentCut,
+                        label = "拆词",
+                        onClick = {
+                            onSplitWords(anchor.item.text, anchor.item.id)
+                        }
+                    ),
+                    LongPressMenuEntry(
+                        icon = Icons.Outlined.StarBorder,
+                        label = "快捷",
+                        onClick = {
+                            viewModel.addToQuickSend(anchor.item.id)
+                        }
+                    ),
+                    LongPressMenuEntry(
+                        icon = Icons.Default.DoneAll,
+                        label = "多选",
+                        onClick = {
+                            isMultiSelect = true
+                            selectedIds = emptySet()
+                        }
+                    ),
+                    LongPressMenuEntry(
+                        icon = Icons.Default.Delete,
+                        label = "删除",
+                        tint = MaterialTheme.colorScheme.error,
+                        onClick = {
+                            viewModel.removeClipboardItem(anchor.item.id)
+                        }
+                    )
+                )
+            } else {
+                listOfNotNull(
+                    LongPressMenuEntry(
+                        icon = Icons.Filled.PushPin,
+                        label = "置顶",
+                        onClick = {
+                            viewModel.togglePinQuickSend(anchor.item.id)
+                        }
+                    ),
+                    onQuickSendEditItem?.let { edit ->
+                        LongPressMenuEntry(
+                            icon = Icons.Default.Create,
+                            label = "编辑",
+                            onClick = {
+                                edit(anchor.item.id, anchor.item.text)
+                            }
+                        )
+                    },
+                    LongPressMenuEntry(
+                        icon = Icons.Default.Delete,
+                        label = "删除",
+                        tint = MaterialTheme.colorScheme.error,
+                        onClick = {
+                            viewModel.removeQuickSendItem(anchor.item.id)
+                        }
+                    )
+                )
+            }
+            LongPressMenuOverlay(
+                text = anchor.item.text,
+                isLeftColumn = anchor.isLeftColumn,
+                backgroundColor = backgroundColor,
+                contentBgColor = itemBgColor,
+                textColor = textColor,
+                onDismiss = { menuAnchor = null },
+                menuItems = menuItems
+            )
+        }
+
+        if (showClearConfirm) {
+            ClearClipboardConfirmOverlay(
+                itemCount = clipboardItems.size,
+                backgroundColor = backgroundColor,
+                cardBgColor = itemBgColor,
+                textColor = textColor,
+                subTextColor = subTextColor,
+                onCancel = { showClearConfirm = false },
+                onConfirm = {
+                    showClearConfirm = false
+                    viewModel.clearClipboard()
+                }
+            )
+        }
     }
 }
 
+@Composable
+private fun ClearClipboardConfirmOverlay(
+    itemCount: Int,
+    backgroundColor: Color,
+    cardBgColor: Color,
+    textColor: Color,
+    subTextColor: Color,
+    onCancel: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(backgroundColor)
+            .clickable(onClick = onCancel),
+        contentAlignment = Alignment.Center
+    ) {
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            color = cardBgColor
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = 24.dp, vertical = 20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = "清空剪贴板",
+                    color = textColor,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "将删除全部 $itemCount 条剪贴板记录",
+                    color = subTextColor,
+                    fontSize = 13.sp
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(16.dp))
+                            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                            .clickable(onClick = onCancel)
+                            .padding(horizontal = 18.dp, vertical = 7.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "取消",
+                            color = textColor,
+                            fontSize = 13.sp
+                        )
+                    }
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(16.dp))
+                            .background(MaterialTheme.colorScheme.error)
+                            .clickable(onClick = onConfirm)
+                            .padding(horizontal = 18.dp, vertical = 7.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "清空",
+                            color = Color.White,
+                            fontSize = 13.sp
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal data class MenuAnchor(
+    val item: ClipboardItem,
+    val isLeftColumn: Boolean,
+    val tab: Int
+)
+
+data class LongPressMenuEntry(
+    val icon: ImageVector,
+    val label: String,
+    val tint: Color? = null,
+    val onClick: () -> Unit
+)
+
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ClipboardTabContent(
     items: List<ClipboardItem>,
@@ -251,7 +540,12 @@ fun ClipboardTabContent(
     onSelect: (String) -> Unit,
     onRemove: (Long) -> Unit,
     onAddToQuickSend: (Long) -> Unit,
-    onSplitWords: (String, Long) -> Unit
+    onSplitWords: (String, Long) -> Unit,
+    onLongPressItem: (ClipboardItem, Boolean) -> Unit,
+    isMultiSelect: Boolean = false,
+    selectedIds: Set<Long> = emptySet(),
+    onToggleSelect: (Long) -> Unit = {},
+    onExitMultiSelect: () -> Unit = {},
 ) {
     if (items.isEmpty()) {
         Box(
@@ -265,170 +559,211 @@ fun ClipboardTabContent(
             )
         }
     } else {
-        LazyColumn(
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2),
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 10.dp, vertical = 2.dp),
-            verticalArrangement = Arrangement.spacedBy(3.dp)
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            items(items, key = { it.id }) { item ->
-                CompactClipboardItem(
-                    item = item,
+            itemsIndexed(items, key = { _, it -> it.id }) { index, item ->
+                GridItemCard(
+                    text = item.text,
+                    highlighted = isMultiSelect && item.id in selectedIds,
                     bgColor = itemBgColor,
                     textColor = textColor,
-                    subTextColor = subTextColor,
                     accentColor = accentColor,
-                    onSelect = { onSelect(item.text) },
-                    onRemove = { onRemove(item.id) },
-                    onAddToQuickSend = { onAddToQuickSend(item.id) },
-                    onSplitWords = { onSplitWords(item.text, item.id) }
+                    modifier = Modifier.height(62.dp),
+                    onClick = {
+                        if (isMultiSelect) onToggleSelect(item.id)
+                        else onSelect(item.text)
+                    },
+                    onLongClick = {
+                        if (isMultiSelect) onExitMultiSelect()
+                        else onLongPressItem(item, index % 2 == 0)
+                    }
                 )
             }
         }
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CompactClipboardItem(
-    item: ClipboardItem,
+fun GridItemCard(
+    text: String,
+    highlighted: Boolean,
     bgColor: Color,
     textColor: Color,
-    subTextColor: Color,
     accentColor: Color,
-    onSelect: () -> Unit,
-    onRemove: () -> Unit,
-    onAddToQuickSend: () -> Unit,
-    onSplitWords: () -> Unit
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
 ) {
-    var showActions by remember { mutableStateOf(false) }
-    var actionsWidthPx by remember { mutableStateOf(0f) }
-
-    val slideOffset by animateFloatAsState(
-        targetValue = if (showActions) actionsWidthPx + 40f else 0f,
-        animationSpec = tween(durationMillis = 300),
-        label = "slideOffset"
-    )
-
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(40.dp)
-            .clip(RoundedCornerShape(8.dp))
+    val shape = RoundedCornerShape(8.dp)
+    val bg = if (highlighted) accentColor.copy(alpha = 0.18f) else bgColor
+    Column(
+        modifier = modifier
+            .border(1.5.dp, if (highlighted) accentColor else Color.Transparent, shape)
+            .clip(shape)
+            .background(bg)
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick,
+                onLongClickLabel = "更多操作"
+            )
+            .padding(horizontal = 10.dp, vertical = 9.dp),
+        verticalArrangement = Arrangement.Center
     ) {
-        Row(
-            modifier = Modifier.fillMaxSize(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.End
-        ) {
-            Row(
-                modifier = Modifier
-                    .height(40.dp)
-                    .padding(end = 4.dp)
-                    .onSizeChanged { actionsWidthPx = it.width.toFloat() },
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(6.dp)
-            ) {
-                Row(
-                    modifier = Modifier
-                        .height(38.dp)
-                        .clip(RoundedCornerShape(20.dp))
-                        .background(MaterialTheme.colorScheme.primaryContainer)
-                        .clickable { showActions = false; onSplitWords() }
-                        .padding(horizontal = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
-                    Icon(
-                        Icons.Default.ContentCut,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(16.dp)
-                    )
-                    Text(
-                        "拆词",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer,
-                        fontSize = 14.sp
-                    )
-                }
+        Text(
+            text = text,
+            color = textColor,
+            fontSize = 14.sp,
+            lineHeight = 19.sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
 
-                Row(
-                    modifier = Modifier
-                        .height(38.dp)
-                        .clip(RoundedCornerShape(20.dp))
-                        .background(MaterialTheme.colorScheme.primaryContainer)
-                        .clickable { showActions = false; onAddToQuickSend() }
-                        .padding(horizontal = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
-                    Icon(
-                        Icons.Outlined.StarBorder,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(16.dp)
-                    )
-                    Text(
-                        "快捷",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer,
-                        fontSize = 14.sp
-                    )
-                }
-
-                Box(
-                    modifier = Modifier
-                        .size(38.dp)
-                        .clip(RoundedCornerShape(20.dp))
-                        .background(MaterialTheme.colorScheme.errorContainer.copy(0.5f))
-                        .clickable { showActions = false; onRemove() },
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Icon(
-                        Icons.Default.Delete,
-                        contentDescription = "删除",
-                        tint = MaterialTheme.colorScheme.error,
-                        modifier = Modifier.size(18.dp)
-                    )
-                }
-            }
-        }
+@Composable
+fun LongPressMenuOverlay(
+    text: String,
+    isLeftColumn: Boolean,
+    backgroundColor: Color,
+    contentBgColor: Color,
+    textColor: Color,
+    onDismiss: () -> Unit,
+    menuItems: List<LongPressMenuEntry>,
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .background(backgroundColor)
+                .clickable(onClick = onDismiss)
+        )
 
         Row(
             modifier = Modifier
-                .fillMaxWidth()
-                .height(40.dp)
-                .offset { IntOffset((-slideOffset).roundToInt(), 0) }
-                .background(bgColor, RoundedCornerShape(8.dp))
-                .clickable {
-                    if (showActions) showActions = false
-                    else onSelect()
-                },
-            verticalAlignment = Alignment.CenterVertically
+                .fillMaxSize()
+                .padding(horizontal = 10.dp, vertical = 2.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            Text(
-                text = item.text,
-                color = textColor,
-                fontSize = 14.sp,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(horizontal = 8.dp)
-            )
-
-            IconButton(
-                onClick = { showActions = !showActions },
-                modifier = Modifier.size(32.dp)
+            Box(
+                modifier = Modifier.weight(if (isLeftColumn) 2f else 1f),
+                contentAlignment = Alignment.Center
             ) {
-                Icon(
-                    imageVector = Icons.Default.MoreVert,
-                    contentDescription = "更多",
-                    tint = accentColor,
-                    modifier = Modifier.size(18.dp)
+                if (isLeftColumn) {
+                    ContentCard(
+                        text = text,
+                        bgColor = contentBgColor,
+                        textColor = textColor
+                    )
+                } else {
+                    MenuCard(menuItems = menuItems, cardBgColor = contentBgColor, onDismiss = onDismiss)
+                }
+            }
+
+            Box(
+                modifier = Modifier.weight(if (isLeftColumn) 1f else 2f),
+                contentAlignment = Alignment.Center
+            ) {
+                if (isLeftColumn) {
+                    MenuCard(menuItems = menuItems, cardBgColor = contentBgColor, onDismiss = onDismiss)
+                } else {
+                    ContentCard(
+                        text = text,
+                        bgColor = contentBgColor,
+                        textColor = textColor
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContentCard(
+    text: String,
+    bgColor: Color,
+    textColor: Color,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(8.dp),
+        color = bgColor
+    ) {
+        Text(
+            text = text,
+            color = textColor,
+            fontSize = 14.sp,
+            lineHeight = 20.sp,
+            maxLines = 8,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 10.dp)
+        )
+    }
+}
+
+@Composable
+private fun MenuCard(
+    menuItems: List<LongPressMenuEntry>,
+    cardBgColor: Color,
+    onDismiss: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        color = cardBgColor
+    ) {
+        Column(modifier = Modifier.padding(vertical = 6.dp)) {
+            menuItems.forEachIndexed { index, entry ->
+                if (index > 0) {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 12.dp),
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+                    )
+                }
+                LongPressMenuItem(
+                    icon = entry.icon,
+                    label = entry.label,
+                    tint = entry.tint ?: MaterialTheme.colorScheme.onSurface,
+                    onClick = {
+                        onDismiss()
+                        entry.onClick()
+                    }
                 )
             }
         }
+    }
+}
+
+@Composable
+fun LongPressMenuItem(
+    icon: ImageVector,
+    label: String,
+    tint: Color = MaterialTheme.colorScheme.onSurface,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 11.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = tint,
+            modifier = Modifier.size(18.dp)
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = label,
+            color = tint,
+            fontSize = 14.sp
+        )
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/menubar/QuickSendView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/menubar/QuickSendView.kt
@@ -1,47 +1,25 @@
 package com.kingzcheung.xime.ui.menubar
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Create
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.ExpandLess
-import androidx.compose.material.icons.filled.ExpandMore
-import androidx.compose.material.icons.filled.PushPin
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kingzcheung.xime.clipboard.ClipboardItem
 import com.kingzcheung.xime.viewmodel.KeyboardViewModel
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun QuickSendTabContent(
     items: List<ClipboardItem>,
@@ -53,6 +31,7 @@ fun QuickSendTabContent(
     onSelect: (String) -> Unit,
     onQuickSendAddClick: (() -> Unit)? = null,
     onQuickSendEditItem: ((Long, String) -> Unit)? = null,
+    onLongPressItem: (ClipboardItem, Boolean) -> Unit,
 ) {
     if (items.isEmpty()) {
         Box(
@@ -66,150 +45,25 @@ fun QuickSendTabContent(
             )
         }
     } else {
-        LazyColumn(
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2),
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 10.dp, vertical = 2.dp),
-            verticalArrangement = Arrangement.spacedBy(3.dp)
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            items(items, key = { it.id }) { item ->
-                QuickSendCard(
-                    item = item,
+            itemsIndexed(items, key = { _, it -> it.id }) { index, item ->
+                GridItemCard(
+                    text = item.text,
+                    highlighted = false,
+                    bgColor = itemBgColor,
                     textColor = textColor,
                     accentColor = accentColor,
-                    viewModel = viewModel,
-                    onSelect = { onSelect(item.text) },
-                    onQuickSendEditItem = onQuickSendEditItem,
+                    modifier = Modifier.height(62.dp),
+                    onClick = { onSelect(item.text) },
+                    onLongClick = { onLongPressItem(item, index % 2 == 0) }
                 )
-            }
-        }
-    }
-}
-
-@Composable
-fun QuickSendCard(
-    item: ClipboardItem,
-    textColor: Color,
-    accentColor: Color,
-    viewModel: KeyboardViewModel,
-    onSelect: () -> Unit,
-    onQuickSendEditItem: ((Long, String) -> Unit)? = null,
-) {
-    var expanded by remember { mutableStateOf(false) }
-    val cardBg = MaterialTheme.colorScheme.surfaceContainerHigh
-
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(8.dp))
-            .background(cardBg, RoundedCornerShape(8.dp))
-            .clickable {
-                if (!expanded) onSelect()
-            }
-            .padding(horizontal = 8.dp, vertical = 6.dp)
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = item.text,
-                color = textColor,
-                fontSize = 14.sp,
-                maxLines = 4,
-                overflow = TextOverflow.Ellipsis,
-                lineHeight = 20.sp,
-                modifier = Modifier.weight(1f)
-            )
-
-            IconButton(
-                onClick = { expanded = !expanded },
-                modifier = Modifier.size(32.dp)
-            ) {
-                Icon(
-                    imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                    contentDescription = if (expanded) "收起" else "展开",
-                    tint = accentColor,
-                    modifier = Modifier.size(18.dp)
-                )
-            }
-        }
-
-        if (expanded) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 4.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                Row(
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(accentColor.copy(alpha = 0.15f))
-                        .clickable { viewModel.togglePinQuickSend(item.id) }
-                        .padding(horizontal = 10.dp, vertical = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(3.dp)
-                ) {
-                    Icon(
-                        Icons.Filled.PushPin,
-                        contentDescription = null,
-                        tint = accentColor,
-                        modifier = Modifier.size(12.dp)
-                    )
-                    Text(
-                        text = "置顶",
-                        color = accentColor,
-                        fontSize = 12.sp
-                    )
-                }
-
-                if (onQuickSendEditItem != null) {
-                    Row(
-                        modifier = Modifier
-                            .clip(RoundedCornerShape(8.dp))
-                            .background(accentColor.copy(alpha = 0.15f))
-                            .clickable { onQuickSendEditItem(item.id, item.text) }
-                            .padding(horizontal = 10.dp, vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(3.dp)
-                    ) {
-                        Icon(
-                            Icons.Default.Create,
-                            contentDescription = null,
-                            tint = accentColor,
-                            modifier = Modifier.size(12.dp)
-                        )
-                        Text(
-                            text = "编辑",
-                            color = accentColor,
-                            fontSize = 12.sp
-                        )
-                    }
-                }
-
-                val deleteColor = MaterialTheme.colorScheme.error
-                Row(
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(deleteColor.copy(alpha = 0.12f))
-                        .clickable { viewModel.removeQuickSendItem(item.id) }
-                        .padding(horizontal = 10.dp, vertical = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(3.dp)
-                ) {
-                    Icon(
-                        Icons.Filled.Delete,
-                        contentDescription = null,
-                        tint = deleteColor,
-                        modifier = Modifier.size(12.dp)
-                    )
-                    Text(
-                        text = "删除",
-                        color = deleteColor,
-                        fontSize = 12.sp
-                    )
-                }
             }
         }
     }

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
@@ -484,12 +484,16 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
         clipboardManager.removeItem(id)
     }
 
+    fun removeClipboardItems(ids: List<Long>) {
+        clipboardManager.removeItems(ids)
+    }
+
     fun splitClipboardItem(id: Long) {
         clipboardManager.splitItem(id)
     }
 
     fun clearClipboard() {
-        clipboardManager.clearAll()
+        clipboardManager.clearClipboard()
     }
 
     fun addToQuickSend(id: Long) {

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/InstallerManager.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/InstallerManager.kt
@@ -71,6 +71,18 @@ class InstallerManager(
         private const val PLUGINS_DIR = "plugins"
         private const val MANIFEST_YAML = "manifest.yaml"
 
+        /** 插件 id 白名单：仅字母/数字/下划线/连字符，最长 64，杜绝路径穿越。 */
+        private val PLUGIN_ID_REGEX = Regex("^[A-Za-z0-9_-]{1,64}$")
+
+        /** 入口脚本：普通文件名，不允许路径分隔符与 ".."。 */
+        private val ENTRY_SCRIPT_REGEX = Regex("^[A-Za-z0-9_.-]{1,128}$")
+
+        private fun isValidPluginId(id: String): Boolean = PLUGIN_ID_REGEX.matches(id)
+
+        private fun isValidEntryScript(name: String): Boolean =
+            ENTRY_SCRIPT_REGEX.matches(name) && !name.contains("..")
+
+
         private val manifestYaml: Yaml by lazy {
             Yaml(configuration = YamlConfiguration(strictMode = false))
         }
@@ -134,6 +146,13 @@ class InstallerManager(
             is PluginParseResult.Success -> parsed.config
         }
         val pluginId = pluginConfig.id
+        if (!isValidPluginId(pluginId)) {
+            return@withContext InstallResult.Failure("非法插件 id: $pluginId（仅允许字母/数字/下划线/连字符）")
+        }
+        val entryScript = pluginConfig.entryScript ?: "main.lua"
+        if (!isValidEntryScript(entryScript)) {
+            return@withContext InstallResult.Failure("非法入口脚本: $entryScript")
+        }
         val pluginDir = getPluginDirectory(pluginId)
 
         // 校验插件声明的宿主版本范围
@@ -170,7 +189,6 @@ class InstallerManager(
 
         try {
             extractPluginArchive(pluginFile, pluginDir)
-            val entryScript = pluginConfig.entryScript ?: "main.lua"
             val entryFile = File(pluginDir, entryScript)
             if (!entryFile.exists()) {
                 throw IllegalArgumentException("Lua 入口脚本不存在: $entryScript")
@@ -211,6 +229,10 @@ class InstallerManager(
     }
 
     suspend fun uninstallPlugin(pluginId: String): Boolean = withContext(Dispatchers.IO) {
+        if (!isValidPluginId(pluginId)) {
+            Log.e("InstallerManager", "uninstallPlugin 拒绝非法 id: $pluginId")
+            return@withContext false
+        }
         val pluginDir = getPluginDirectory(pluginId)
         if (pluginDir.exists()) {
             pluginDir.deleteRecursively()
@@ -240,6 +262,7 @@ class InstallerManager(
     }
 
     internal fun getPluginDirectory(pluginId: String): File {
+        require(isValidPluginId(pluginId)) { "非法插件 id: $pluginId" }
         return File(pluginsDir, pluginId)
     }
 


### PR DESCRIPTION
## 概述

- 实现批量删除剪贴板条目功能，保留快捷发送项目不受影响
- 添加清空剪贴板功能，仅清除普通剪贴板内容而不影响快捷发送
- 重构数据库操作方法，区分剪贴板和快捷发送项目的删除操作
- 更新剪贴板视图使用网格布局显示项目
- 添加长按菜单支持，提供拆词、添加到快捷发送、多选和删除选项
- 实现多选模式，支持批量操作剪贴板项目
- 添加清空确认对话框防止误操作
- 优化图标资源，使用更合适的Assignment图标替换ContentPasteGo
- 更新测试用例以验证新的批量删除和清空功能

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] 新功能
- [x] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
