### PR TITLE
feat(clipboard): 移除后台轮询改为手动拉取模式

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/clipboard/sync/ClipboardSyncBridge.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/sync/ClipboardSyncBridge.kt
@@ -1,8 +1,5 @@
 package com.kingzcheung.xime.clipboard.sync
 
-import android.content.Context
-import android.content.IntentFilter
-import android.os.PowerManager
 import android.util.Log
 import com.kingzcheung.xime.clipboard.ClipboardManager
 import com.kingzcheung.xime.plugin.core.api.ClipboardProfile
@@ -12,11 +9,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 /**
@@ -24,23 +19,22 @@ import kotlinx.coroutines.launch
  *
  * 规则（与 ximed 设计一致的三通道去重语义）：
  * - 本地剪贴板变化 → 与上次推送 hash 不同且非"自写内容" → 推送到远端
- * - 轮询远端 → 与本地 hash 及"自写 hash"比对 → 不同才写回本地剪贴板
+ * - 拉取远端（启动时 + 键盘显示时 pullOnce）→ 与本地 hash 及"自写 hash"比对 → 不同才写回本地剪贴板
  * - 自写抑制：引擎写回本地后记录 hash，监听到同一 hash 判定为回声，跳过推送
+ *
+ * 不再做后台轮询：拉取只在启动时和键盘显示（[pullOnce]）时各触发一次，
+ * 避免 IME service 生命周期内频繁请求；推送仍由本地剪贴板变化实时触发。
  *
  * 宿主只持有引擎与剪贴板桥，具体传输协议（WebDAV/S3/ximed）由 [ClipboardSyncPlugin]
  * 的 Lua 实现承载。
  */
 class ClipboardSyncBridge(
-    private val context: Context,
     private val clipboardManager: ClipboardManager,
     private val plugin: ClipboardSyncPlugin,
-    private val pullOnOpen: Boolean = false,
     val pluginId: String = ""
 ) {
     companion object {
         private const val TAG = "ClipboardSync"
-        private const val DEFAULT_POLL_MS = 3000L
-        private const val BATTERY_SAVER_POLL_MS = 60_000L
         private const val PUSH_RETRY_BACKOFF_MS = 5_000L
     }
 
@@ -61,17 +55,12 @@ class ClipboardSyncBridge(
     @Volatile
     private var retryUntil = 0L
 
-    private var pollJob: Job? = null
     private var collectJob: Job? = null
-
-    private val powerManager by lazy {
-        context.getSystemService(Context.POWER_SERVICE) as PowerManager
-    }
 
     fun start() {
         if (running) return
         running = true
-        Log.d(TAG, if (pullOnOpen) "Sync started (pull on open)" else "Sync started")
+        Log.d(TAG, "Sync started")
 
         // 1. 订阅本地剪贴板变化 → push（回声抑制：selfWritten 命中的跳过）
         collectJob = clipboardManager.clipboardChanged
@@ -86,36 +75,15 @@ class ClipboardSyncBridge(
             }
             .launchIn(scope)
 
-        if (pullOnOpen) {
-            // 打开即拉取一次，不启动轮询（后续由键盘显示时 pullOnce() 触发）
-            scope.launch { pullRemote() }
-            return
-        }
-
-        // 2. 轮询远端 → 拉取 → 写回（hash 去重）
-        pollJob = scope.launch {
-            while (isActive) {
-                try {
-                    val interval = currentPollInterval()
-                    pullRemote()
-                    delay(interval)
-                } catch (e: kotlinx.coroutines.CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    Log.e(TAG, "Poll error", e)
-                    delay(5000)
-                }
-            }
-        }
+        // 2. 启动即拉取一次；后续由键盘显示时 pullOnce() 触发
+        scope.launch { pullRemote() }
     }
 
     fun stop() {
         if (!running) return
         running = false
         collectJob?.cancel()
-        pollJob?.cancel()
         collectJob = null
-        pollJob = null
         Log.d(TAG, "Sync stopped")
     }
 
@@ -124,16 +92,12 @@ class ClipboardSyncBridge(
         scope.cancel()
     }
 
-    /** 键盘显示时触发一次拉取（仅 pullOnOpen 模式；轮询模式忽略）。 */
+    /** 键盘显示时触发一次拉取。 */
     fun pullOnce() {
-        if (!running || !pullOnOpen) return
+        if (!running) return
         scope.launch {
             pullRemote()
         }
-    }
-
-    private fun currentPollInterval(): Long {
-        return if (powerManager.isPowerSaveMode) BATTERY_SAVER_POLL_MS else DEFAULT_POLL_MS
     }
 
     private suspend fun pushLocal(text: String, hash: String) {

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
@@ -83,6 +83,7 @@ internal fun rememberImeKeyboardCallbacks(
             onToggleDarkMode = { service.toggleDarkMode() },
             onClipboard = {},
             onClipboardSelect = { text -> service.textCommit.selectClipboardItem(text) },
+            onClipboardPullRemote = { service.clipboardSyncBridge?.pullOnce() },
             onCommitText = { text -> service.textCommit.commitClipboardText(text) },
             onDeleteText = { count -> service.textCommit.deleteClipboardChars(count) },
             onQuickSend = {},

--- a/app/src/main/java/com/kingzcheung/xime/service/InputUIState.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/InputUIState.kt
@@ -48,4 +48,5 @@ data class InputUIState(
     val quickSendFormFocused: Boolean = false,
     val quickSendEditingItemId: Long? = null,
     val quickSendEditingItemText: String = "",
+    val clipboardSyncEnabled: Boolean = false,
 )

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -173,7 +173,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     
     internal lateinit var clipboardManager: ClipboardManager
 
-    private var clipboardSyncBridge: ClipboardSyncBridge? = null
+    internal var clipboardSyncBridge: ClipboardSyncBridge? = null
     
     internal lateinit var keyboardContainer: VoiceKeyboardContainer
     
@@ -379,10 +379,6 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 SettingsPreferences.KEY_SMART_PREDICTION_ENABLED -> onPredictionSettingChanged()
                 SettingsPreferences.KEY_CLIPBOARD_SYNC_ENABLED -> updateClipboardSync()
                 SettingsPreferences.KEY_CLIPBOARD_SYNC_PLUGIN_ID -> {
-                    stopClipboardSync()
-                    updateClipboardSync()
-                }
-                SettingsPreferences.KEY_CLIPBOARD_SYNC_PULL_ON_OPEN -> {
                     stopClipboardSync()
                     updateClipboardSync()
                 }
@@ -659,13 +655,12 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             val selected = enabled.firstOrNull { it.first == preferredId } ?: enabled.first()
             val plugin = selected.second
             clipboardSyncBridge = ClipboardSyncBridge(
-                this,
                 clipboardManager,
                 plugin,
-                pullOnOpen = SettingsPreferences.isClipboardSyncPullOnOpen(this),
                 pluginId = selected.first
             )
             clipboardSyncBridge?.start()
+            uiState.value = uiState.value.copy(clipboardSyncEnabled = true)
             Log.d(TAG, "Clipboard sync started: ${selected.first}")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start clipboard sync", e)
@@ -675,6 +670,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     private fun stopClipboardSync() {
         clipboardSyncBridge?.release()
         clipboardSyncBridge = null
+        uiState.value = uiState.value.copy(clipboardSyncEnabled = false)
     }
 
     /** 剪贴板同步设置或插件状态变化时调用，按条件动态启停。 */
@@ -958,6 +954,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                     quickSendFormFocused = state.quickSendFormFocused,
                                     quickSendEditingItemId = state.quickSendEditingItemId,
                                     quickSendEditingItemText = state.quickSendEditingItemText,
+                                    clipboardSyncEnabled = state.clipboardSyncEnabled,
                                 )
                             }
                             val callbacks = rememberImeKeyboardCallbacks(this@XimeInputMethodService, floatingMinY, state, effectiveScreenH)

--- a/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
@@ -601,7 +601,6 @@ object SettingsPreferences {
     }
 
     const val KEY_CLIPBOARD_SYNC_ENABLED = "clipboard_sync_enabled"
-    const val KEY_CLIPBOARD_SYNC_PULL_ON_OPEN = "clipboard_sync_pull_on_open"
     const val KEY_CLIPBOARD_SYNC_PLUGIN_ID = "clipboard_sync_plugin_id"
 
     fun isClipboardSyncEnabled(context: Context): Boolean {
@@ -610,14 +609,6 @@ object SettingsPreferences {
 
     fun setClipboardSyncEnabled(context: Context, enabled: Boolean) {
         getPrefs(context).edit().putBoolean(KEY_CLIPBOARD_SYNC_ENABLED, enabled).apply()
-    }
-
-    fun isClipboardSyncPullOnOpen(context: Context): Boolean {
-        return getPrefs(context).getBoolean(KEY_CLIPBOARD_SYNC_PULL_ON_OPEN, false)
-    }
-
-    fun setClipboardSyncPullOnOpen(context: Context, enabled: Boolean) {
-        getPrefs(context).edit().putBoolean(KEY_CLIPBOARD_SYNC_PULL_ON_OPEN, enabled).apply()
     }
 
     fun getClipboardSyncPluginId(context: Context): String {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
@@ -76,6 +76,11 @@ data class KeyboardCallbacks(
      */
     var onT9RefreshComposition: ((RimeComposition) -> Unit)? = null,
     val onShowQuickSendForm: (() -> Unit)? = null,
+    /**
+     * 从剪贴板面板主动拉取远端剪贴板内容（仅剪贴板同步已启用时非空）。
+     * 由剪贴板面板导航头的「拉取」按钮触发。
+     */
+    val onClipboardPullRemote: (() -> Unit)? = null,
     val onHideQuickSendForm: (() -> Unit)? = null,
     val onQuickSendEditItem: ((Long, String) -> Unit)? = null,
     val onQuickSendFormFocusChange: ((Boolean) -> Unit)? = null,

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -922,6 +922,8 @@ fun KeyboardView(
                             viewModel.closeOverlay()
                             callbacks.onQuickSendEditItem?.invoke(id, text)
                         },
+                        onPullRemote = callbacks.onClipboardPullRemote,
+                        pullRemoteAvailable = state.clipboardSyncEnabled,
                     )
                     is OverlayRoute.ToolbarCustomize -> ToolbarCustomizeView(
                         toolbarButtons = state.toolbarButtons,

--- a/app/src/main/java/com/kingzcheung/xime/ui/menubar/ClipboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/menubar/ClipboardView.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.outlined.StarBorder
+import androidx.compose.material.icons.twotone.Sync
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -78,6 +79,8 @@ fun ClipboardView(
     modifier: Modifier = Modifier,
     onQuickSendAddClick: (() -> Unit)? = null,
     onQuickSendEditItem: ((Long, String) -> Unit)? = null,
+    onPullRemote: (() -> Unit)? = null,
+    pullRemoteAvailable: Boolean = false,
 ) {
     // 卡片/格子背景：与菜单项背景一致（keyBgColor，浅色纯白、深色跟随 keyboard.colors）
     val itemBgColor = keyBgColor
@@ -200,21 +203,42 @@ fun ClipboardView(
                             modifier = Modifier.size(18.dp)
                         )
                     }
-                } else if (clipboardItems.isNotEmpty()) {
-                    Box(
-                        modifier = Modifier
-                            .size(28.dp)
-                            .clip(CircleShape)
-                            .background(iconButtonContainer)
-                            .clickable { showClearConfirm = true },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.DeleteSweep,
-                            contentDescription = "清空剪贴板",
-                            tint = accentColor,
-                            modifier = Modifier.size(18.dp)
-                        )
+                } else {
+                    // 剪贴板同步已启用（配置+启用插件）时，提供主动拉取按钮
+                    if (pullRemoteAvailable && onPullRemote != null) {
+                        Box(
+                            modifier = Modifier
+                                .size(28.dp)
+                                .clip(CircleShape)
+                                .background(iconButtonContainer)
+                                .clickable(onClick = onPullRemote),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.TwoTone.Sync,
+                                contentDescription = "拉取远端剪贴板",
+                                tint = accentColor,
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                    }
+                    if (clipboardItems.isNotEmpty()) {
+                        Box(
+                            modifier = Modifier
+                                .size(28.dp)
+                                .clip(CircleShape)
+                                .background(iconButtonContainer)
+                                .clickable { showClearConfirm = true },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.DeleteSweep,
+                                contentDescription = "清空剪贴板",
+                                tint = accentColor,
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/ClipboardSyncSettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/ClipboardSyncSettingsScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.twotone.Refresh
 import androidx.compose.material.icons.twotone.Sync
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -47,9 +46,6 @@ fun ClipboardSyncSettingsContent(
     val scope = rememberCoroutineScope()
     var enabled by remember {
         mutableStateOf(SettingsPreferences.isClipboardSyncEnabled(context))
-    }
-    var pullOnOpen by remember {
-        mutableStateOf(SettingsPreferences.isClipboardSyncPullOnOpen(context))
     }
     val syncPlugins = remember { ExtensionManager.getEnabledClipboardSyncPlugins(context) }
     // 偏好未设置时，自动选中第一个已启用的插件（与服务端 fallback 一致）
@@ -104,21 +100,11 @@ fun ClipboardSyncSettingsContent(
                     SettingsToggleItem(
                         icon = Icons.TwoTone.Sync,
                         title = "启用剪贴板同步",
-                        subtitle = "将剪贴板文本与远端设备双向同步",
+                        subtitle = "将剪贴板文本与远端设备双向同步（拉取在启动及打开键盘/剪贴板面板时触发）",
                         checked = enabled,
                         onCheckedChange = { checked ->
                             enabled = checked
                             SettingsPreferences.setClipboardSyncEnabled(context, checked)
-                        }
-                    )
-                    SettingsToggleItem(
-                        icon = Icons.TwoTone.Refresh,
-                        title = "仅打开键盘时拉取",
-                        subtitle = "开启后不持续轮询，仅在键盘弹出时从远端拉取一次",
-                        checked = pullOnOpen,
-                        onCheckedChange = { checked ->
-                            pullOnOpen = checked
-                            SettingsPreferences.setClipboardSyncPullOnOpen(context, checked)
                         }
                     )
                 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/PluginsSettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/PluginsSettingsScreen.kt
@@ -103,7 +103,8 @@ fun PluginsSettingsContent(
     onBack: () -> Unit,
     onNavigateToPluginSettings: (String) -> Unit = {},
     onNavigateToPluginMarketDetail: (String) -> Unit = {},
-    onNavigateToSpeechToText: () -> Unit = {}
+    onNavigateToSpeechToText: () -> Unit = {},
+    onNavigateToClipboardSync: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val viewModel: PluginsSettingsViewModel = viewModel()
@@ -258,6 +259,7 @@ fun PluginsSettingsContent(
                     }
                 } else {
                     val activeAsrPluginId = SettingsPreferences.getSttOnlinePluginId(context)
+                    val activeClipboardSyncPluginId = SettingsPreferences.getClipboardSyncPluginId(context)
                     items(uiState.extensions, key = { it.id }) { extension ->
                         ExtensionItem(
                             extension = extension,
@@ -266,10 +268,18 @@ fun PluginsSettingsContent(
                             viewModel = viewModel,
                             onClick = { onNavigateToPluginSettings(extension.id) },
                             onOpenMarketDetail = { onNavigateToPluginMarketDetail(extension.id) },
-                            isActive = extension.category == PluginCategory.ASR && extension.id == activeAsrPluginId,
-                            onActivate = if (extension.category.activation == Activation.SINGLE) {
-                                onNavigateToSpeechToText
-                            } else null
+                            isActive = when (extension.category) {
+                                PluginCategory.ASR ->
+                                    extension.id == activeAsrPluginId
+                                PluginCategory.CLIPBOARD_SYNC ->
+                                    extension.id == activeClipboardSyncPluginId
+                                else -> false
+                            },
+                            onActivate = when (extension.category) {
+                                PluginCategory.ASR -> onNavigateToSpeechToText
+                                PluginCategory.CLIPBOARD_SYNC -> onNavigateToClipboardSync
+                                else -> null
+                            }
                         )
                     }
                 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsScreen.kt
@@ -127,7 +127,8 @@ fun SettingsScreen(
                 onNavigateToPluginMarketDetail = { pluginId ->
                     navController.navigate("plugin_market_detail/$pluginId")
                 },
-                onNavigateToSpeechToText = { navController.navigate(SettingsRoutes.SpeechToText) }
+                onNavigateToSpeechToText = { navController.navigate(SettingsRoutes.SpeechToText) },
+                onNavigateToClipboardSync = { navController.navigate(SettingsRoutes.ClipboardSync) }
             )
         }
         composable(

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
@@ -80,6 +80,7 @@ data class KeyboardUiState(
     val quickSendFormFocused: Boolean = false,
     val quickSendEditingItemId: Long? = null,
     val quickSendEditingItemText: String = "",
+    val clipboardSyncEnabled: Boolean = false,
 )
 
 class KeyboardViewModel(application: Application) : AndroidViewModel(application) {


### PR DESCRIPTION
移除剪贴板同步的后台轮询机制，改为仅在启动时和键盘显示时拉取远端内容，
避免在输入法服务生命周期内频繁请求。添加主动拉取远端剪贴板的功能按钮，
允许用户手动触发同步操作。

BREAKING CHANGE: 移除了轮询相关的配置选项和实现逻辑。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [x] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
