### PR TITLE
fix(plugin): 增强插件 ID 验证支持命名空间格式

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 20260817
-        versionName = "2.6.0"
+        versionCode = 20260818
+        versionName = "2.6.1"
 
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/kingzcheung/xime/settings/WebDavSyncHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/WebDavSyncHelper.kt
@@ -142,19 +142,24 @@ object WebDavSyncHelper {
             val remoteFiles = listRemoteDirRecursive(client, remoteBase, headers)
 
             for (remoteFile in remoteFiles.filter { !it.isDirectory && isSyncableFile(it.name) }) {
-                // 计算相对于 remoteBase 的相对路径
+                // 计算相对于 remoteBase 的相对路径（URL 编码，便于下载时原样请求）
                 val remoteFileUrl = remoteFile.path
-                val relativePath = if (remoteFileUrl.startsWith(remoteBase)) {
-                    remoteFileUrl.removePrefix(remoteBase).trimStart('/')
-                } else {
-                    remoteFile.name
+                val relativePathEncoded = resolveRelativePath(remoteFileUrl, remoteBase)
+                // 本地文件名解码（中文/空格等），GET 用原始 href 保持编码
+                val relativePath = try {
+                    java.net.URLDecoder.decode(relativePathEncoded, "UTF-8")
+                } catch (e: Exception) {
+                    relativePathEncoded
                 }
 
                 val localFile = File(rimeDir, relativePath)
                 localFile.parentFile?.mkdirs()
 
-                val fullUrl = if (remoteFileUrl.startsWith("http")) remoteFileUrl
-                    else "$remoteBase/$relativePath"
+                val fullUrl = if (remoteFileUrl.startsWith("http://") || remoteFileUrl.startsWith("https://")) {
+                    remoteFileUrl
+                } else {
+                    "$remoteBase/$relativePathEncoded"
+                }
 
                 onProgress("下载 $relativePath")
                 val err = downloadFile(client, fullUrl, localFile, headers)
@@ -179,6 +184,31 @@ object WebDavSyncHelper {
             normalized = "https://$normalized"
         }
         return normalized
+    }
+
+    /**
+     * 计算 PROPFIND href 相对 remoteBase 的路径。
+     * 兼容三种 href 形式：完整 URL（https://host/dav/rime/x）、根相对路径（/dav/rime/x）、
+     * 相对目录路径（x）。修复了旧实现把子目录文件退化为文件名导致 GET 404 的问题。
+     */
+    private fun resolveRelativePath(href: String, remoteBase: String): String {
+        val basePath = rootPathOf(remoteBase)
+        val hrefPath = rootPathOf(href)
+        return when {
+            hrefPath.startsWith("$basePath/") -> hrefPath.removePrefix("$basePath/")
+            hrefPath.startsWith("/") -> hrefPath.trimStart('/')
+            else -> hrefPath
+        }
+    }
+
+    /** 归一化为根相对路径（如 /dav/rime），兼容完整 URL 与相对路径；去尾斜杠与查询串。 */
+    private fun rootPathOf(raw: String): String {
+        val noQuery = raw.substringBefore('?').trimEnd('/')
+        if (noQuery.startsWith("http://") || noQuery.startsWith("https://")) {
+            val path = noQuery.substringAfter("://").substringAfter('/')
+            return "/$path".trimEnd('/')
+        }
+        return noQuery
     }
 
     private fun ensureRemoteDir(

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/InstallerManager.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/InstallerManager.kt
@@ -71,13 +71,15 @@ class InstallerManager(
         private const val PLUGINS_DIR = "plugins"
         private const val MANIFEST_YAML = "manifest.yaml"
 
-        /** 插件 id 白名单：仅字母/数字/下划线/连字符，最长 64，杜绝路径穿越。 */
-        private val PLUGIN_ID_REGEX = Regex("^[A-Za-z0-9_-]{1,64}$")
+        /** 插件 id 白名单：字母/数字/下划线/连字符，点号仅作命名空间分段（禁止 .. / 空段 / /），最长 64，杜绝路径穿越。 */
+        private val PLUGIN_ID_REGEX = Regex("^[A-Za-z0-9_-]+(\\.[A-Za-z0-9_-]+)*$")
+        private const val PLUGIN_ID_MAX_LENGTH = 64
 
         /** 入口脚本：普通文件名，不允许路径分隔符与 ".."。 */
         private val ENTRY_SCRIPT_REGEX = Regex("^[A-Za-z0-9_.-]{1,128}$")
 
-        private fun isValidPluginId(id: String): Boolean = PLUGIN_ID_REGEX.matches(id)
+        internal fun isValidPluginId(id: String): Boolean =
+            id.length <= PLUGIN_ID_MAX_LENGTH && PLUGIN_ID_REGEX.matches(id)
 
         private fun isValidEntryScript(name: String): Boolean =
             ENTRY_SCRIPT_REGEX.matches(name) && !name.contains("..")
@@ -147,7 +149,7 @@ class InstallerManager(
         }
         val pluginId = pluginConfig.id
         if (!isValidPluginId(pluginId)) {
-            return@withContext InstallResult.Failure("非法插件 id: $pluginId（仅允许字母/数字/下划线/连字符）")
+            return@withContext InstallResult.Failure("非法插件 id: $pluginId（仅允许字母/数字/下划线/连字符，点号分段，最长 64）")
         }
         val entryScript = pluginConfig.entryScript ?: "main.lua"
         if (!isValidEntryScript(entryScript)) {

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/runtime/installer/ManifestParseTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/runtime/installer/ManifestParseTest.kt
@@ -97,4 +97,21 @@ class ManifestParseTest {
         val config = (InstallerManager.parseManifestContent(content) as PluginParseResult.Success).config
         assertEquals("demo", config.id)
     }
+
+    @Test
+    fun `插件 id 支持反域名命名空间`() {
+        assertTrue("反域名 id 应合法", InstallerManager.isValidPluginId("com.kingzcheung.xime.plugin.funasr_asr"))
+        assertTrue("下划线/连字符 id 应合法", InstallerManager.isValidPluginId("webdav-clipboard_sync"))
+    }
+
+    @Test
+    fun `非法插件 id 被拒绝`() {
+        assertTrue("空 id 非法", !InstallerManager.isValidPluginId(""))
+        assertTrue("含点号连续出现非法", !InstallerManager.isValidPluginId("a..b"))
+        assertTrue("点号开头非法", !InstallerManager.isValidPluginId(".abc"))
+        assertTrue("点号结尾非法", !InstallerManager.isValidPluginId("abc."))
+        assertTrue("含斜杠非法", !InstallerManager.isValidPluginId("a/b"))
+        assertTrue("超过 64 非法", !InstallerManager.isValidPluginId("a".repeat(65)))
+        assertTrue("含中文非法", !InstallerManager.isValidPluginId("插件a"))
+    }
 }


### PR DESCRIPTION
- 更新插件 ID 正则表达式支持点号分段的反域名命名空间格式
- 添加最大长度限制（64 字符）和路径穿越防护
- 扩展验证规则禁止非法字符和格式（如 ..、/、空段等）
- 更新错误提示信息反映新的验证规则
- 添加相关单元测试覆盖各种命名空间格式场景

feat(sync): 改进 WebDAV 同步支持 URL 编码和路径解析

- 修复中文文件名同步时的编码问题，添加 URL 解码处理
- 改进远程路径解析逻辑，支持完整 URL、根相对路径和相对路径三种格式
- 修复子目录文件因路径计算错误导致的 404 问题
- 优化 HTTP 协议头检查逻辑

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
