### PR TITLE
fix(service): 修复输入会话重置时键盘布局被错误重置的问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1248,7 +1248,9 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
 
         // 重置键盘布局到初始状态，避免切换应用后仍残留之前的布局（如英文、数字、符号）。
         // 必须携带当前 schemaId，否则 T9/笔画等专用布局会被错误重置为默认全键盘。
-        if (RimeEngine.isInitialized()) {
+        // restarting=true 表示同一输入会话内的状态刷新（应用 restartInput），此时不应
+        // 重置布局，否则数字/符号面板会在输入中被切回全键盘。
+        if (RimeEngine.isInitialized() && !restarting) {
             val rimeAscii = rimeEngine.isAsciiMode()
             uiState.value = uiState.value.copy(isAsciiMode = rimeAscii)
             // currentSchemaId 为空（如引擎重建后 updateSchemaName 尚未完成）时，

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
@@ -226,7 +226,10 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
             }
             is KeyboardDispatchAction.InputSessionStarted -> {
                 val currentPage = _page.value
-                if (currentPage is KeyboardPage.Main && currentPage.type == MainType.HANDWRITING) {
+                // 面板（数字/符号）不应被新会话事件重置，否则输入一个数字后键盘会切回全键盘
+                if (current is KeyboardViewState.NumberPanel || current is KeyboardViewState.CommonSymbolPanel) {
+                    Triple(current, _page.value, _keyboardState.value)
+                } else if (currentPage is KeyboardPage.Main && currentPage.type == MainType.HANDWRITING) {
                     Triple(_viewState.value, currentPage, _keyboardState.value)
                 } else {
                     val kb = initialKeyboardLayoutState(action.isAsciiMode, action.schemaId)


### PR DESCRIPTION
当在同一输入会话内进行restartInput操作时，数字面板和符号面板不应该被重置为全键盘，
否则会导致输入过程中键盘意外切换。通过添加!restarting条件判断来解决此问题。

fix(viewmodel): 避免新输入会话重置数字/符号面板

面板（数字/符号）不应被新会话事件重置，否则输入一个数字后键盘会切回全键盘。
在InputSessionStarted处理中添加对NumberPanel和CommonSymbolPanel的特殊处理。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
