### PR TITLE
feat(rime): 添加引擎繁忙状态检测并优化线程调度

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
@@ -254,6 +254,11 @@ class RimeEngine {
         return nativeIsMaintaining()
     }
 
+    /** 引擎是否繁忙（维护中或 rimeLock 被占用）：非阻塞探测，供 UI 立即反馈使用。 */
+    fun isEngineBusy(): Boolean {
+        return nativeIsMaintaining() || rimeLock.isLocked
+    }
+
     fun getCurrentSchema(): String {
         if (!nativeHasSession()) return ""
         return tryLocked("") {
@@ -394,8 +399,10 @@ class RimeEngine {
     }
 
     fun toggleAsciiMode(): Boolean {
-        return tryLocked(false) {
-            if (!nativeHasSession() && !nativeCreateSession()) return@tryLocked false
+        // 用户显式切换操作：阻塞等待锁（部署/维护持锁时排队，完成后自动切换），
+        // 不静默失败；调用方保证不在主线程执行（ImeKeyRouter 的 key-process 线程）。
+        return locked {
+            if (!nativeHasSession() && !nativeCreateSession()) return@locked false
             nativeToggleAsciiMode()
         }
     }

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
@@ -301,9 +301,9 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                 "mode_change" -> {
                 }
                 "ime_switch" -> {
-                    withContext(Dispatchers.Main) {
-                        service.schemaController.switchInputMethod()
-                    }
+                    // 在 key-processing 线程上执行切换：toggleAsciiMode 阻塞等待 rimeLock
+                    // （部署/维护持锁时排队，完成后自动切换），不在主线程阻塞避免 ANR。
+                    service.schemaController.switchInputMethod()
                 }
                 "abc" -> {
                     service.calculatorEngine.clear()

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeSchemaController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeSchemaController.kt
@@ -45,17 +45,24 @@ internal class ImeSchemaController(private val service: XimeInputMethodService) 
             } else {
                 val input = candState.inputText
                 if (input.isNotEmpty()) {
-                    service.commitText(input)
+                    withContext(Dispatchers.Main) {
+                        service.commitText(input)
+                    }
                     service.rimeEngine.clearComposition()
                 }
             }
         }
+        // 由 ImeKeyRouter 在 key-processing 线程调用：toggleAsciiMode 阻塞等待 rimeLock
+        // （部署/维护持锁时排队，完成后自动切换），不静默失败、不阻塞主线程。
+        // 仅在 session 创建失败（引擎真正不可用）时返回 false。
         if (!service.rimeEngine.toggleAsciiMode()) {
-            Toast.makeText(service, "输入法引擎繁忙，请稍后再试", Toast.LENGTH_SHORT).show()
+            Toast.makeText(service, "输入法引擎不可用，请稍后再试", Toast.LENGTH_SHORT).show()
             return
         }
         service.sessionController.persistSchemaOption("ascii_mode", service.rimeEngine.isAsciiMode())
-        service.updateUI()
+        withContext(Dispatchers.Main) {
+            service.updateUI()
+        }
     }
     
     internal fun reloadConfig() {
@@ -65,7 +72,10 @@ internal class ImeSchemaController(private val service: XimeInputMethodService) 
             android.widget.Toast.makeText(service, "方案部署中...", android.widget.Toast.LENGTH_SHORT).show()
         }
         
-        service.serviceScope.launch(Dispatchers.IO) {
+        // 部署投递到 key-processing 队列：与按键/切换同队列串行执行，
+        // 部署期间输入/切换操作排队等待，完成后自动恢复，
+        // 不再因 rimeLock 被部署占用而失败或静默丢弃。
+        service.keyRouter.postRimeJob {
             try {
                 KeysConfigHelper.loadConfig(service)
                 // 重新加载配色方案（用户可能在 xime.custom.yaml 中修改了 color_schemes）
@@ -98,7 +108,7 @@ internal class ImeSchemaController(private val service: XimeInputMethodService) 
                     Log.w(XimeInputMethodService.TAG, "Schema $savedSchema not found in available schemas")
                 }
                 
-                // 直接在 IO 线程同步读取 name，避免嵌套协程的时序问题
+                // 直接在 key-processing 线程同步读取 name，避免嵌套协程的时序问题
                 val currentSchemaId = service.rimeEngine.getCurrentSchema()
                 val schemaName = SchemaManager.getSchemaDisplayName(
                     service, currentSchemaId
@@ -318,7 +328,8 @@ internal class ImeSchemaController(private val service: XimeInputMethodService) 
     }
     
     private fun deploy() {
-        service.serviceScope.launch(Dispatchers.IO) {
+        // 部署投递到 key-processing 队列，与输入/切换串行执行，避免持锁饿死输入
+        service.keyRouter.postRimeJob {
             // 部署前刷新手势配置和配色方案缓存
             KeysConfigHelper.loadConfig(service)
             KeyboardThemes.reload(service)


### PR DESCRIPTION
- 新增 isEngineBusy() 方法用于非阻塞检测引擎是否繁忙（维护中或 rimeLock 被占用）
- 将 toggleAsciiMode() 改为阻塞等待锁，确保部署/维护完成后自动切换
- 修复 ime_switch 操作在主线程执行导致 ANR 的问题
- 将 schemaController 的 UI 更新操作移到主线程执行
- 将部署操作投递到 key-processing 队列，与按键/切换同队列串行执行
- 避免因 rimeLock 被部署占用而导致的失败或静默丢弃问题
- 优化部署期间输入/切换操作的排队处理机制

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [x] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
