### PR TITLE
fix(engine): 修复ASCII模式切换时会话创建问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
@@ -395,14 +395,14 @@ class RimeEngine {
 
     fun toggleAsciiMode(): Boolean {
         return tryLocked(false) {
-            if (!nativeHasSession()) return@tryLocked false
+            if (!nativeHasSession() && !nativeCreateSession()) return@tryLocked false
             nativeToggleAsciiMode()
         }
     }
 
     fun isAsciiMode(): Boolean {
         return tryLocked(false) {
-            if (!nativeHasSession()) return@tryLocked false
+            if (!nativeHasSession() && !nativeCreateSession()) return@tryLocked false
             nativeIsAsciiMode()
         }
     }

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeSchemaController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeSchemaController.kt
@@ -50,7 +50,10 @@ internal class ImeSchemaController(private val service: XimeInputMethodService) 
                 }
             }
         }
-        service.rimeEngine.toggleAsciiMode()
+        if (!service.rimeEngine.toggleAsciiMode()) {
+            Toast.makeText(service, "输入法引擎繁忙，请稍后再试", Toast.LENGTH_SHORT).show()
+            return
+        }
         service.sessionController.persistSchemaOption("ascii_mode", service.rimeEngine.isAsciiMode())
         service.updateUI()
     }


### PR DESCRIPTION
当原生会话不存在时自动创建会话，确保ASCII模式切换功能正常工作。

fix(ui): 改进ASCII模式切换错误处理

添加错误提示机制，当输入法引擎繁忙时显示Toast提示用户，
避免无声失败的情况发生。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
