### PR TITLE
fix(market): 修复更新版本时，默认方案污染用户当前使用方案的问题。

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
@@ -6,6 +6,7 @@ import com.kingzcheung.xime.BuildConfig
 import com.kingzcheung.xime.settings.PersonalDictManager
 import com.kingzcheung.xime.settings.SchemaConfigHelper
 import com.kingzcheung.xime.settings.SchemaManifestManager
+import com.kingzcheung.xime.settings.MarketVersionStore
 import com.kingzcheung.xime.settings.SchemaManager
 import com.kingzcheung.xime.settings.SettingsPreferences
 import kotlinx.coroutines.TimeoutCancellationException
@@ -18,6 +19,11 @@ import java.io.IOException
 object RimeConfigHelper {
     private const val TAG = "RimeConfigHelper"
     private const val ASSETS_RIME_DIR = "rime"
+
+    /** 市场索引中随 app 发布的内置默认方案集条目 id（见 rimes/index.yaml 的 `builtin`）。 */
+    private const val BUILTIN_MARKET_ID = "builtin"
+    /** 内置方案集的初始占位版本：`0.0.0` 保证不等于任何真实 git tag，从而在市场提示「更新」。 */
+    private const val BUILTIN_PLACEHOLDER_VERSION = "0.0.0"
 
     /** 部署互斥：Application 预初始化与输入法服务初始化可能并发触发部署，串行化避免重复/并发全量编译。 */
     private val deploymentLock = Any()
@@ -204,13 +210,16 @@ object RimeConfigHelper {
     }
 
     private fun copyAssetsToRimeDir(context: Context, targetDir: File): Boolean {
-        // assets 编译进 APK，同一 versionCode 内不会变化。记录上次同步的版本号，
-        // 一致时跳过全量拷贝：避免每次启动都覆盖 default.yaml 等文件（assets 默认压缩，
-        // openFd 抛异常导致 size 判断失效），从而保证部署 hash 稳定、不再每次启动全量重编译。
-        // 版本匹配时必须确认关键文件确实已落地：若上次拷贝失败（如 assets 缺失/为空），
-        // 仅记版本号而未拷入文件，覆盖安装后仍会误跳过导致方案文件永远缺失。
-        val versionMatched = SettingsPreferences.getRimeAssetsVersion(context) == BuildConfig.VERSION_CODE
-        if (versionMatched && File(targetDir, "default.yaml").exists()) {
+        // 判断 rime/ 是否已部署过任何方案（存在任意 <name>.schema.yaml）。
+        // 全新安装时 rime/ 为空 → 全量复制内置默认方案与系统文件，保证开箱即用。
+        // 一旦已部署过方案（内置旧版或从市场安装的第三方方案），app 更新时
+        // 一律不再用内置 assets 覆盖，避免覆盖第三方同名文件造成污染；
+        // 需要更新的方案统一走方案市场。此判定不依赖具体方案 id/文件名，天然鲁棒。
+        val alreadyHasSchemas = targetDir.listFiles()
+            ?.any { it.isFile && it.name.endsWith(".schema.yaml") } == true
+        if (alreadyHasSchemas) {
+            // 仅兜底确保 default.yaml 存在（librime 入口必需），缺失时补一份，不覆盖已有。
+            ensureDefaultYaml(context, targetDir)
             return false
         }
         val copied = try {
@@ -219,11 +228,33 @@ object RimeConfigHelper {
             Log.e(TAG, "Failed to copy assets", e)
             false
         }
-        // 仅当真正拷贝成功才记录版本，避免失败时留下"已同步"假象
         if (copied) {
-            SettingsPreferences.setRimeAssetsVersion(context, BuildConfig.VERSION_CODE)
+            seedBuiltinPackageVersion(context)
         }
         return copied
+    }
+
+    /**
+     * 全新安装复制内置默认方案集后，为市场条目 `builtin`（type=built-in 的默认方案包，
+     * 一个压缩包里含多个 schema）写入一个初始占位版本号。
+     *
+     * 市场方案的版本号与具体 .schema.yaml 无关，是方案集所属 git 仓库的 tag（见
+     * rimes/index.yaml 中 builtin 条目）。随 app 发布的内置方案集在运行时无法自报其
+     * 对应的 git tag，因此写入一个不等于任何真实 tag 的占位值，使市场 `hasUpdate`
+     * （installedVersion != currentVersion）成立，从而向用户提示「更新」，把默认方案
+     * 从市场更新到带真实版本号的版本。仅当该条目尚无版本记录时写入。
+     */
+    private fun seedBuiltinPackageVersion(context: Context) {
+        if (MarketVersionStore.getSchemeVersion(context, BUILTIN_MARKET_ID) == null) {
+            MarketVersionStore.setSchemeVersion(context, BUILTIN_MARKET_ID, BUILTIN_PLACEHOLDER_VERSION)
+        }
+    }
+
+    /** 兜底确保 default.yaml 存在（首次复制失败/旧结构迁移时可能缺失），缺失才补且不覆盖已有内容。 */
+    private fun ensureDefaultYaml(context: Context, targetDir: File) {
+        val defaultYaml = File(targetDir, "default.yaml")
+        if (defaultYaml.exists()) return
+        copyAssetFile(context, "$ASSETS_RIME_DIR/default.yaml", defaultYaml)
     }
     
     private fun copyAssetsRecursively(context: Context, assetPath: String, targetDir: File): Boolean {

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
@@ -237,6 +237,7 @@ object SchemaManager {
         fromMarket: Boolean = false,
         dependencies: List<String> = emptyList(),
         resolveDepUrl: (String) -> String? = { null },
+        switchEnabled: Boolean = true,
     ): InstallFromDirResult = withContext(Dispatchers.IO) {
         try {
             val dir = getMarketDir(context, packageId)
@@ -313,11 +314,12 @@ object SchemaManager {
                 SettingsPreferences.addInstalledMarketId(context, packageId)
             }
 
-            // 至少启用一个新方案，避免 RimeEngine 因 schema_list 为空而挂起
+            // 至少启用一个新方案，避免 RimeEngine 因 schema_list 为空而挂起。
+            // 更新已安装方案时（switchEnabled=false）不强制切换启用列表，保留用户现有方案。
             val firstSchema = newIds.firstOrNull()
                 ?: targetFiles.firstOrNull { it.endsWith(".schema.yaml") }
                     ?.removeSuffix(".schema.yaml")
-            if (firstSchema != null) {
+            if (firstSchema != null && switchEnabled) {
                 setEnabledSchemas(context, listOf(firstSchema))
             }
 

--- a/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexSource.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexSource.kt
@@ -307,6 +307,7 @@ object XimeIndexSource {
         context: Context,
         scheme: MarketScheme,
         resolveDepUrl: (String) -> String? = { null },
+        switchEnabled: Boolean = true,
     ): InstallResult = withContext(Dispatchers.IO) {
         if (!SchemaManager.isSchemeDownloaded(context, scheme.id)) {
             return@withContext InstallResult(false, failureReason = "压缩包不存在，请先下载")
@@ -319,6 +320,7 @@ object XimeIndexSource {
             fromMarket = true,
             dependencies = scheme.dependencies,
             resolveDepUrl = resolveDepUrl,
+            switchEnabled = switchEnabled,
         )
         if (!result.success) {
             val reason = result.failureReason ?: result.conflicts.joinToString("、") { c ->

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/MarketHubScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/MarketHubScreen.kt
@@ -299,6 +299,7 @@ private fun SchemesMarketTab(
                                         item = item,
                                         uiState = uiState,
                                         onDownload = { viewModel.downloadScheme(item) },
+                                        onUpdate = { viewModel.updateScheme(item) },
                                     )
                                 },
                             )
@@ -331,6 +332,7 @@ private fun SchemeTrailingButton(
     item: MarketSchemeItem,
     uiState: SchemaMarketUiState,
     onDownload: () -> Unit,
+    onUpdate: () -> Unit = onDownload,
 ) {
     val scheme = item.scheme
     when {
@@ -349,7 +351,7 @@ private fun SchemeTrailingButton(
         }
 
         scheme.id in uiState.downloadedIds && item.hasUpdate -> Button(
-            onClick = onDownload,
+            onClick = onUpdate,
             shape = RoundedCornerShape(50),
             colors = ButtonDefaults.buttonColors(
                 containerColor = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaMarketViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaMarketViewModel.kt
@@ -217,7 +217,76 @@ class SchemaMarketViewModel(application: Application) : AndroidViewModel(applica
         }
     }
 
-    fun clearToast() = _uiState.update { it.copy(toastMessage = null) }
+    /**
+     * 更新已下载的方案：重新下载当前版本并安装覆盖 rime/ 旧版。
+     * 更新不强制切换启用方案（保留用户现有 schema_list）。
+     */
+    fun updateScheme(item: MarketSchemeItem) {
+        if (_uiState.value.downloadingId != null) {
+            showToast("有其他方案正在操作，请稍候")
+            return
+        }
+        if (!item.compatible) {
+            showToast("需 App ≥ ${item.minAppVersion}")
+            return
+        }
+        viewModelScope.launch {
+            _uiState.update { it.copy(downloadingId = item.scheme.id, downloadProgress = 0f) }
+            val selectedVersion = _uiState.value.selectedVersions[item.scheme.id]
+            val download = withContext(Dispatchers.IO) {
+                XimeIndexSource.downloadScheme(
+                    context, item.scheme,
+                    version = selectedVersion,
+                    onDownloadProgress = { downloaded, total ->
+                        val progress = if (total > 0) (downloaded.toFloat() / total) else 0f
+                        _uiState.update { it.copy(downloadProgress = progress) }
+                    },
+                )
+            }
+            if (!download.success) {
+                val reason = if (download.sha256Status == false)
+                    "下载校验失败，文件可能不完整" else (download.failureReason ?: "下载失败")
+                _uiState.update { it.copy(downloadingId = null, downloadProgress = 0f) }
+                showToast(reason)
+                return@launch
+            }
 
+            val install = withContext(Dispatchers.IO) {
+                XimeIndexSource.installFromMarket(context, item.scheme, switchEnabled = false)
+            }
+
+            val newVersion = selectedVersion ?: item.scheme.resolvedVersion()?.version
+                ?: item.scheme.currentVersion
+            _uiState.update { st ->
+                st.copy(downloadingId = null, downloadProgress = 0f)
+            }
+
+            if (install.success) {
+                withContext(Dispatchers.IO) {
+                    MarketVersionStore.setSchemeVersion(context, item.scheme.id, newVersion)
+                }
+                _uiState.update { st ->
+                    st.copy(
+                        downloadedVersions = st.downloadedVersions + (item.scheme.id to newVersion),
+                        schemes = st.schemes.map { s ->
+                            if (s.scheme.id == item.scheme.id) s.copy(installedVersion = newVersion)
+                            else s
+                        },
+                    )
+                }
+                val msg = buildString {
+                    append("已更新「${item.scheme.name}」")
+                    if (install.unresolvedDeps.isNotEmpty()) {
+                        append("\n依赖未完整：${install.unresolvedDeps.joinToString("、")}")
+                    }
+                }
+                showToast(msg)
+            } else {
+                showToast(install.failureReason ?: "安装失败")
+            }
+        }
+    }
+
+    fun clearToast() = _uiState.update { it.copy(toastMessage = null) }
     private fun showToast(message: String) = _uiState.update { it.copy(toastMessage = message) }
 }


### PR DESCRIPTION
- 引入 MarketVersionStore 用于管理方案版本存储
- 实现 updateScheme 功能，支持重新下载并覆盖安装已下载的方案
- 更新时不强制切换启用方案，保留用户现有配置
- 为内置方案添加占位版本号，确保市场能正确提示更新
- 优化 assets 复制逻辑，全新安装后仅确保 default.yaml 存在
- 修复方案安装时的依赖处理和版本记录机制

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
