### PR TITLE
feat(ime): 优化英文模式下按键处理逻辑

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
@@ -356,10 +356,16 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                     
                     // 所有按键统一经过 Rime 引擎
                     // 字母键不进入此分支（即使 pendingEnglish 非空），需要继续积累编码
-                    if (pendingEnglish.isNotEmpty() && !key.matches(Regex("[a-zA-Z]"))) {
+                    // 英文模式（isAsciiMode）下非字母键（QWERTY 上滑的数字/符号、数字/符号面板）
+                    // 直接上屏，不进入 Rime 引擎与 pendingEnglish 累积（上滑字符即输即上）。
+                    if ((state.isAsciiMode || pendingEnglish.isNotEmpty()) && !key.matches(Regex("[a-zA-Z]"))) {
                         val finalKey = key
                         withContext(Dispatchers.Main) {
-                            service.commitText(pendingEnglish + finalKey)
+                            if (pendingEnglish.isNotEmpty()) {
+                                service.commitText(pendingEnglish + finalKey)
+                            } else {
+                                service.commitText(finalKey)
+                            }
                             service.candidateState.value = service.candidateState.value.copy(
                                 pendingEnglishText = "",
                                 associationCandidates = emptyList()


### PR DESCRIPTION
英文模式（isAsciiMode）下非字母键（QWERTY 上滑的数字/符号、数字/符号面板）
直接上屏，不进入 Rime 引擎与 pendingEnglish 累积。
同时修复了 pendingEnglish 为空时仍拼接文本的问题，确保非字母键能正确上屏。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [x] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
