### PR TITLE
fix(t9): 修复带调方案的 T9 preedit 显示尊重方案lua避免竞争与右选调频声调保真

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
@@ -575,17 +575,19 @@ class RimeEngine {
     // ═══════════════════════════════════════════════════════════
 
     /**
-     * 右选候选：根据候选拼音注释与文本长度执行右侧选词（消费计算）。
+     * 右选候选：根据候选拼音注释、候选文本与文本长度执行右侧选词（消费计算）。
      * 委托给 T9RightCommitHandler 三层消费算法，判断 full/partial commit。
      * 调频不在此进行——由 Kotlin 在 full commit 上屏后经 [t9Memorize] 单独调用。
      * @param pinyin 候选词的拼音注释（如 "li hua"）
+     * @param text 候选词文本（如 "丽华"）；用于 (comment, text) 双条件精确定位，
+     *   避免同注释歧义（如 几股/击鼓 均 "ji gu"）时捕获他词的调频码
      * @param textLength 候选词字数（如 "丽华" 为 2）
      */
-    fun t9SelectCandidate(pinyin: String, textLength: Int): Boolean {
+    fun t9SelectCandidate(pinyin: String, text: String?, textLength: Int): Boolean {
         if (!isInitialized) return false
         return tryLocked(false) {
             if (!nativeHasSession() && !nativeCreateSession()) return@tryLocked false
-            nativeT9SelectCandidate(pinyin, textLength)
+            nativeT9SelectCandidate(pinyin, text, textLength)
         }
     }
 
@@ -674,7 +676,7 @@ class RimeEngine {
     private external fun nativeUpdateLastBuildTime()
     private external fun nativeSetPageSize(schemaId: String, pageSize: Int)
     private external fun nativeDestroy()
-    private external fun nativeT9SelectCandidate(pinyin: String, textLength: Int): Boolean
+    private external fun nativeT9SelectCandidate(pinyin: String, text: String?, textLength: Int): Boolean
     private external fun nativeT9Memorize(text: String, pinyin: String): Boolean
     private external fun nativeT9Forget(text: String, pinyin: String): Boolean
     private external fun nativeT9SelectPinyinDirect(pinyin: String, digitLength: Int): Boolean

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
@@ -309,12 +309,17 @@ class T9InputController(
      * 调频不在此进行——由服务层在 full commit 上屏后经 rimeEngine.t9Memorize 单独调用。
      *
      * @param candidatePinyin 候选词拼音注释（comment），null 表示无注释候选（如 emoji）
+     * @param candidateText 候选词文本，供 C++ (comment, text) 双条件定位（防同注释错码）
      * @param candidateTextLength 候选词字数
      */
-    fun onRightCandidateSelected(candidatePinyin: String? = null, candidateTextLength: Int = 0): Boolean {
+    fun onRightCandidateSelected(
+        candidatePinyin: String? = null,
+        candidateText: String? = null,
+        candidateTextLength: Int = 0,
+    ): Boolean {
         awaitT9Queue()
         val isFullCommit = if (candidatePinyin != null) {
-            val result = rimeEngine.t9SelectCandidate(candidatePinyin, candidateTextLength)
+            val result = rimeEngine.t9SelectCandidate(candidatePinyin, candidateText, candidateTextLength)
             rimeEngine.t9FlushRimeInput()
             result
         } else {

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
@@ -712,9 +712,10 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
 
         // 在 RIME 真正 select/commit 之前，先同步通知 T9 控制器消费数字。
         // 控制器返回 true 表示输入序列已被该候选词完整消费，服务层应视为 full commit。
+        // 传入候选文本用于 C++ (comment, text) 双条件精确定位（注释歧义防错码）。
         val candidateTextLength = selectedCandidate?.length ?: 0
         val fullyConsumed = if (isT9) {
-            service.keyboardCallbacks?.onT9RightCandidateWillBeSelected?.invoke(candidatePinyin, candidateTextLength) ?: false
+            service.keyboardCallbacks?.onT9RightCandidateWillBeSelected?.invoke(candidatePinyin, selectedCandidate, candidateTextLength) ?: false
         } else {
             false
         }

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
@@ -48,9 +48,10 @@ data class KeyboardCallbacks(
      * 右侧候选词即将被 RIME select 前同步通知 T9 控制器。
      * 返回 true 表示控制器判断输入序列已被该候选词完整消费。
      * @param pinyin RIME 候选词注释
+     * @param text 候选词文本（可空），用于 C++ (comment, text) 双条件精确定位
      * @param textLength 候选词文字长度（汉字数），0 表示未知
      */
-    var onT9RightCandidateWillBeSelected: ((String?, Int) -> Boolean)? = null,
+    var onT9RightCandidateWillBeSelected: ((String?, String?, Int) -> Boolean)? = null,
     /**
      * T9 键盘切换离开（至数字/英文键盘）时调用。
      * 服务层负责提交首位候选词并清理 T9 状态。

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -123,13 +123,13 @@ fun KeyboardView(
     }
 
     SideEffect {
-        callbacks.onT9RightCandidateWillBeSelected = { pinyin, textLength ->
+        callbacks.onT9RightCandidateWillBeSelected = { pinyin, text, textLength ->
             // 返回 C++ T9RightCommitHandler 的 full_commit 权威标志，
             // 不依赖 RIME 引擎 input（full_commit 后引擎 input 可能残留，判断会失真）
             if (pinyin.isNullOrBlank()) {
                 t9Controller.onRightCandidateSelectedByDirectCommit()
             } else {
-                t9Controller.onRightCandidateSelected(pinyin, textLength)
+                t9Controller.onRightCandidateSelected(pinyin, text, textLength)
             }
         }
         callbacks.onT9ForceSendToRime = {

--- a/app/src/main/jni/librime-t9/src/t9_filter.cc
+++ b/app/src/main/jni/librime-t9/src/t9_filter.cc
@@ -66,6 +66,76 @@ static bool IsDigit(char c) {
     return c >= '0' && c <= '9';
 }
 
+// ── 声调归一化 ──
+// 带声调的拼音方案（如万象）词库编码使用 Unicode 预组合声调字符
+// （如 jī huà），comment 经 spelling_hints 暴露时保留声调。
+// 逐字节 ASCII 过滤会丢弃这些多字节字符的每个字节，导致元音丢失
+// （jī→j, huà→hu）。此处逐 Unicode 码点解码，将声调元音归一化为
+// 普通 ASCII 字母，与方案 speller algebra 的 xlit 语义一致。
+// 映射表与万象 wanxiang_t9.schema.yaml 第 139 行 xlit 对齐（大小写声调
+// 字符统一映射为小写 ASCII 字母）：
+//   āáǎà/ĀǍÁÀ→a   ēéěè/ĒĚÉÈ→e   īíǐì/ĪǏÍÌ→i   ōóǒò/ŌǑÓÒ→o
+//   ūúǔù/ŪǓÚÙ→u   ǖǘǚǜü/ǕǗǙǛÜ→v  ńňǹ/ŃŇǸ→n   ḿ/Ḿ→m
+// 注 1：万象 xlit 中的 m̀（m+组合附加符号 U+0300）不在此表——组合标记由
+//   NormalizePinyinComment 的"ASCII 字母保留 + 未识别多字节丢弃"路径隐式
+//   归一化为 m，与 xlit 语义一致（下表 ḿ/Ḿ 为预组合形式）。
+// 注 2：未识别的多字节字符（如组合用附加符号 U+0300）一律静默丢弃。
+static char ToneToAscii(uint32_t cp) {
+    switch (cp) {
+        // a: ā ǎ á à  Ā Ǎ Á À (U+0101/U+01CE/U+00E1/U+00E0/U+0100/U+01CD/U+00C1/U+00C0)
+        case 0x0101: case 0x01CE: case 0x00E1: case 0x00E0:
+        case 0x0100: case 0x01CD: case 0x00C1: case 0x00C0: return 'a';
+        // e: ē ě é è  Ē Ě É È (U+0113/U+011B/U+00E9/U+00E8/U+0112/U+011A/U+00C9/U+00C8)
+        case 0x0113: case 0x011B: case 0x00E9: case 0x00E8:
+        case 0x0112: case 0x011A: case 0x00C9: case 0x00C8: return 'e';
+        // i: ī ǐ í ì  Ī Ǐ Í Ì (U+012B/U+01D0/U+00ED/U+00EC/U+012A/U+01CF/U+00CD/U+00CC)
+        case 0x012B: case 0x01D0: case 0x00ED: case 0x00EC:
+        case 0x012A: case 0x01CF: case 0x00CD: case 0x00CC: return 'i';
+        // o: ō ǒ ó ò  Ō Ǒ Ó Ò (U+014D/U+01D2/U+00F3/U+00F2/U+014C/U+01D1/U+00D3/U+00D2)
+        case 0x014D: case 0x01D2: case 0x00F3: case 0x00F2:
+        case 0x014C: case 0x01D1: case 0x00D3: case 0x00D2: return 'o';
+        // u: ū ǔ ú ù  Ū Ǔ Ú Ù (U+016B/U+01D4/U+00FA/U+00F9/U+016A/U+01D3/U+00DA/U+00D9)
+        case 0x016B: case 0x01D4: case 0x00FA: case 0x00F9:
+        case 0x016A: case 0x01D3: case 0x00DA: case 0x00D9: return 'u';
+        // ü/v: ǖ ǘ ǚ ǜ ü  Ǖ Ǘ Ǚ Ǜ Ü (U+01D6/U+01D8/U+01DA/U+01DC/U+00FC/U+01D5/U+01D7/U+01D9/U+01DB/U+00DC)
+        case 0x01D6: case 0x01D8: case 0x01DA: case 0x01DC: case 0x00FC:
+        case 0x01D5: case 0x01D7: case 0x01D9: case 0x01DB: case 0x00DC: return 'v';
+        // n: ń ň ǹ  Ń Ň Ǹ (U+0144/U+0148/U+01F9/U+0143/U+0147/U+01F8)
+        case 0x0144: case 0x0148: case 0x01F9:
+        case 0x0143: case 0x0147: case 0x01F8: return 'n';
+        // m: ḿ Ḿ (U+1E3F/U+1E3E)
+        case 0x1E3F: case 0x1E3E: return 'm';
+        default: return 0;
+    }
+}
+
+// 将 comment 中的带声调拼音归一化为纯 ASCII 小写拼音。
+// 逐码点解码：声调字符 → 对应 ASCII 字母，ASCII 字母统一转小写，
+// 其他字符（分隔符、括号等）丢弃。非 static：供 t9_processor 复用。
+std::string NormalizePinyinComment(const std::string& comment) {
+    std::string result;
+    const char* p = comment.c_str();
+    const char* end = p + comment.size();
+    while (p < end) {
+        const char* prev = p;
+        uint32_t cp = DecodeUtf8(p, end);
+        if (cp == 0) continue;
+        if (cp < 0x80) {
+            if ((cp >= 'a' && cp <= 'z') || (cp >= 'A' && cp <= 'Z')) {
+                // 统一小写：归一化用于比较与音节选择，须大小写不敏感。
+                result += static_cast<char>(std::tolower(static_cast<unsigned char>(cp)));
+            }
+        } else {
+            char mapped = ToneToAscii(cp);
+            if (mapped != 0) {
+                result += mapped;
+            }
+            // 未识别的多字节字符（如组合用附加符号 U+0300）静默丢弃
+        }
+    }
+    return result;
+}
+
 // ── 输入分段 ──
 
 struct InputPart {
@@ -151,14 +221,10 @@ std::string T9ConvertPreedit(const std::string& preedit,
         std::string word;
         while (iss >> word) {
             if (!word.empty()) {
-                // 过滤 comment_format 引入的非字母字符（如雾凇方案的「」
-                // 确保 pinyin_parts 只包含纯拼音，避免 T9ConvertPreedit 输出异常字符
-                std::string filtered;
-                for (char c : word) {
-                    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
-                        filtered += c;
-                    }
-                }
+                // 过滤 comment_format 引入的非字母字符（如雾凇方案的「」），
+                // 同时归一化带声调的预组合字符（如万象方案的 jī huà），
+                // 确保 pinyin_parts 只包含纯 ASCII 拼音。
+                std::string filtered = NormalizePinyinComment(word);
                 if (!filtered.empty()) {
                     pinyin_parts.push_back(filtered);
                 }

--- a/app/src/main/jni/librime-t9/src/t9_filter.cc
+++ b/app/src/main/jni/librime-t9/src/t9_filter.cc
@@ -11,6 +11,8 @@
 #include <rime/schema.h>
 #include <rime/config.h>
 #include <rime/common.h>
+#include <rime/gear/translator_commons.h>  // Phrase（Phrase 码缓存）
+#include "t9_processor.h"  // T9ProcessorRequire / CachePhraseCode（Phrase 码缓存）
 #endif
 
 namespace rime {
@@ -342,6 +344,16 @@ void T9Translation::ConvertCurrent() {
     T9_PERF_SCOPED_TIMER("[T9Filter] ConvertCurrent");
     if (!cand_) return;
     auto genuine = Candidate::GetGenuineCandidate(cand_);
+    // 缓存 Phrase 真实码（含声调真相）：t9_filter 位于 filters 最前，候选尚为
+    // 带调 Phrase；后续 lua filter 链可能重建为非 Phrase，导致右选调频无法从
+    // 候选取码。缓存由 T9Processor 在每次 flush 重建、右选时按 (text, 归一化
+    // comment) 匹配兜底。
+    if (auto phrase = As<Phrase>(genuine)) {
+        if (auto* proc = T9ProcessorRequire()) {
+            proc->CachePhraseCode(genuine->text(), genuine->comment(), phrase->code());
+        }
+    }
+    if (!convert_preedit_) return;  // 透传：仅缓存，不改 preedit
     std::string converted = T9ConvertCandidatePreedit(genuine->preedit(),
                                                        genuine->comment(),
                                                        genuine->text());
@@ -354,10 +366,12 @@ void T9Translation::ConvertCurrent() {
 
 T9Translation::T9Translation(an<Translation> translation,
                                char auto_delim,
-                               char manual_delim)
+                               char manual_delim,
+                               bool convert_preedit)
     : translation_(translation),
       auto_delim_(auto_delim),
-      manual_delim_(manual_delim) {
+      manual_delim_(manual_delim),
+      convert_preedit_(convert_preedit) {
     // 不调用 translation_->Next()：Translation 创建时已定位在第一个候选
     if (translation_->exhausted()) {
         set_exhausted(true);
@@ -400,9 +414,11 @@ T9Filter::T9Filter(const Ticket& ticket) : Filter(ticket) {
 an<Translation> T9Filter::Apply(an<Translation> translation,
                                  CandidateList* candidates) {
     T9_PERF_SCOPED_TIMER("[T9Filter] Apply");
-    if (!convert_preedit_) return translation;
     if (!translation) return translation;
-    return New<T9Translation>(translation, auto_delimiter_, manual_delimiter_);
+    // 始终包装 T9Translation：false 时转换 preedit，true 时透传但均顺带缓存
+    // Phrase 码（供右选调频捕获兜底，见 ConvertCurrent）。
+    return New<T9Translation>(translation, auto_delimiter_, manual_delimiter_,
+                              convert_preedit_);
 }
 
 #endif  // T9_ALGO_ONLY_BUILD

--- a/app/src/main/jni/librime-t9/src/t9_filter.h
+++ b/app/src/main/jni/librime-t9/src/t9_filter.h
@@ -32,23 +32,35 @@ std::string T9ConvertCandidatePreedit(const std::string& preedit,
                                       const std::string& comment,
                                       const std::string& candidate_text);
 
+// 将拼音注释中的带声调字符归一化为纯 ASCII 小写拼音（jī huà → ji hua）。
+// 供 t9_processor 调频码声调保真复用：comment 归一化匹配、无声调音节
+// → 带声调变体选择（避免命中轻声音节）。
+std::string NormalizePinyinComment(const std::string& comment);
+
 #ifndef T9_ALGO_ONLY_BUILD
 // 包装候选，覆盖 preedit() 返回转换后的拼音，
 // 不修改原始候选对象，避免跨 .so 边界的 dynamic_cast 失效问题。
-class T9PreeditCandidate : public Candidate {
+// 继承 SimpleCandidate 而非 Candidate，使得 Lua 绑定的
+// dynamic_cast<SimpleCandidate*>(&c) 成功，从而 set_preedit()
+// 可被后续 filter（如 super_comment_preedit）通过 cand.preedit = val
+// 覆盖 preedit 值，避免锁死 bug。
+class T9PreeditCandidate : public SimpleCandidate {
 public:
     T9PreeditCandidate(an<Candidate> item, const string& preedit)
-        : Candidate(item->type() + "'t9",
-                    item->start(), item->end(), item->quality()),
-          item_(item), preedit_(preedit) {}
+        : SimpleCandidate(item->type() + "'t9",
+                          item->start(), item->end(),
+                          item->text(), item->comment(), preedit),
+          item_(item) {
+        set_quality(item->quality());
+    }
 
-    const string& text() const override { return item_->text(); }
-    string comment() const override { return item_->comment(); }
-    string preedit() const override { return preedit_; }
+    // text()/comment()/preedit() 均继承自 SimpleCandidate（存 item 副本）；
+    // set_preedit(v) 供后续 Lua filter（super_comment_preedit）覆盖 preedit。
+
+    an<Candidate> item() const { return item_; }
 
 private:
     an<Candidate> item_;
-    string preedit_;
 };
 
 class T9Translation : public Translation {

--- a/app/src/main/jni/librime-t9/src/t9_filter.h
+++ b/app/src/main/jni/librime-t9/src/t9_filter.h
@@ -67,7 +67,8 @@ class T9Translation : public Translation {
 public:
     T9Translation(an<Translation> translation,
                    char auto_delim,
-                   char manual_delim);
+                   char manual_delim,
+                   bool convert_preedit);
     bool Next() override;
     an<Candidate> Peek() override { return cand_; }
 
@@ -78,6 +79,8 @@ private:
     an<Candidate> cand_;
     char auto_delim_;
     char manual_delim_;
+    // false（isDisplayOriginalPreedit: true）时透传 preedit，仅缓存 Phrase 码供调频。
+    bool convert_preedit_ = false;
 };
 
 class T9Filter : public Filter {

--- a/app/src/main/jni/librime-t9/src/t9_patch_utils.cc
+++ b/app/src/main/jni/librime-t9/src/t9_patch_utils.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <sstream>
 
 namespace rime {
 namespace t9_patch_utils {
@@ -93,6 +94,34 @@ std::string StripPacksLines(const std::string& custom_yaml_content) {
     pos = eol + 1;
   }
   return result;
+}
+
+bool HasPreeditLuaFilter(const std::string& content) {
+  // 逐行扫描 `lua_filter@` 引用名，含 "preedit" 即命中。
+  // 行首注释跳过（避免示例误判）；引用名用"包含"匹配（兼容
+  // *wanxiang.super_comment_preedit 前缀写法）。
+  std::istringstream iss(content);
+  std::string line;
+  while (std::getline(iss, line)) {
+    if (!line.empty() && line.back() == '\r') line.pop_back();
+    const size_t first = line.find_first_not_of(" \t");
+    if (first == std::string::npos || line[first] == '#') continue;
+
+    const size_t pos = line.find("lua_filter@");
+    if (pos == std::string::npos) continue;
+    size_t name_start = pos + std::string("lua_filter@").size();
+    size_t name_end = name_start;
+    while (name_end < line.size() && line[name_end] != ' ' && line[name_end] != '\t' &&
+           line[name_end] != '#' && line[name_end] != ']' && line[name_end] != '"' &&
+           line[name_end] != '\r') {
+      ++name_end;
+    }
+    const std::string ref = line.substr(name_start, name_end - name_start);
+    if (ref.find("preedit") != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
 }
 
 }  // namespace t9_patch_utils

--- a/app/src/main/jni/librime-t9/src/t9_patch_utils.h
+++ b/app/src/main/jni/librime-t9/src/t9_patch_utils.h
@@ -44,6 +44,12 @@ PacksState EvaluatePacksState(const std::string& custom_yaml_content,
 // 返回值末尾无多余的连续空行，供调用方继续追加合法补丁。
 std::string StripPacksLines(const std::string& custom_yaml_content);
 
+// 判定内容是否自带 preedit 管理型 lua filter（如万象 super_comment_preedit）：
+// 任意 `lua_filter@` 引用名含 "preedit" 即命中。相较旧版全表 "preedit" 子串
+// 扫描，不误伤仅含 preedit_format / 注释提及 preedit 的三方方案。
+// 命中时 DoEnsureT9SchemaPatches 默认 t9/isDisplayOriginalPreedit: true。
+bool HasPreeditLuaFilter(const std::string& content);
+
 }  // namespace t9_patch_utils
 }  // namespace rime
 

--- a/app/src/main/jni/librime-t9/src/t9_processor.cc
+++ b/app/src/main/jni/librime-t9/src/t9_processor.cc
@@ -12,13 +12,17 @@
 #include <rime/schema.h>
 #include <rime/ticket.h>
 #include <rime/dict/dictionary.h>
+#include <rime/dict/prism.h>
 #include <rime/dict/user_dictionary.h>
+#include <rime/algo/syllabifier.h>
+#include <rime/gear/translator_commons.h>  // Phrase（右选码捕获）
 #include <algorithm>
 #include <atomic>
 #include <set>
 
 #include "t9_log.h"
 #include "t9_right_commit_utils.h"  // ParseSyllables
+#include "t9_filter.h"              // NormalizePinyinComment（调频码声调保真）
 
 namespace rime {
 
@@ -431,12 +435,13 @@ void T9Processor::HandleSelectionReplacementChoice(const SyllableOption& option)
 // ════════════════════════════════════════
 
 bool T9Processor::SelectCandidate(const std::string& candidate_pinyin,
+                                   const std::string& candidate_text,
                                    int candidate_text_length) {
     // ── 诊断日志：入口状态 ──
     T9_SCOPED_TIMER_TAG("T9Processor", "SelectCandidate");
     T9_PERF_SCOPED_TIMER("[T9] SelectCandidate");
-    T9LOG(">> SelectCandidate ENTRY: pinyin='%s', textLen=%d",
-          candidate_pinyin.c_str(), candidate_text_length);
+    T9LOG(">> SelectCandidate ENTRY: pinyin='%s', text='%s', textLen=%d",
+          candidate_pinyin.c_str(), candidate_text.c_str(), candidate_text_length);
     T9LOG(">>   buf: digitSeq='%s', selCount=%zu, consumedCount=%d, unassigned='%s'",
           input_buffer_.digit_sequence.c_str(),
           input_buffer_.selections.size(),
@@ -478,8 +483,22 @@ bool T9Processor::SelectCandidate(const std::string& candidate_pinyin,
 
     // 方案 A：优先用 RIME 候选 end 换算的消费位数（精确反映 schema 派生编码
     // 的匹配范围），无法确定时用 -1 fallback 到现有 AlignWithBuffer 算法。
-    int rime_consumed = QueryRimeConsumedDigits(candidate_pinyin);
+    // 顺带捕获候选真实数据（Phrase 文本 + 音节码，含声调真相）供调频使用。
+    Code captured_code;
+    std::string captured_text;
+    int rime_consumed =
+        QueryRimeConsumedDigits(candidate_pinyin, candidate_text, &captured_code, &captured_text);
     T9LOG(">> SelectCandidate: rimeConsumedDigits=%d", rime_consumed);
+    if (!captured_code.empty()) {
+        // 捕获随段模型同生命周期（Clear/undo 由段模型权威管理）；
+        // rime::Code → 段模型 RIME 无关表示（T9SyllableCode，同型互转）。
+        undo_model_.PushCommitCapture(captured_text,
+                                      T9SyllableCode(captured_code.begin(), captured_code.end()));
+        std::string ids;
+        for (auto id : captured_code) ids += std::to_string(id) + ",";
+        T9LOG(">> SelectCandidate: captured '%s' code=[%s] (%zu syl)",
+              captured_text.c_str(), ids.c_str(), captured_code.size());
+    }
 
     bool full_commit = right_commit_handler_.HandleRightCommit(
         ctx, candidate_pinyin, candidate_text_length, rime_consumed);
@@ -532,9 +551,29 @@ bool T9Processor::BuildEntryForPinyin(const std::string& text,
         return false;
     Code code;
     for (const auto& syl : syllables) {
+        // 声调保真：无声调音节（如调频拼音 "ji"）优先选带声调变体（jī/jí/jǐ/jì），
+        // 避免命中词库轻声音节（簸箕 ji）导致调频码丢声调（tone_display 失效）。
+        if (!HasTone(syl)) {
+            EnsureTonedSyllableMap();
+            auto toned = toned_syllable_map_.find(syl);
+            if (toned != toned_syllable_map_.end()) {
+                code.push_back(toned->second);
+                continue;
+            }
+        }
         auto it = syllabary_map_.find(syl);
-        if (it == syllabary_map_.end())
-            return false;  // 音节不在词典（如英文/符号），放弃调频
+        if (it == syllabary_map_.end()) {
+            // 带声调词典（如万象 běn）与无声调调频拼音（ben）格式差异：
+            // 表音节精确匹配失败时，借方案 Prism 解析（含 xlit 声调消除）。
+            auto prism_id = ResolveSyllableViaPrism(syl);
+            if (!prism_id) {
+                T9LOG(">> BuildEntryForPinyin: syllable '%s' not resolvable, skip",
+                      syl.c_str());
+                return false;  // 音节不在词典（如英文/符号），放弃调频
+            }
+            code.push_back(*prism_id);
+            continue;
+        }
         code.push_back(it->second);
     }
     entry->text = text;
@@ -542,40 +581,167 @@ bool T9Processor::BuildEntryForPinyin(const std::string& text,
     return true;
 }
 
-bool T9Processor::UpdateDictEntry(const std::string& text,
-                                  const std::string& pinyin,
-                                  int commits) {
+std::optional<SyllableId> T9Processor::ResolveSyllableViaPrism(
+    const std::string& syllable) {
+    if (!dict_ || !dict_->prism())
+        return std::nullopt;
+    // 用与查询侧一致的 Syllabifier 建图：Prism 内含方案 speller algebra
+    // （万象 xlit 声调消除、补丁注入的简拼派生），是"拼写→音节"的权威映射。
+    // 例：ben → běn 的 SyllableId；ji → 所有带调/轻声音节的任一命中。
+    Syllabifier syllabifier(" '");
+    SyllableGraph graph;
+    if (syllabifier.BuildSyllableGraph(syllable, *dict_->prism(), &graph) <= 0)
+        return std::nullopt;
+    // 只接受覆盖整个输入的单音节（graph.edges[start][end] 的 SpellingMap）。
+    // 多音字（如 xiang 匹配 xiāng/xiáng/xiǎng/xiàng）取任一命中即可：
+    // userdb 查询按输入音节图遍历所有声调路径（见 UserDictionary::DfsLookup），
+    // 存储任一有效变体都能被对应输入的查询路径命中（声调不影响数字码）。
+    auto start_it = graph.edges.find(0);
+    if (start_it == graph.edges.end())
+        return std::nullopt;
+    auto end_it = start_it->second.find(syllable.size());
+    if (end_it == start_it->second.end() || end_it->second.empty())
+        return std::nullopt;
+    return end_it->second.begin()->first;
+}
+
+bool T9Processor::HasTone(const std::string& syllable) {
+    // 声调字符（ā é ǐ 等）均为 UTF-8 多字节；出现非 ASCII 字节即带声调。
+    for (unsigned char c : syllable) {
+        if (c >= 0x80) return true;
+    }
+    return false;
+}
+
+void T9Processor::EnsureTonedSyllableMap() {
+    // 惰性构建 无声调拼写 → 带声调音节 映射（如 "ji" → jī 系任一，
+    // "ben" → běn），供 BuildEntryForPinyin 声调保真选择，避免命中轻声音节。
+    if (!toned_syllable_map_.empty() || syllabary_map_.empty())
+        return;
+    for (const auto& [s, id] : syllabary_map_) {
+        if (!HasTone(s)) continue;  // 跳过轻声音节（全 ASCII）
+        std::string norm = NormalizePinyinComment(s);
+        if (!norm.empty() && !toned_syllable_map_.count(norm)) {
+            toned_syllable_map_[norm] = id;  // 每个拼写取首个带调变体
+        }
+    }
+}
+
+void T9Processor::CachePhraseCode(const std::string& text,
+                                  const std::string& comment,
+                                  const Code& code) {
+    phrase_code_cache_.push_back(
+        PhraseCodeEntry{text, comment, T9SyllableCode(code.begin(), code.end())});
+}
+
+void T9Processor::ClearPhraseCodeCache() {
+    phrase_code_cache_.clear();
+}
+
+T9SyllableCode T9Processor::FindPhraseCode(
+    const std::string& text,
+    const std::string& normalized_comment) const {
+    for (const auto& e : phrase_code_cache_) {
+        if (e.text == text &&
+            NormalizePinyinComment(e.comment) == normalized_comment) {
+            return e.code;
+        }
+    }
+    return {};
+}
+
+bool T9Processor::WriteDictEntry(const std::string& text,
+                                 const Code& code,
+                                 int commits) {
     if (!user_dict_ || !user_dict_->loaded() || user_dict_->readonly())
         return false;
-    if (text.empty() || pinyin.empty())
+    if (text.empty() || code.empty())
         return false;
     DictEntry entry;
-    if (!BuildEntryForPinyin(text, pinyin, &entry))
-        return false;
+    entry.text = text;
+    entry.code = code;
     // 刷新 tick：与主翻译器的 UserDictionary 共享 db（db_pool_），
     // 但各实例独立缓存 tick_，写前同步防 tick 倒退（UpdateEntry 依赖 tick 计算权重）。
     user_dict_->Load();
     const char* op = commits > 0 ? "Memorize" : "Forget";
     if (user_dict_->UpdateEntry(entry, commits)) {
-        T9LOG(">> %sEntry OK: '%s' pinyin='%s'", op, text.c_str(), pinyin.c_str());
+        T9LOG(">> %sEntry OK: '%s'", op, text.c_str());
         return true;
     }
-    T9LOG(">> %sEntry FAIL: '%s' pinyin='%s'", op, text.c_str(), pinyin.c_str());
+    T9LOG(">> %sEntry FAIL: '%s'", op, text.c_str());
     return false;
+}
+
+bool T9Processor::UpdateDictEntry(const std::string& text,
+                                  const std::string& pinyin,
+                                  int commits) {
+    if (text.empty() || pinyin.empty())
+        return false;
+    T9LOG(">> UpdateDictEntry: FALLBACK text='%s' pinyin='%s'", text.c_str(), pinyin.c_str());
+    DictEntry entry;
+    if (!BuildEntryForPinyin(text, pinyin, &entry))
+        return false;
+    return WriteDictEntry(text, entry.code, commits);
 }
 
 bool T9Processor::MemorizeEntry(const std::string& text,
                                 const std::string& pinyin) {
+    // 优先使用右选捕获的 (text, code)（含声调真相，见 T9UndoModel::commit_captures）：
+    // 事后无声调拼音解析会命中轻声音节（计划→ji/hua 轻声）导致调频码丢声调。
+    const auto& captures = undo_model_.commit_captures();
+    T9LOG(">> MemorizeEntry: text='%s' pinyin='%s' captures=%zu",
+          text.c_str(), pinyin.c_str(), captures.size());
+    if (!captures.empty()) {
+        auto pinyin_syllables = ParseSyllables(pinyin);
+        std::string captured_text;
+        size_t total_syllables = 0;
+        for (const auto& [seg_text, code] : captures) {
+            captured_text += seg_text;
+            total_syllables += code.size();
+        }
+        // 文本拼接 + 音节数双重校验：任一不符视为序列被中断的过期捕获，
+        // 作废后回退到拼音解析（避免把残留捕获误写到本次上屏文本上）。
+        if (captured_text == text && !pinyin_syllables.empty() &&
+            total_syllables == pinyin_syllables.size()) {
+            Code full_code;
+            for (const auto& [seg_text, code] : captures)
+                full_code.insert(full_code.end(), code.begin(), code.end());
+            undo_model_.ClearCommitCaptures();
+            std::string ids;
+            for (auto id : full_code) ids += std::to_string(id) + ",";
+            T9LOG(">> MemorizeEntry: USE CAPTURE code=[%s]", ids.c_str());
+            return WriteDictEntry(text, full_code, 1);
+        }
+        T9LOG(">> MemorizeEntry: capture mismatch (join='%s'), clear + fallback",
+              captured_text.c_str());
+        undo_model_.ClearCommitCaptures();  // 不匹配 → 作废过期捕获
+    }
     return UpdateDictEntry(text, pinyin, 1);
 }
 
 bool T9Processor::ForgetEntry(const std::string& text,
                               const std::string& pinyin) {
+    // 撤销段：弹出段模型中最右选捕获的 (text, code)（Kotlin 撤销段时驱动，
+    // 与段模型生命周期一致）。text + 音节数双重校验：匹配才用捕获码回滚，
+    // 否则回退拼音解析（防止写错 key 而无法真正回滚原调频条目）。
+    auto capture = undo_model_.PopLastCommitCapture();
+    if (capture) {
+        auto pinyin_syllables = ParseSyllables(pinyin);
+        if (capture->first == text && !pinyin_syllables.empty() &&
+            capture->second.size() == pinyin_syllables.size()) {
+            // T9SyllableCode → rime::Code（同型互转）
+            Code code(capture->second.begin(), capture->second.end());
+            return WriteDictEntry(text, code, -1);
+        }
+    }
     return UpdateDictEntry(text, pinyin, -1);
 }
 
 int T9Processor::QueryRimeConsumedDigits(
-    const std::optional<std::string>& candidate_pinyin) const {
+    const std::optional<std::string>& candidate_pinyin,
+    const std::string& candidate_text,
+    Code* captured_code,
+    std::string* captured_text) const {
     // 方案 A：右选消费优先采用 RIME 候选的实际匹配范围。
     // RIME 已通过 schema 的 speller/algebra（含 derive/abbrev 派生规则）
     // 精确计算出候选在输入中的匹配结束位置（Candidate::end()），
@@ -586,6 +752,7 @@ int T9Processor::QueryRimeConsumedDigits(
     if (!ctx) return -1;
     const std::string& rime_input = ctx->input();
     const auto& comp = ctx->composition();
+    const bool match_text = !candidate_text.empty();
     for (const auto& seg : comp) {
         if (!seg.menu) continue;
         // 只遍历已生成的候选（candidate_count()），不调用 Prepare(n) 强制扩展——
@@ -597,9 +764,33 @@ int T9Processor::QueryRimeConsumedDigits(
             auto cand = seg.menu->GetCandidateAt(i);
             auto genuine = Candidate::GetGenuineCandidate(cand);
             if (!genuine) continue;
-            // T9PreeditCandidate 包装的 comment() 委托给内部候选，
-            // 与 Kotlin 传入的 candidate_pinyin（spelling_hints 拼音）一致。
-            if (genuine->comment() != *candidate_pinyin) continue;
+            // 归一化比较（声调保真）：带声调词库的 genuine comment 可能保留声调
+            // （"jì huà"），而 UI comment 经方案 lua 处理为无声调（"ji hua"）。
+            // 精确比较会漏匹配 → 调频码捕获失败 → fallback 命中轻声音节。
+            // 归一化后两者同为 "jihua"；多音字（yínháng/yínxíng）仍可区分。
+            if (NormalizePinyinComment(genuine->comment()) !=
+                NormalizePinyinComment(*candidate_pinyin))
+                continue;
+            // 注释歧义根治：Kotlin 同时传入候选文本，双条件精确定位用户点选
+            // 的候选（如 几股/击鼓 同注释 "ji gu"），避免捕获同注释他词的码。
+            // text 为空（兼容/异常兜底）时退化为仅按注释匹配的旧行为。
+            if (match_text && genuine->text() != candidate_text) continue;
+            // 顺带捕获 Phrase 的真实码（含声调真相），供调频保留声调。
+            if (captured_code || captured_text) {
+                if (auto phrase = As<Phrase>(genuine)) {
+                    if (captured_code) *captured_code = phrase->code();
+                    if (captured_text) *captured_text = phrase->text();
+                } else {
+                    // 候选被 lua filter 链重建（非 Phrase）：从 t9_filter 预存的
+                    // Phrase 码缓存兜底（filters 最前阶段候选尚为带调 Phrase）。
+                    auto cached = FindPhraseCode(
+                        genuine->text(), NormalizePinyinComment(*candidate_pinyin));
+                    if (!cached.empty()) {
+                        if (captured_code) *captured_code = Code(cached.begin(), cached.end());
+                        if (captured_text) *captured_text = genuine->text();
+                    }
+                }
+            }
             size_t end = genuine->end();
             int digits = 0;
             size_t limit = std::min(end, rime_input.size());
@@ -798,6 +989,8 @@ void T9Processor::FlushRimeInput() {
     // 埋点体现引擎调用本身耗时（含 compose_total），供对比观察。
     T9_SCOPED_TIMER_TAG("T9Processor", "FlushRimeInput");
     T9_PERF_SCOPED_TIMER("[T9] FlushRimeInput");
+    // 新 input 的候选集即将生成，作废上一轮 Phrase 码缓存（t9_filter 将重建）。
+    ClearPhraseCodeCache();
     switch (pending_action_) {
         case RimePendingAction::kNone:
             return;
@@ -841,7 +1034,7 @@ void T9Processor::EnterIdle() {
     left_column_locked_ = false;
     separator_consumed_digits_.reset();   // 修复（2026-08-06）：外部清空触发的
     last_choice_consumed_digits_.reset(); // EnterIdle 也重置分词键/左选临时状态
-    // 段模型为回退唯一真相源：清空全部段状态（2026-08-06 起命令模式已移除，无残留栈）
+    // 段模型为回退唯一真相源：清空全部段状态（含 commit_captures_ 调频捕获）。
     undo_model_.Clear();
 }
 

--- a/app/src/main/jni/librime-t9/src/t9_processor.h
+++ b/app/src/main/jni/librime-t9/src/t9_processor.h
@@ -56,16 +56,27 @@ public:
 
     // 右侧候选选词，返回 true = 完整消费（full commit）
     // 委托给 T9RightCommitHandler 三层消费算法
-    // 注：传入候选拼音注释（comment）与候选词字数，而非索引；
-    //     RIME Menu::GetCandidateAt 使用绝对索引，而 Kotlin 层持有的是当前页
-    //     相对索引，直接传拼音可避免翻页后索引错位导致消费计算错误。
-    bool SelectCandidate(const std::string& candidate_pinyin, int candidate_text_length);
+    // 注：传入拼音注释（comment）、候选文本与字数而非索引，避免翻页后索引
+    //     错位；并按 (comment, text) 双条件定位（同注释歧义防错码，如
+    //     几股/击鼓 均 "ji gu"）。
+    bool SelectCandidate(const std::string& candidate_pinyin,
+                         const std::string& candidate_text,
+                         int candidate_text_length);
 
     // ── 用户词典调频（Kotlin 上屏路径为唯一真相源）──
     // 调频文本与拼音由 Kotlin 在 full commit（含 partial 拼接）时传入，
     // C++ 构造 RIME 原生 DictEntry 写入（key 由 RIME 生成）；撤销段时 ForgetEntry 回滚。
     bool MemorizeEntry(const std::string& text, const std::string& pinyin);
     bool ForgetEntry(const std::string& text, const std::string& pinyin);
+
+    // ── Phrase 码缓存（t9_filter 预存，右选调频捕获兜底）──
+    // t9_filter 位于 filters 最前，此时候选尚为带调 Phrase；后续 lua filter 链
+    // 可能重建为非 Phrase（As<Phrase> 失败），缓存保证仍能取到精确调频码。
+    void CachePhraseCode(const std::string& text, const std::string& comment, const Code& code);
+    void ClearPhraseCodeCache();
+    // 按 (text, 归一化 comment) 精确匹配返回码；未命中返回空。
+    T9SyllableCode FindPhraseCode(const std::string& text,
+                                  const std::string& normalized_comment) const;
 
     // 获取 partial commit 后剩余的数字串
     std::string GetRemainingDigits() const;
@@ -144,18 +155,40 @@ private:
 
     // ── 辅助 ──
     void LogPreeditState();
-    // 构造 DictEntry（text + 拼音音节 code）；音节不在词典 syllabary 时返回 false。
+    // 构造 DictEntry（text + 拼音音节 code）：无声调音节优先带声调变体
+    // （toned_syllable_map_，声调保真），其次精确匹配，最后 Prism 兜底；
+    // 音节完全无法解析时返回 false（如英文/符号，放弃调频）。
     bool BuildEntryForPinyin(const std::string& text, const std::string& pinyin,
                              DictEntry* entry);
+    // 通过方案 Prism（含 speller algebra：xlit 声调消除 / 简拼派生）将拼音音节
+    // 解析为词典原生 SyllableId，解决带声调词典（如万象 běn）与无声调调频拼音
+    // （ben）的格式差异。返回覆盖整个输入的单音节 id；无法解析返回 nullopt。
+    // 例：ben → běn 的 SyllableId；ji → jǐ/轻声 ji 等任一命中变体。
+    std::optional<SyllableId> ResolveSyllableViaPrism(const std::string& syllable);
+    // 惰性构建 无声调拼写 → 带声调音节 映射（调频声调保真，2026-08-16）：
+    // 万象类词库 syllables 同时含带调音节（jì）与轻声音节（ji，簸箕），
+    // 无声调调频拼音直接命中轻声会丢声调 → userdb 候选 comment 无声调。
+    // 本映射保证无声调输入优先选带调变体（jī/jí/jǐ/jì 任一）。
+    void EnsureTonedSyllableMap();
+    // 判断音节是否含声调字符（非 ASCII 字节）。
+    static bool HasTone(const std::string& syllable);
     // 调频写入/回滚公共实现（MemorizeEntry/ForgetEntry 共用）：commits=+1 记忆 / -1 回滚。
     bool UpdateDictEntry(const std::string& text, const std::string& pinyin, int commits);
+    // 使用已解析的 Code 直接写/回滚用户词典（MemorizeEntry 的右选码捕获路径复用）。
+    bool WriteDictEntry(const std::string& text, const Code& code, int commits);
 
     // 方案 A（消费算法优化）：查询 RIME 候选的实际匹配结束位置，
     // 换算为 T9 应消费的数字位数（RIME input[0:end) 中数字字符数，跳过分隔符）。
-    // 候选通过 comment（spelling_hints 拼音）匹配。
+    // 候选按 comment 归一化匹配（容忍带调/无调差异，见 NormalizePinyinComment），
+    // candidate_text 非空时再按文本双条件定位（同注释歧义防错码）。
     // 返回 -1 表示无法确定（fallback 到现有 AlignWithBuffer 消费算法）。
+    // captured_code / captured_text（可空）：命中候选为 Phrase 时顺带捕获
+    // 其真实码（含声调真相）与文本，供 MemorizeEntry 调频保留声调。
     int QueryRimeConsumedDigits(
-        const std::optional<std::string>& candidate_pinyin) const;
+        const std::optional<std::string>& candidate_pinyin,
+        const std::string& candidate_text,
+        Code* captured_code = nullptr,
+        std::string* captured_text = nullptr) const;
 
     // ════════════════════════════════════════
     // 状态成员（对应 Kotlin T9InputController 的私有字段）
@@ -190,6 +223,15 @@ private:
     // 音节→SyllableId 映射（惰性构建，与 UserDictionary::Lookup 的 RecruitEntry
     // 构造方式一致：GetSyllabary 返回顺序即 id）。用于把拼音音节转为原生 Code。
     std::unordered_map<std::string, SyllableId> syllabary_map_;
+    // 无声调拼写 → 带声调音节 SyllableId（惰性构建，见 EnsureTonedSyllableMap）。
+    std::unordered_map<std::string, SyllableId> toned_syllable_map_;
+    // Phrase 码缓存条目（t9_filter 预存，每次 flush 重建）。
+    struct PhraseCodeEntry {
+        std::string text;
+        std::string comment;  // 带调原始 comment（t9_filter 阶段，lua 尚未改写）
+        T9SyllableCode code;
+    };
+    std::vector<PhraseCodeEntry> phrase_code_cache_;
 
     // ── 异步 flush 状态（SendToRime 标记，FlushRimeInput 消费）──
     // pending_action_ / pending_input_ 的读写都发生在 RimeEngine.rimeLock

--- a/app/src/main/jni/librime-t9/src/t9_undo_model.cc
+++ b/app/src/main/jni/librime-t9/src/t9_undo_model.cc
@@ -190,6 +190,20 @@ void T9UndoModel::Clear() {
     delete_mode_ = false;
     delete_min_pos_ = -1;
     last_backspace_undid_commit_ = false;
+    // 右选序列的调频捕获随段模型一并清空（EnterIdle 会话边界）。
+    commit_captures_.clear();
+}
+
+void T9UndoModel::PushCommitCapture(const std::string& text, const T9SyllableCode& code) {
+    commit_captures_.emplace_back(text, code);
+}
+
+std::optional<std::pair<std::string, T9SyllableCode>> T9UndoModel::PopLastCommitCapture() {
+    if (commit_captures_.empty())
+        return std::nullopt;
+    auto capture = std::move(commit_captures_.back());
+    commit_captures_.pop_back();
+    return capture;
 }
 
 bool T9UndoModel::HasPendingCommit() const {

--- a/app/src/main/jni/librime-t9/src/t9_undo_model.h
+++ b/app/src/main/jni/librime-t9/src/t9_undo_model.h
@@ -1,14 +1,21 @@
 #ifndef T9_SEGMENT_MODEL_H_
 #define T9_SEGMENT_MODEL_H_
 
+#include <cstdint>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "t9_buffer.h"
 #include "t9_pinyin_map.h"
 
 namespace rime {
+
+// 音节码的 RIME 无关表示（int32_t 与 rime::SyllableId 同型）：
+// 段模型属纯算法层（T9_ALGO_ONLY_BUILD），不依赖 RIME 头文件；
+// 处理器在边界与 rime::Code 互转（迭代器拷贝即可）。
+using T9SyllableCode = std::vector<int32_t>;
 
 // 段（Segment）：一个拼音音节的完整生命周期（设计文档 §3）。
 //
@@ -131,6 +138,20 @@ public:
     // 清空全部状态（对应 EnterIdle / ClearComposition 的 undo_model 同步）
     void Clear();
 
+    // ── 右选序列的调频捕获（text+code，与段模型同生命周期）──
+    // 每次右选 push 一条；码含声调真相（Phrase::code），供调频保留声调
+    // （无声调拼音解析会命中轻声音节，如万象 计划→ji/hua 轻声，导致丢声调）。
+    // Clear() 一并清空；MemorizeEntry 全量消费、ForgetEntry 弹栈回滚。
+    void PushCommitCapture(const std::string& text, const T9SyllableCode& code);
+    // 全部捕获（按选择顺序）；MemorizeEntry 校验文本拼接/音节数后消费。
+    const std::vector<std::pair<std::string, T9SyllableCode>>& commit_captures() const {
+        return commit_captures_;
+    }
+    // 弹出最近一次右选捕获（撤销段时由 ForgetEntry 消费）；空栈返回 nullopt。
+    std::optional<std::pair<std::string, T9SyllableCode>> PopLastCommitCapture();
+    // 仅清空捕获（MemorizeEntry 消费后调用；Clear() 内部也调用）。
+    void ClearCommitCaptures() { commit_captures_.clear(); }
+
     // 是否存在未撤销的 commit 操作（kRC/kTailConsume）——对应命令模式
     // HasPendingRightCommit（EnterIdle 时决定是否清空撤销栈）。
     bool HasPendingCommit() const;
@@ -250,6 +271,9 @@ private:
     bool last_backspace_undid_commit_ = false;
     // 撤销的 commit 操作计数（kRC/kTailConsume 各计 1），ConsumeUndoneCommitCount 清零
     int undone_commit_count_ = 0;
+    // 右选序列的调频捕获（text+code，按选择顺序）。生命周期见上方公开 API：
+    // Clear() 一并清空（EnterIdle 会话边界），Memorize/Forget 由处理器经访问器驱动。
+    std::vector<std::pair<std::string, T9SyllableCode>> commit_captures_;
 };
 
 }  // namespace rime

--- a/app/src/main/jni/librime-t9/test/t9_patch_utils_test.cc
+++ b/app/src/main/jni/librime-t9/test/t9_patch_utils_test.cc
@@ -9,6 +9,7 @@
 #include "t9_patch_utils.h"
 
 using rime::t9_patch_utils::EvaluatePacksState;
+using rime::t9_patch_utils::HasPreeditLuaFilter;
 using rime::t9_patch_utils::PacksState;
 using rime::t9_patch_utils::SanitizePackName;
 using rime::t9_patch_utils::StripPacksLines;
@@ -101,4 +102,69 @@ TEST(T9PatchUtilsTest, Strip_No_Packs_Line_Keeps_Content) {
   const std::string stripped = StripPacksLines(content);
   EXPECT_NE(stripped.find("t9/isDisplayOriginalPreedit"), std::string::npos);
   EXPECT_EQ(stripped.find("translator/packs"), std::string::npos);
+}
+
+// ── HasPreeditLuaFilter（isDisplayOriginalPreedit 默认值启发式）──
+
+TEST(T9PatchUtilsTest, PreeditFilter_Detects_Wanxiang_Schema) {
+  // 万象九键：filters 段含 lua_filter@*wanxiang.super_comment_preedit
+  const std::string content =
+      "engine:\n"
+      "  filters:\n"
+      "    - lua_filter@*wanxiang.super_lookup\n"
+      "    - lua_filter@*wanxiang.super_comment_preedit\n"
+      "    - lua_filter@*wanxiang.super_filter\n"
+      "    - uniquifier\n";
+  EXPECT_TRUE(HasPreeditLuaFilter(content));
+}
+
+TEST(T9PatchUtilsTest, PreeditFilter_Detects_CustomYaml_Patch) {
+  // 用户经 custom.yaml 追加的 lua preedit filter（补丁管线亦需识别）
+  const std::string content =
+      "patch:\n"
+      "  \"engine/filters/+prepend\": [lua_filter@*wanxiang.super_comment_preedit]\n"
+      "  \"t9/isDisplayOriginalPreedit\": true\n";
+  EXPECT_TRUE(HasPreeditLuaFilter(content));
+}
+
+TEST(T9PatchUtilsTest, PreeditFilter_Ignores_PreeditFormat_Only) {
+  // 仅含 preedit_format（翻译器层格式器，非 lua preedit filter）→ 不命中
+  const std::string content =
+      "translator:\n"
+      "  preedit_format:\n"
+      "    - xlit/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/\n";
+  EXPECT_FALSE(HasPreeditLuaFilter(content));
+}
+
+TEST(T9PatchUtilsTest, PreeditFilter_Ignores_Comment_Mention) {
+  // 注释提及 preedit（无 lua_filter@）→ 不命中（旧全表子串扫描会误判）
+  const std::string content =
+      "engine:\n"
+      "  filters:\n"
+      "    # 注释说明：此方案由 t9_filter 管理 preedit\n"
+      "    - t9_filter\n";
+  EXPECT_FALSE(HasPreeditLuaFilter(content));
+}
+
+TEST(T9PatchUtilsTest, PreeditFilter_Ignores_LuaTranslator) {
+  // lua_translator 不是 filter（不参与候选过滤），名称含 preedit 亦不命中
+  const std::string content =
+      "engine:\n"
+      "  translators:\n"
+      "    - lua_translator@*wanxiang.preedit_demo\n";
+  EXPECT_FALSE(HasPreeditLuaFilter(content));
+}
+
+TEST(T9PatchUtilsTest, PreeditFilter_Ignores_Doc_Example_In_Comment) {
+  // 行首注释中的 lua_filter@ 示例（文档）不参与判定
+  const std::string content =
+      "# 用法示例：lua_filter@*my.preedit_filter\n"
+      "engine:\n"
+      "  filters:\n"
+      "    - uniquifier\n";
+  EXPECT_FALSE(HasPreeditLuaFilter(content));
+}
+
+TEST(T9PatchUtilsTest, PreeditFilter_Empty_Content) {
+  EXPECT_FALSE(HasPreeditLuaFilter(""));
 }

--- a/app/src/main/jni/librime-t9/test/t9_preedit_converter_test.cc
+++ b/app/src/main/jni/librime-t9/test/t9_preedit_converter_test.cc
@@ -189,3 +189,42 @@ TEST(T9PreeditConverterTest, TonedCommentPreserveExisting) {
     EXPECT_EQ(T9ConvertPreedit("5", "le"), "l");
     EXPECT_EQ(T9ConvertPreedit("9", "zhong"), "zh");
 }
+
+// ── NormalizePinyinComment（调频声调保真的基础）──
+// 归一化用于：comment 匹配（容忍带调/无调差异）与带声调变体选择。
+// 核心不变量：带调与无声调归一化结果一致。
+
+TEST(NormalizePinyinCommentTest, TonedAndTonelessEquivalent) {
+    // 核心不变量：带声调与无声调的归一化结果一致（调频匹配的前提）
+    EXPECT_EQ(rime::NormalizePinyinComment("jì huà"),
+              rime::NormalizePinyinComment("ji hua"));
+    EXPECT_EQ(rime::NormalizePinyinComment("jī"),
+              rime::NormalizePinyinComment("ji"));
+    EXPECT_EQ(rime::NormalizePinyinComment("huà"),
+              rime::NormalizePinyinComment("hua"));
+}
+
+TEST(NormalizePinyinCommentTest, Basic) {
+    EXPECT_EQ(rime::NormalizePinyinComment("jì huà"), "jihua");
+    EXPECT_EQ(rime::NormalizePinyinComment("ji hua"), "jihua");
+    EXPECT_EQ(rime::NormalizePinyinComment("jī guā"), "jigua");
+}
+
+TEST(NormalizePinyinCommentTest, NeutralTonePreserved) {
+    // 轻声音节（簸箕 ji / 笑话 hua）全 ASCII，归一化原样保留
+    EXPECT_EQ(rime::NormalizePinyinComment("bò ji"), "boji");
+    EXPECT_EQ(rime::NormalizePinyinComment("xiào hua"), "xiaohua");
+    EXPECT_EQ(rime::NormalizePinyinComment("ji"), "ji");
+    EXPECT_EQ(rime::NormalizePinyinComment("hua"), "hua");
+}
+
+TEST(NormalizePinyinCommentTest, NonLetterCharsDropped) {
+    // 非字母字符（分隔符/括号/数字）被丢弃，与无声调拼音对齐
+    EXPECT_EQ(rime::NormalizePinyinComment("〔jì〕〔huà〕"), "jihua");
+    EXPECT_EQ(rime::NormalizePinyinComment("nǐ3"), "ni");
+}
+
+TEST(NormalizePinyinCommentTest, UppercaseNormalized) {
+    EXPECT_EQ(rime::NormalizePinyinComment("JĪ HUÀ"), "jihua");
+    EXPECT_EQ(rime::NormalizePinyinComment("JI HUA"), "jihua");
+}

--- a/app/src/main/jni/librime-t9/test/t9_preedit_converter_test.cc
+++ b/app/src/main/jni/librime-t9/test/t9_preedit_converter_test.cc
@@ -128,3 +128,64 @@ TEST(T9PreeditConverterTest, UppercaseComment) {
 TEST(T9PreeditConverterTest, MixedCaseComment) {
     EXPECT_EQ(T9ConvertPreedit("54482", "Ji Gua"), "jigua");
 }
+
+// ── 带声调 comment（万象方案场景）──
+// 声调元音通过 NormalizePinyinComment 归一化为纯 ASCII 字母，
+// 不依赖逐字节 ASCII 过滤（避免 jī→j、huà→hu 的 bug）。
+
+TEST(T9PreeditConverterTest, TonedCommentRegular) {
+    // "54482" + "jī huà" → "jihua"（声调字符归一化后与无声调一致）
+    EXPECT_EQ(T9ConvertPreedit("54482", "jī huà"), "jihua");
+}
+
+TEST(T9PreeditConverterTest, TonedCommentThreeSyllable) {
+    // "5482" + "jī huà" → "jihua"
+    EXPECT_EQ(T9ConvertPreedit("5482", "jī huà"), "jihua");
+}
+
+TEST(T9PreeditConverterTest, TonedCommentAllTones) {
+    // 覆盖全部四种声调：āáǎà ēéěè īíǐì ōóǒò ūúǔù ǖǘǚǜ
+    EXPECT_EQ(T9ConvertPreedit("54482", "ī í ǐ ì"), "iiii");
+    EXPECT_EQ(T9ConvertPreedit("54482", "ā á ǎ à"), "aaaa");
+    EXPECT_EQ(T9ConvertPreedit("54482", "ē é ě è"), "eeee");
+    EXPECT_EQ(T9ConvertPreedit("54482", "ō ó ǒ ò"), "oooo");
+    EXPECT_EQ(T9ConvertPreedit("54482", "ū ú ǔ ù"), "uuuu");
+    // ü 映射为 v（与 speller xlit 一致）
+    EXPECT_EQ(T9ConvertPreedit("54482", "ǖ ǘ ǚ ǜ"), "vvvv");
+    EXPECT_EQ(T9ConvertPreedit("54482", "ü"), "v");
+}
+
+TEST(T9PreeditConverterTest, TonedCommentNandM) {
+    // ńňǹ→n, ḿ→m
+    EXPECT_EQ(T9ConvertPreedit("54482", "ń ň ǹ"), "nnn");
+    EXPECT_EQ(T9ConvertPreedit("54482", "ḿ"), "m");
+}
+
+TEST(T9PreeditConverterTest, TonedCommentWeirdDelimiter) {
+    // 带声调 comment 混合雾凇风格括号 → 括号被过滤，声调被归一化
+    EXPECT_EQ(T9ConvertPreedit("54482", "〔jī〕〔huà〕"), "jihua");
+}
+
+TEST(T9PreeditConverterTest, TonedCommentSingleDigitJianpin) {
+    // "5" + "jī" → "j"（单数字段取首字母，不依赖完整拼音）
+    EXPECT_EQ(T9ConvertPreedit("5", "jī"), "j");
+}
+
+TEST(T9PreeditConverterTest, TonedCommentSingleSegmentMulti) {
+    // "54482" + "jī huà" → "jihua"（单段多音节，合并输出）
+    // 验证 NormalizePinyinComment 替代逐字节过滤后单段多音节分支仍能正确拼接
+    EXPECT_EQ(T9ConvertPreedit("54482", "jī huà"), "jihua");
+}
+
+TEST(T9PreeditConverterTest, TonedCommentMixedCase) {
+    // 大写声调 comment → 归一化后小写
+    EXPECT_EQ(T9ConvertPreedit("54482", "JĪ HUÀ"), "jihua");
+}
+
+TEST(T9PreeditConverterTest, TonedCommentPreserveExisting) {
+    // 有声调 comment 已有的无声调场景不受影响（回归）
+    EXPECT_EQ(T9ConvertPreedit("54482", "ji gua"), "jigua");
+    EXPECT_EQ(T9ConvertPreedit("54482", "ji hua"), "jihua");
+    EXPECT_EQ(T9ConvertPreedit("5", "le"), "l");
+    EXPECT_EQ(T9ConvertPreedit("9", "zhong"), "zh");
+}

--- a/app/src/main/jni/librime_jni/rime_jni.cc
+++ b/app/src/main/jni/librime_jni/rime_jni.cc
@@ -1944,13 +1944,14 @@ Java_com_kingzcheung_xime_rime_RimeEngine_nativeIsModuleRegistered(
 
 // 右选候选：根据候选拼音与文本长度执行右侧选词（消费计算）。
 // 委托给 T9RightCommitHandler 三层消费算法（设计稿 §6.2）。
-// 注：传入候选拼音注释（comment）与候选词字数，而非索引，避免翻页后索引错位。
+// 注：传入候选拼音注释（comment）、候选文本与候选词字数，而非索引，避免翻页后索引错位。
 // 用户词典调频不在此处进行——由 Kotlin 在 full commit 上屏后经 nativeT9Memorize 单独调用。
 JNIEXPORT jboolean JNICALL
 Java_com_kingzcheung_xime_rime_RimeEngine_nativeT9SelectCandidate(
     JNIEnv* env,
     jobject thiz,
     jstring pinyin,
+    jstring text,
     jint text_length
 ) {
     rime::T9Processor* proc = rime::T9ProcessorRequire();
@@ -1960,7 +1961,15 @@ Java_com_kingzcheung_xime_rime_RimeEngine_nativeT9SelectCandidate(
     }
     const char* p = env->GetStringUTFChars(pinyin, nullptr);
     if (!p) return JNI_FALSE;
-    bool result = proc->SelectCandidate(std::string(p), text_length);
+    std::string candidate_text;
+    if (text) {
+        const char* t = env->GetStringUTFChars(text, nullptr);
+        if (t) {
+            candidate_text.assign(t);
+            env->ReleaseStringUTFChars(text, t);
+        }
+    }
+    bool result = proc->SelectCandidate(std::string(p), candidate_text, text_length);
     env->ReleaseStringUTFChars(pinyin, p);
     return result ? JNI_TRUE : JNI_FALSE;
 }

--- a/app/src/main/jni/librime_jni/rime_jni.cc
+++ b/app/src/main/jni/librime_jni/rime_jni.cc
@@ -1474,6 +1474,14 @@ static jboolean DoEnsureT9SchemaPatches(
 
     // 收集需要追加的补丁行（幂等：schema 或 custom 已含该组件则跳过）。
     std::vector<std::string> patch_lines;
+
+    // 方案自带 preedit 管理型 lua filter（万象 super_comment_preedit，
+    // HasPreeditLuaFilter 判定）→ 默认 isDisplayOriginalPreedit: true（透传，
+    // 让方案 lua 管理 preedit）；否则（t9_pinyin 无声调方案）默认 false。
+    // schema/custom 显式声明的 isDisplayOriginalPreedit 始终优先（下方补丁跳过）。
+    const bool has_schema_preedit_filter =
+        rime::t9_patch_utils::HasPreeditLuaFilter(schema_content) ||
+        rime::t9_patch_utils::HasPreeditLuaFilter(existing_content);
     if (schema_content.find("t9_processor") == std::string::npos &&
         existing_content.find("t9_processor") == std::string::npos) {
         patch_lines.push_back("  \"engine/processors/@before 0\": t9_processor");
@@ -1484,7 +1492,11 @@ static jboolean DoEnsureT9SchemaPatches(
     }
     if (schema_content.find("isDisplayOriginalPreedit") == std::string::npos &&
         existing_content.find("isDisplayOriginalPreedit") == std::string::npos) {
-        patch_lines.push_back("  \"t9/isDisplayOriginalPreedit\": false");
+        // 透传 true：避免 t9_filter 转换与方案 lua 的 preedit 管理冲突；
+        // 默认 false：t9_filter 管理 preedit（无声调方案）。
+        const char* preedit_default = has_schema_preedit_filter ? "true" : "false";
+        patch_lines.push_back(
+            std::string("  \"t9/isDisplayOriginalPreedit\": ") + preedit_default);
     }
     if (schema_content.find("t9_date_translator") == std::string::npos &&
         existing_content.find("t9_date_translator") == std::string::npos) {


### PR DESCRIPTION
## 概述
@kingzcheung 
为增加九键输入后动态调频方案健壮性，解决带声调方案中输入异常问题，需要对目前九键代码做出部分调整。

## 关联 Issue

Closes #670 

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明: 使用过程中额外问题，建议参考issue中描述。
