### PR TITLE
feat(service): 添加双写机制确保方案状态持久化

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/ImeSessionController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeSessionController.kt
@@ -210,10 +210,15 @@ internal class ImeSessionController(private val service: XimeInputMethodService)
         service.serviceScope.launch(Dispatchers.IO) {
             val page = service.keyboardViewModel.page.value
             val isHandwritingMode = (page as? com.kingzcheung.xime.keyboard.KeyboardPage.Main)?.type == com.kingzcheung.xime.keyboard.MainType.HANDWRITING
+            val engineSchemaId = service.rimeEngine.getCurrentSchema()
+            // session 未就绪时 getCurrentSchema() 返回空串：用持久化方案兜底，
+            // 避免空值覆盖已正确的 currentSchemaId/schemaName 导致键盘退化为全键盘
             val currentSchemaId = if (isHandwritingMode) {
                 HANDWRITING_SCHEMA_ID
+            } else if (engineSchemaId.isNotEmpty()) {
+                engineSchemaId
             } else {
-                service.rimeEngine.getCurrentSchema()
+                SettingsPreferences.getCurrentSchema(context)
             }
             val name = SchemaManager.getSchemaDisplayName(context, currentSchemaId)
 

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1245,7 +1245,11 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         if (RimeEngine.isInitialized()) {
             val rimeAscii = rimeEngine.isAsciiMode()
             uiState.value = uiState.value.copy(isAsciiMode = rimeAscii)
-            keyboardViewModel.resetKeyboard(rimeAscii, uiState.value.currentSchemaId)
+            // currentSchemaId 为空（如引擎重建后 updateSchemaName 尚未完成）时，
+            // 用持久化方案兜底，避免布局退化为 26 键全键盘
+            val schemaId = uiState.value.currentSchemaId
+                .ifBlank { SettingsPreferences.getCurrentSchema(this) }
+            keyboardViewModel.resetKeyboard(rimeAscii, schemaId)
         }
 
         // 先重置候选状态到初始值，避免前一 session 的残留状态影响新输入

--- a/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
@@ -7,6 +7,8 @@ import com.kingzcheung.xime.plugin.core.runtime.PluginManager
 object SettingsPreferences {
     private const val PREFS_NAME = "kime_settings"
     private const val KEY_CURRENT_SCHEMA = "current_schema"
+    /** 双写标记：仅新版本双写后置 true，本地值才可信（旧版本只写 rime，本地是过时迁移值） */
+    private const val KEY_CURRENT_SCHEMA_DUAL = "current_schema_dual"
     private const val KEY_DEPLOYMENT_DONE = "deployment_done"
     private const val KEY_DEPLOYMENT_HASH = "deployment_hash"
     private const val KEY_RIME_ASSETS_VERSION = "rime_assets_version"
@@ -120,7 +122,13 @@ object SettingsPreferences {
     }
     
     fun getCurrentSchema(context: Context): String {
-        // 方案状态以 librime user.yaml 的 var/previously_selected_schema 为准
+        val prefs = getPrefs(context)
+        // 双写标记已置：本地值是新版本写入的最新方案，进程重建后 rime 未初始化也能恢复
+        if (prefs.getBoolean(KEY_CURRENT_SCHEMA_DUAL, false)) {
+            val local = prefs.getString(KEY_CURRENT_SCHEMA, null)
+            if (!local.isNullOrBlank()) return local
+        }
+        // 未双写（旧版本升级/首次）：rime user.yaml 为权威，本地仅作迁移兜底
         val fromRime = try {
             if (com.kingzcheung.xime.rime.RimeEngine.isInitialized()) {
                 com.kingzcheung.xime.rime.RimeEngine.getInstance()
@@ -129,24 +137,26 @@ object SettingsPreferences {
         } catch (_: Throwable) {
             null
         }
-        if (!fromRime.isNullOrBlank()) return fromRime
-        // 旧版本 SharedPreferences 数据仅作一次性迁移，迁移后不再写入
-        val legacy = getPrefs(context).getString(KEY_CURRENT_SCHEMA, null)
-        if (!legacy.isNullOrBlank()) {
-            try {
-                if (com.kingzcheung.xime.rime.RimeEngine.isInitialized()) {
-                    com.kingzcheung.xime.rime.RimeEngine.getInstance()
-                        .setUserConfigString("var/previously_selected_schema", legacy)
-                }
-            } catch (_: Throwable) {
-            }
-            return legacy
+        if (!fromRime.isNullOrBlank()) {
+            // 回写 SharedPreferences 并置双写标记，之后本地优先
+            prefs.edit()
+                .putString(KEY_CURRENT_SCHEMA, fromRime)
+                .putBoolean(KEY_CURRENT_SCHEMA_DUAL, true)
+                .apply()
+            return fromRime
         }
+        val legacy = prefs.getString(KEY_CURRENT_SCHEMA, null)
+        if (!legacy.isNullOrBlank()) return legacy
         return "wubi86"
     }
 
     fun setCurrentSchema(context: Context, schemaId: String) {
-        // 方案状态只写 librime user.yaml，不写 SharedPreferences
+        // 双写：SharedPreferences 保证进程重建后不依赖 rime 即可恢复，
+        // librime user.yaml 保持引擎侧状态一致（switchSchema 后由 librime 持久化）
+        getPrefs(context).edit()
+            .putString(KEY_CURRENT_SCHEMA, schemaId)
+            .putBoolean(KEY_CURRENT_SCHEMA_DUAL, true)
+            .apply()
         try {
             if (com.kingzcheung.xime.rime.RimeEngine.isInitialized()) {
                 com.kingzcheung.xime.rime.RimeEngine.getInstance()


### PR DESCRIPTION
当Rime引擎未初始化时，通过本地存储兜底恢复当前输入方案，
避免键盘布局退化为全键盘。实现SharedPreferences与librime
user.yaml的双写机制，确保进程重建后能正确恢复输入方案状态。

- 在ImeSessionController中添加引擎状态检查逻辑
- 在XimeInputMethodService中添加schemaId兜底恢复
- 在SettingsPreferences中实现双写标记机制
- 解决引擎重建后currentSchemaId为空导致的键盘退化问题

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
