### PR TITLE
feat(plugin-market): 刷新插件市场本地安装状态

### DIFF
--- a/app/src/main/assets/xime.yaml
+++ b/app/src/main/assets/xime.yaml
@@ -11,8 +11,8 @@ xime_index:
   # 可替换为自建代理/镜像，下载器按顺序依次尝试，直到成功为止。
   # 末尾需要 /。
   base_urls:
-    # - "https://cdn.jsdelivr.net/gh/ximeiorg/xime-index@master/"
-    # - "https://fastly.jsdelivr.net/gh/ximeiorg/xime-index@master/"
+    - "https://cdn.jsdelivr.net/gh/ximeiorg/xime-index@master/"
+    - "https://fastly.jsdelivr.net/gh/ximeiorg/xime-index@master/"
     - "https://index.ximei.me/"
     - "https://raw.githubusercontent.com/ximeiorg/xime-index/refs/heads/main/"
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/MarketHubScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/MarketHubScreen.kt
@@ -629,6 +629,12 @@ private fun PluginsMarketTab(
     var isRefreshing by remember { mutableStateOf(false) }
     val pullRefreshState = rememberPullToRefreshState()
 
+    // 每次进入插件 Tab 时刷新本地已安装状态（如从插件设置页卸载后返回），
+    // 不重新拉取网络索引，避免缓存 installed=true 残留
+    LaunchedEffect(Unit) {
+        viewModel.refreshInstalledState()
+    }
+
     LaunchedEffect(uiState.toastMessage) {
         uiState.toastMessage?.let { message ->
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
@@ -1840,6 +1846,11 @@ fun PluginMarketDetailContent(
     val viewModel: PluginMarketViewModel = viewModel()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    // 进入详情页时刷新本地已安装状态（卸载后返回不再残留 installed=true）
+    LaunchedEffect(Unit) {
+        viewModel.refreshInstalledState()
+    }
+
     LaunchedEffect(uiState.toastMessage) {
         uiState.toastMessage?.let { message ->
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
@@ -1904,7 +1915,7 @@ private fun PluginDetailBody(
     val selectedVersion = uiState.selectedVersions[plugin.id]
         ?: plugin.resolvedVersion()?.version.orEmpty()
 
-    val installedPlugin = remember(item.plugin.id) {
+    val installedPlugin = remember(item.plugin.id, item.installed) {
         if (item.installed) {
             PluginManager.getAllInstallPlugins().find { it.id == item.plugin.id }
         } else {

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/PluginMarketViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/PluginMarketViewModel.kt
@@ -100,6 +100,29 @@ class PluginMarketViewModel(application: Application) : AndroidViewModel(applica
         loadPlugins()
     }
 
+    /**
+     * 仅重新计算已安装状态（不重新拉取网络索引）。
+     * 卸载插件后从其他页面返回市场时调用，避免缓存 installed=true 残留。
+     */
+    fun refreshInstalledState() {
+        viewModelScope.launch {
+            val installed = withContext(Dispatchers.IO) { installedVersions() }
+            _uiState.update { st ->
+                st.copy(
+                    plugins = st.plugins.map { p ->
+                        val isInstalled = p.plugin.id in installed
+                        if (p.installed != isInstalled || p.installedVersion != installed[p.plugin.id]) {
+                            p.copy(
+                                installed = isInstalled,
+                                installedVersion = installed[p.plugin.id],
+                            )
+                        } else p
+                    },
+                )
+            }
+        }
+    }
+
     fun selectCategory(category: String?) {
         _uiState.update { it.copy(selectedCategory = category) }
     }


### PR DESCRIPTION
- 每次进入插件市场Tab时自动刷新本地已安装状态，确保从插件设置页卸载后返回时状态正确
- 进入插件详情页时刷新本地已安装状态，避免卸载后返回时installed=true状态残留
- 添加refreshInstalledState方法，仅重新计算已安装状态而不重新拉取网络索引
- 更新remember依赖项以正确响应安装状态变化

fix(download): 启用CDN镜像地址配置

- 移除xime.yaml中jsDelivr CDN地址的注释，启用备用下载源
- 保留原有的index.ximei.me和GitHub原始地址作为下载选项

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [x] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
