### PR TITLE
feat(keyboard): 调换数字键盘的符号键与返回键位置

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/NumberKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/NumberKeyboardLayout.kt
@@ -301,16 +301,17 @@ private fun NumberRows(
                             .fillMaxHeight()
                             .weight(1f),
                     ) {
-                        IconKeyButton(
-                            icon = rememberVectorPainter(Icons.AutoMirrored.Filled.ArrowBack),
-                            onClick = { onKeyPress("abc") },
+                        KeyButton(
+                            text = "符号",
+                            onClick = { onKeyPress("symbol") },
                             backgroundColor = specialKeyBackgroundColor,
-                            iconColor = specialKeyTextColor,
+                            textColor = specialKeyTextColor,
                             modifier = Modifier.weight(1f),
-                            onPress = { onKeyPressDown?.invoke("abc") },
+                            onPress = { onKeyPressDown?.invoke("symbol") },
                             shadowEnabled = shadowEnabled,
                             shadowElevation = shadowElevation,
                             shadowShapeRadius = shadowShapeRadius,
+                            fontSize = ctrlFontSize,
                         )
                     }
 
@@ -397,17 +398,17 @@ private fun NumberRows(
                             .weight(1f),
                     ) {
 
-                        KeyButton(
-                            text = "符号",
-                            onClick = { onKeyPress("symbol") },
+
+                        IconKeyButton(
+                            icon = rememberVectorPainter(Icons.AutoMirrored.Filled.ArrowBack),
+                            onClick = { onKeyPress("abc") },
                             backgroundColor = specialKeyBackgroundColor,
-                            textColor = specialKeyTextColor,
+                            iconColor = specialKeyTextColor,
                             modifier = Modifier.weight(1f),
-                            onPress = { onKeyPressDown?.invoke("symbol") },
+                            onPress = { onKeyPressDown?.invoke("abc") },
                             shadowEnabled = shadowEnabled,
                             shadowElevation = shadowElevation,
                             shadowShapeRadius = shadowShapeRadius,
-                            fontSize = ctrlFontSize,
                         )
                         KeyButton(
                             text = "0",


### PR DESCRIPTION
- 将符号键从KeyButton改为IconKeyButton，并恢复为箭头图标
- 将返回键从IconKeyButton改为KeyButton，显示"符号"文字
- 修正了按键点击事件对应的值：符号键发送"symbol"，返回键发送"abc"
- 调整了相关的颜色、字体大小等样式属性

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [x] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
