### PR TITLE
fix(VoiceKeyboard): 修复悬浮模式切换后键盘容器高度异常问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/VoiceKeyboardContainer.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/VoiceKeyboardContainer.kt
@@ -43,6 +43,15 @@ class VoiceKeyboardContainer(
         }
     }
 
+    fun resetHeight() {
+        val params = layoutParams
+        if (params != null && params.height != FrameLayout.LayoutParams.MATCH_PARENT) {
+            params.height = FrameLayout.LayoutParams.MATCH_PARENT
+            layoutParams = params
+            requestLayout()
+        }
+    }
+
     override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
         ev?.let {
             when (it.action) {

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -838,6 +838,10 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                             // 键盘内容在 Compose 内贴底，由 onComputeInsets 报告键盘内容顶部。
                             if (state.isCompact || state.isFloatingMode) {
                                 keyboardContainer.updateHeight(totalDp)
+                            } else {
+                                // 从悬浮/紧凑模式切回时恢复容器为 MATCH_PARENT，
+                                // 否则容器高度残留悬浮时的固定值导致布局异常。
+                                keyboardContainer.resetHeight()
                             }
                             currentEffectiveKeyboardHeight = if (state.isFloatingMode) keyboardHeight + floatingDragBarHeight + 50 + state.keyboardBottomPaddingDp
                                 else if (state.isCompact) HARDWARE_CANDIDATE_BAR_HEIGHT


### PR DESCRIPTION
当从悬浮/紧凑模式切换回正常模式时，键盘容器高度会保留之前模式下的固定值，
导致布局异常。现在在切换时重置容器高度为MATCH_PARENT以确保正常显示。

同时更新了 rime 和 librime-lua-deps 子项目的提交记录。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
