### PR TITLE
feat(t9): 九键数字序列用户词典实现 T9DigitUserDict 解决自造词长词召回失败问题

### DIFF
--- a/app/src/main/jni/librime-t9/CMakeLists.txt
+++ b/app/src/main/jni/librime-t9/CMakeLists.txt
@@ -1,9 +1,18 @@
 cmake_minimum_required(VERSION 3.18.0)
 
 # ── 调试日志与耗时埋点开关 ──
-# 对应 P12/P9 重构：release 构建零开销，debug/CI 构建可独立启用
-option(T9_ENABLE_VERBOSE_LOG "Enable verbose T9 debug logging" ON)
-option(T9_ENABLE_TIMING      "Enable T9 timing instrumentation" ON)
+# 默认 OFF；可通过环境变量按需开启：
+#   T9_ENABLE_VERBOSE_LOG=ON T9_ENABLE_TIMING=ON ./gradlew assembleDebug
+option(T9_ENABLE_VERBOSE_LOG "Enable verbose T9 debug logging" OFF)
+option(T9_ENABLE_TIMING      "Enable T9 timing instrumentation" OFF)
+
+# 环境变量覆盖（不持久化到 CMakeCache，每次构建重新评估）
+if(DEFINED ENV{T9_ENABLE_VERBOSE_LOG} AND NOT "$ENV{T9_ENABLE_VERBOSE_LOG}" STREQUAL "")
+    set(T9_ENABLE_VERBOSE_LOG "$ENV{T9_ENABLE_VERBOSE_LOG}" CACHE BOOL "" FORCE)
+endif()
+if(DEFINED ENV{T9_ENABLE_TIMING} AND NOT "$ENV{T9_ENABLE_TIMING}" STREQUAL "")
+    set(T9_ENABLE_TIMING "$ENV{T9_ENABLE_TIMING}" CACHE BOOL "" FORCE)
+endif()
 
 # 使用 file(GLOB CONFIGURE_DEPENDS) 替代 aux_source_directory，
 # 让 CMake 在源文件新增/删除时自动重新配置。
@@ -57,7 +66,7 @@ if(T9_BUILD_TESTS)
     # 排除 t9_processor.cc / t9_module.cc（依赖 RIME Context/Menu/Candidate 等）
     # t9_filter.cc 保留：通过 T9_ALGO_ONLY_BUILD 编译守卫，仅编译 converter 部分（无 RIME 依赖）
     file(GLOB T9_ALGO_SRC CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc)
-    list(FILTER T9_ALGO_SRC EXCLUDE REGEX "t9_processor\\.cc$|t9_module\\.cc$|t9_date_translator\\.cc$")
+    list(FILTER T9_ALGO_SRC EXCLUDE REGEX "t9_processor\\.cc$|t9_module\\.cc$|t9_date_translator\\.cc$|t9_user_translator\\.cc$|t9_digit_userdict\\.cc$")
     add_library(t9-algo-objs OBJECT ${T9_ALGO_SRC})
     target_include_directories(t9-algo-objs PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src

--- a/app/src/main/jni/librime-t9/src/t9_digit_userdict.cc
+++ b/app/src/main/jni/librime-t9/src/t9_digit_userdict.cc
@@ -1,0 +1,151 @@
+#include "t9_digit_userdict.h"
+
+#include <sstream>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <rime/dict/level_db.h>
+
+#include "t9_log.h"
+
+namespace rime {
+
+T9DigitUserDict& T9DigitUserDict::Instance() {
+  static T9DigitUserDict instance;
+  return instance;
+}
+
+// static
+std::string T9DigitUserDict::BuildLookupKey(const std::string& rime_input) {
+  return T9DigitUserDictCore::BuildLookupKey(rime_input);
+}
+
+// static
+void T9DigitUserDict::SetFilePath(const std::string& path) {
+  auto& self = Instance();
+  if (self.loaded_)
+    return;
+  if (self.OpenDb(path)) {
+    self.LoadFromDb();
+    self.loaded_ = true;
+    T9_LOG_DEBUG("T9DigitDict", ">> SetFilePath '%s' db opened, tick=%llu codes=%zu",
+                 path.c_str(), (unsigned long long)self.core_.tick(),
+                 self.core_.size());
+  } else {
+    T9_LOG_DEBUG("T9DigitDict", ">> SetFilePath '%s' OPEN FAILED (fallback: 内存模式)",
+                 path.c_str());
+    self.loaded_ = true;
+  }
+}
+
+bool T9DigitUserDict::OpenDb(const std::string& path) {
+  if (db_)
+    return true;
+  // 确保父目录存在（user_data_dir 恒存在，此处防御性处理）。
+  size_t slash = path.rfind('/');
+  if (slash != std::string::npos) {
+    std::string dir = path.substr(0, slash);
+    struct stat st;
+    if (stat(dir.c_str(), &st) != 0 || !S_ISDIR(st.st_mode)) {
+      if (mkdir(dir.c_str(), 0700) != 0) {
+        T9_LOG_DEBUG("T9DigitDict", ">> OpenDb: mkdir failed for '%s'",
+                     dir.c_str());
+        return false;
+      }
+    }
+  }
+  // rime::path 的 string 构造为 explicit，需显式转换。
+  db_ = new LevelDb(rime::path(path), "t9_digit_user", "userdb");
+  if (db_->Open())
+    return true;
+  T9_LOG_DEBUG("T9DigitDict", ">> OpenDb: open failed for '%s', trying Recover",
+               path.c_str());
+  if (db_->Recover() && db_->Open())
+    return true;
+  delete db_;
+  db_ = nullptr;
+  return false;
+}
+
+void T9DigitUserDict::LoadFromDb() {
+  core_.Reset();
+  std::string tick_s;
+  if (db_->MetaFetch("/tick", &tick_s)) {
+    try {
+      core_.SetTick(std::stoull(tick_s));
+    } catch (...) {
+      core_.SetTick(0);
+    }
+  }
+  auto accessor = db_->QueryAll();
+  std::string key, value;
+  while (accessor && accessor->GetNextRecord(&key, &value)) {
+    core_.InsertFromStorage(key, value);
+  }
+  T9_LOG_DEBUG("T9DigitDict", ">> LoadFromDb: loaded codes=%zu tick=%llu",
+               core_.size(), (unsigned long long)core_.tick());
+}
+
+void T9DigitUserDict::ApplyOps(
+    const std::vector<T9DigitUserDictCore::StorageOp>& ops) {
+  if (ops.empty())
+    return;
+  if (!db_ || !db_->loaded()) {
+    T9_LOG_DEBUG("T9DigitDict", ">> ApplyOps: db unavailable, memory-only");
+    return;
+  }
+  db_->BeginTransaction();
+  for (const auto& op : ops) {
+    if (op.kind == T9DigitUserDictCore::StorageOp::kErase) {
+      db_->Erase(op.key);
+    } else {
+      db_->Update(op.key, op.value);
+    }
+  }
+  std::ostringstream os;
+  os << core_.tick();
+  db_->MetaUpdate("/tick", os.str());
+  db_->CommitTransaction();
+}
+
+void T9DigitUserDict::Memorize(const std::string& digits,
+                               const std::string& text,
+                               const std::string& pinyin) {
+  auto ops = core_.Memorize(digits, text, pinyin);
+  ApplyOps(ops);
+  // 每次写入后 compact（close+reopen），flush memtable 为 .ldb 文件。
+  // 多 .ldb 文件是 leveldb 的正常行为（rime_ice.userdb 同样有多个）。
+  Compact();
+}
+
+void T9DigitUserDict::Forget(const std::string& digits,
+                             const std::string& text) {
+  auto ops = core_.Forget(digits, text);
+  ApplyOps(ops);
+}
+
+void T9DigitUserDict::Compact() {
+  if (!db_ || !db_->loaded())
+    return;
+  db_->Close();
+  if (!db_->Open()) {
+    T9_LOG_DEBUG("T9DigitDict", ">> Compact: reopen failed, trying Recover");
+    if (!db_->Recover() || !db_->Open()) {
+      T9_LOG_DEBUG("T9DigitDict", ">> Compact: reopen FAILED (data in memory only)");
+      return;
+    }
+  }
+  T9_LOG_DEBUG("T9DigitDict", ">> Compact: done (memtable flushed to .ldb)");
+}
+
+// static
+void T9DigitUserDict::CompactDb() {
+  Instance().Compact();
+}
+
+std::vector<T9DigitUserDictCore::Entry> T9DigitUserDict::Lookup(
+    const std::string& digits, size_t limit) {
+  return core_.Lookup(digits, limit);
+}
+
+}  // namespace rime

--- a/app/src/main/jni/librime-t9/src/t9_digit_userdict.h
+++ b/app/src/main/jni/librime-t9/src/t9_digit_userdict.h
@@ -1,0 +1,59 @@
+#ifndef T9_DIGIT_USERDICT_H_
+#define T9_DIGIT_USERDICT_H_
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+#include "t9_digit_userdict_core.h"
+
+namespace rime {
+
+class LevelDb;
+
+// 九键数字序列用户词典（数字序列 → 用户词召回层）。
+// 与 RIME pinyin 用户词典并存：场景A 走 RIME userdb，场景B/C 走 T9 侧。
+// 存储：librime LevelDb，路径 <user_data_dir>/t9_digit.userdb。
+// 数据格式见 T9DigitUserDictCore（纯算法核心，独立单测）。
+class T9DigitUserDict {
+ public:
+  static T9DigitUserDict& Instance();
+
+  // 设置持久化路径并打开 leveldb（仅首次调用生效）。
+  static void SetFilePath(const std::string& path);
+
+  // 从 RIME input 构建查找键（"54482" / "54482:ji"）。
+  static std::string BuildLookupKey(const std::string& rime_input);
+
+  // 关闭并重新打开 leveldb，将 memtable 刷为 .ldb 文件。
+  static void CompactDb();
+
+  void Memorize(const std::string& digits, const std::string& text,
+                const std::string& pinyin);
+  void Forget(const std::string& digits, const std::string& text);
+  std::vector<T9DigitUserDictCore::Entry> Lookup(const std::string& digits,
+                                                 size_t limit);
+
+  bool loaded() const { return loaded_; }
+  // 全局 tick（供 T9UserTranslator 计算 present_tick = tick + 1）。
+  TickCount tick() const { return core_.tick(); }
+
+ private:
+  T9DigitUserDict() = default;
+  T9DigitUserDict(const T9DigitUserDict&) = delete;
+  T9DigitUserDict& operator=(const T9DigitUserDict&) = delete;
+
+  bool OpenDb(const std::string& path);
+  void LoadFromDb();
+  void ApplyOps(const std::vector<T9DigitUserDictCore::StorageOp>& ops);
+  // 关闭并重新打开 leveldb，刷 memtable 为 .ldb 文件。
+  void Compact();
+
+  T9DigitUserDictCore core_;
+  LevelDb* db_ = nullptr;
+  bool loaded_ = false;
+};
+
+}  // namespace rime
+
+#endif  // T9_DIGIT_USERDICT_H_

--- a/app/src/main/jni/librime-t9/src/t9_digit_userdict_core.cc
+++ b/app/src/main/jni/librime-t9/src/t9_digit_userdict_core.cc
@@ -1,0 +1,398 @@
+#include "t9_digit_userdict_core.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cctype>
+#include <iomanip>
+#include <sstream>
+
+#include "t9_log.h"
+#include "t9_pinyin_map.h"
+
+namespace rime {
+
+// 衰减公式：d_new = d_delta + d_old * exp((t_old - t_new) / 200)
+// 与 librime/src/rime/algo/dynamics.h 的 formula_d 一致，内联实现以免引入 RIME 头依赖。
+// static
+double T9DigitUserDictCore::FormulaD(double delta, double now,
+                                     double old_dee, double old_tick) {
+  return delta + old_dee * exp((old_tick - now) / 200);
+}
+
+// 排序权重公式（与 dynamics.h 的 formula_p 一致，内联实现）。
+// static
+double T9DigitUserDictCore::FormulaP(double s, double u, double t, double d) {
+  const double kM = 1.0 / (1.0 - exp(-0.005));
+  double m = s - (s - u) * pow((1.0 - exp(-t / 10000.0)), 10);
+  return (d < 20) ? m + (0.5 - m) * (d / kM)
+                  : m + (1.0 - m) * (pow(4.0, (d / kM)) - 1.0) / 3.0;
+}
+
+// static
+std::string T9DigitUserDictCore::BuildLookupKey(const std::string& rime_input) {
+  std::string left_pinyin;
+  std::string digits;
+  for (char c : rime_input) {
+    if (c >= '2' && c <= '9') {
+      digits += c;
+    } else if (std::isalpha(static_cast<unsigned char>(c))) {
+      left_pinyin += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+  }
+  // key = <digits>[:<left_pinyin>]，两部分皆可为空（全空时返回空 = 无 key）。
+  // 场景 A/B：纯数字 "54482"；场景 C：数字+左选 "4482:j"；
+  // 场景 D（左选完全消费数字）：纯左选 "km"。
+  if (digits.empty() && left_pinyin.empty())
+    return {};
+  if (digits.empty())
+    return left_pinyin;
+  if (left_pinyin.empty())
+    return digits;
+  return digits + ":" + left_pinyin;
+}
+
+// static
+std::string T9DigitUserDictCore::PinyinToFullCode(const std::string& pinyin) {
+  if (pinyin.empty())
+    return {};
+  std::string result;
+  std::istringstream in(pinyin);
+  std::string syllable;
+  while (in >> syllable) {
+    auto code = T9PinyinMap::Instance().PinyinToDigitCode(syllable);
+    if (!code.has_value())
+      return {};
+    result += *code;
+  }
+  return result;
+}
+
+// static
+std::string T9DigitUserDictCore::BuildKey(const std::string& input_digits,
+                                          const std::string& full_code,
+                                          const std::string& text) {
+  return input_digits + "\t" + full_code + "\t" + text;
+}
+
+// static
+bool T9DigitUserDictCore::ParseKey(const std::string& key,
+                                   std::string* input_digits,
+                                   std::string* full_code,
+                                   std::string* text) {
+  size_t t1 = key.find('\t');
+  if (t1 == std::string::npos)
+    return false;
+  size_t t2 = key.find('\t', t1 + 1);
+  if (t2 == std::string::npos)
+    return false;
+  if (input_digits)
+    *input_digits = key.substr(0, t1);
+  if (full_code)
+    *full_code = key.substr(t1 + 1, t2 - t1 - 1);
+  if (text)
+    *text = key.substr(t2 + 1);
+  return true;
+}
+
+// static
+std::string T9DigitUserDictCore::PackValue(const Entry& entry) {
+  std::ostringstream out;
+  out << "p=" << entry.pinyin << '\t'
+      << "c=" << entry.commits << '\t'
+      << "d=" << std::setprecision(17) << entry.dee << '\t'
+      << "t=" << entry.last_tick;
+  return out.str();
+}
+
+// static
+bool T9DigitUserDictCore::UnpackValue(const std::string& value, Entry* entry) {
+  if (!entry)
+    return false;
+  size_t p0 = 0;
+  auto read_field = [&](size_t* pos, const std::string& prefix,
+                        std::string* out) -> bool {
+    if (*pos == std::string::npos)
+      return false;
+    size_t start = *pos;
+    size_t end = value.find('\t', start);
+    if (end == std::string::npos)
+      end = value.size();
+    *pos = (end == value.size()) ? std::string::npos : end + 1;
+    if (value.compare(start, prefix.size(), prefix) != 0)
+      return false;
+    *out = value.substr(start + prefix.size(), end - start - prefix.size());
+    return true;
+  };
+  std::string pinyin, commits_s, dee_s, tick_s;
+  if (!read_field(&p0, "p=", &pinyin) ||
+      !read_field(&p0, "c=", &commits_s) ||
+      !read_field(&p0, "d=", &dee_s) ||
+      !read_field(&p0, "t=", &tick_s))
+    return false;
+  try {
+    entry->pinyin = pinyin;
+    entry->commits = std::stoi(commits_s);
+    entry->dee = std::stod(dee_s);
+    entry->last_tick = std::stoull(tick_s);
+  } catch (...) {
+    return false;
+  }
+  return true;
+}
+
+std::vector<T9DigitUserDictCore::StorageOp>
+T9DigitUserDictCore::Memorize(const std::string& digits,
+                              const std::string& text,
+                              const std::string& pinyin) {
+  std::vector<StorageOp> ops;
+  if (digits.empty() || text.empty() || pinyin.empty())
+    return ops;
+
+  // 计算完整拼音数字码 C(W)
+  // PinyinToDigitCode 内部已做声调归一化，带调拼音（如 "lì hù"）能正确映射。
+  std::string full_code = PinyinToFullCode(pinyin);
+  if (full_code.empty())
+    return ops;
+
+  // 递增全局 tick
+  ++tick_;
+
+  // 写入主存储：C(W) → Entry
+  auto& vec = entries_by_code_[full_code];
+  for (auto& e : vec) {
+    if (e.text == text) {
+      // 已有条目：更新 dee、commits，迁移 input_digits
+      e.commits += 1;
+      e.dee = FormulaD(1.0, (double)tick_, e.dee, (double)e.last_tick);
+      e.last_tick = tick_;
+      if (e.pinyin.empty())
+        e.pinyin = pinyin;
+      // 输入序列变化时迁移索引到新 key
+      if (e.input_digits != digits) {
+        auto& old_list = digit_to_code_[e.input_digits];
+        old_list.erase(std::remove(old_list.begin(), old_list.end(), full_code),
+                       old_list.end());
+        if (old_list.empty())
+          digit_to_code_.erase(e.input_digits);
+        ops.push_back(StorageOp{StorageOp::kErase,
+                                BuildKey(e.input_digits, full_code, text), {}});
+        e.input_digits = digits;
+        auto& new_list = digit_to_code_[digits];
+        if (std::find(new_list.begin(), new_list.end(), full_code) ==
+            new_list.end()) {
+          new_list.push_back(full_code);
+        }
+      }
+      ops.push_back(StorageOp{StorageOp::kUpdate,
+                              BuildKey(e.input_digits, full_code, text),
+                              PackValue(e)});
+      T9_LOG_DEBUG("T9DigitDict", ">> Memorize: update dee=%.4f commits=%d tick=%llu",
+                   e.dee, e.commits, (unsigned long long)tick_);
+      return ops;
+    }
+  }
+
+  // 新条目
+  vec.push_back(Entry{
+      text, pinyin,                         // text, pinyin
+      FormulaD(1.0, (double)tick_, 0.0, 0.0),  // dee: 首次 = 1.0
+      1, tick_,                             // commits=1, last_tick
+      full_code, digits                     // full_code, input_digits
+  });
+
+  // 更新辅助索引
+  auto& code_list = digit_to_code_[digits];
+  if (std::find(code_list.begin(), code_list.end(), full_code) == code_list.end()) {
+    code_list.push_back(full_code);
+  }
+
+  T9_LOG_DEBUG("T9DigitDict",
+               ">> Memorize: new digits='%s' text='%s' dee=%.4f commits=1 "
+               "tick=%llu",
+               digits.c_str(), text.c_str(), vec.back().dee,
+               (unsigned long long)tick_);
+  ops.push_back(StorageOp{StorageOp::kUpdate, BuildKey(digits, full_code, text),
+                          PackValue(vec.back())});
+  return ops;
+}
+
+std::vector<T9DigitUserDictCore::StorageOp>
+T9DigitUserDictCore::Forget(const std::string& digits,
+                            const std::string& text) {
+  std::vector<StorageOp> ops;
+  auto idx_it = digit_to_code_.find(digits);
+  if (idx_it == digit_to_code_.end())
+    return ops;
+
+  ++tick_;
+  bool changed = false;
+  std::vector<std::string> remaining_codes;
+  for (const auto& code : idx_it->second) {
+    auto entry_it = entries_by_code_.find(code);
+    if (entry_it == entries_by_code_.end())
+      continue;
+    auto& vec = entry_it->second;
+    bool code_has_remaining = false;
+    for (auto e = vec.begin(); e != vec.end();) {
+      if (e->text == text) {
+        e->commits -= 1;
+        if (e->commits <= 0) {
+          ops.push_back(StorageOp{StorageOp::kErase,
+                                  BuildKey(digits, code, text), {}});
+          e = vec.erase(e);
+          changed = true;
+          continue;
+        }
+        e->dee = FormulaD(0.0, (double)tick_, e->dee, (double)e->last_tick);
+        e->last_tick = tick_;
+        ops.push_back(StorageOp{StorageOp::kUpdate,
+                                BuildKey(digits, code, text), PackValue(*e)});
+        changed = true;
+      }
+      if (e->commits > 0)
+        code_has_remaining = true;
+      ++e;
+    }
+    if (code_has_remaining)
+      remaining_codes.push_back(code);
+    if (vec.empty())
+      entries_by_code_.erase(entry_it);
+  }
+
+  if (remaining_codes.empty()) {
+    digit_to_code_.erase(idx_it);
+  } else {
+    idx_it->second = std::move(remaining_codes);
+  }
+
+  return ops;
+}
+
+std::vector<T9DigitUserDictCore::Entry>
+T9DigitUserDictCore::Lookup(const std::string& digits, size_t limit) {
+  std::vector<Entry> result;
+
+  // 路径 1：精确匹配 lookup_key（含左选复合键）——命中场景 C/D 词。
+  // 这些词代表"用户真实用过的输入路径"，直接返回不过滤（rank=0 优先）。
+  std::vector<std::pair<int, Entry>> ranked;  // (rank, entry): 0=精确, 1=还原
+  auto idx_it = digit_to_code_.find(digits);
+  if (idx_it != digit_to_code_.end()) {
+    for (const auto& code : idx_it->second) {
+      auto entry_it = entries_by_code_.find(code);
+      if (entry_it == entries_by_code_.end())
+        continue;
+      for (auto& e : entry_it->second) {
+        if (e.commits > 0) {
+          ranked.emplace_back(0, e);
+        }
+      }
+    }
+  }
+
+  // 路径 2：左选是完整首音节（长度 >= 2）时，还原完整数字序列做前缀筛选。
+  // 如 left_pinyin="ji"→"54"+"482"→"54482"，命中场景 B 词（key=纯数字序列），
+  // 按首音节匹配过滤（左选 ji 时筛掉首音节 li 的词）。
+  // 左选声母简拼（长度=1，如 j/k/l）跳过还原（精确匹配已覆盖场景 C 词）。
+  size_t colon_pos = digits.find(':');
+  if (colon_pos != std::string::npos && colon_pos + 1 < digits.size()) {
+    std::string remaining_digits = digits.substr(0, colon_pos);
+    std::string left_pinyin = digits.substr(colon_pos + 1);
+    if (left_pinyin.size() >= 2) {
+      auto left_code = T9PinyinMap::Instance().PinyinToDigitCode(left_pinyin);
+      if (left_code.has_value()) {
+        std::string full_digits = *left_code + remaining_digits;
+        if (full_digits != digits) {  // 防自身命中重复
+        auto full_it = digit_to_code_.find(full_digits);
+        if (full_it != digit_to_code_.end()) {
+          for (const auto& code : full_it->second) {
+            auto entry_it = entries_by_code_.find(code);
+            if (entry_it == entries_by_code_.end())
+              continue;
+            for (auto& e : entry_it->second) {
+              if (e.commits <= 0)
+                continue;
+              // 首音节匹配：词拼音首音节以左选拼音开头
+              size_t sp = e.pinyin.find(' ');
+              std::string first_syllable =
+                  e.pinyin.substr(0, sp == std::string::npos ? e.pinyin.size() : sp);
+              if (first_syllable.size() >= left_pinyin.size() &&
+                  first_syllable.compare(0, left_pinyin.size(), left_pinyin) == 0) {
+                bool dup = false;
+                for (const auto& r : ranked) {
+                  if (r.second.text == e.text && r.second.full_code == e.full_code) {
+                    dup = true;
+                    break;
+                  }
+                }
+                if (!dup)
+                  ranked.emplace_back(1, e);
+              }
+            }
+          }
+        }
+        }
+        }
+      }
+  }
+
+  // 排序：rank 优先（精确匹配 > 还原），同 rank 按 dee 降序 → commits 降序。
+  std::sort(ranked.begin(), ranked.end(),
+            [](const std::pair<int, Entry>& a, const std::pair<int, Entry>& b) {
+              if (a.first != b.first)
+                return a.first < b.first;
+              if (a.second.dee != b.second.dee)
+                return a.second.dee > b.second.dee;
+              return a.second.commits > b.second.commits;
+            });
+  result.clear();
+  result.reserve(ranked.size());
+  for (auto& r : ranked)
+    result.push_back(r.second);
+
+  if (limit && result.size() > limit)
+    result.resize(limit);
+  T9_LOG_DEBUG("T9DigitDict", ">> Lookup digits='%s' hits=%zu",
+               digits.c_str(), result.size());
+  return result;
+}
+
+void T9DigitUserDictCore::InsertFromStorage(const std::string& key,
+                                            const std::string& value) {
+  std::string input_digits, full_code, text;
+  if (!ParseKey(key, &input_digits, &full_code, &text))
+    return;
+  Entry entry;
+  entry.full_code = full_code;
+  entry.input_digits = input_digits;
+  if (!UnpackValue(value, &entry))
+    return;
+  entry.text = text;
+  // 防御性覆盖，避免崩溃恢复后出现重复词条。
+  auto& vec = entries_by_code_[full_code];
+  bool updated = false;
+  for (auto& e : vec) {
+    if (e.text == text) {
+      e.pinyin = entry.pinyin;
+      e.dee = entry.dee;
+      e.commits = entry.commits;
+      e.last_tick = entry.last_tick;
+      e.input_digits = input_digits;
+      updated = true;
+      break;
+    }
+  }
+  if (!updated) {
+    vec.push_back(entry);
+  }
+  auto& code_list = digit_to_code_[input_digits];
+  if (std::find(code_list.begin(), code_list.end(), full_code) == code_list.end())
+    code_list.push_back(full_code);
+}
+
+void T9DigitUserDictCore::Reset() {
+  entries_by_code_.clear();
+  digit_to_code_.clear();
+  tick_ = 0;
+}
+
+}  // namespace rime

--- a/app/src/main/jni/librime-t9/src/t9_digit_userdict_core.h
+++ b/app/src/main/jni/librime-t9/src/t9_digit_userdict_core.h
@@ -1,0 +1,93 @@
+#ifndef T9_DIGIT_USERDICT_CORE_H_
+#define T9_DIGIT_USERDICT_CORE_H_
+
+#include <stdint.h>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace rime {
+
+using TickCount = uint64_t;
+
+// 九键数字序列用户词典——纯算法核心（无 RIME 依赖，可独立单测）。
+// 双索引：entries_by_code_（full_code → Entry）与 digit_to_code_（lookup_key → [full_code]）。
+// 调频模型：对齐 RIME userdb 的 c/d/t 三元组，排序按 dee 降序 → commits 降序。
+// 序列化：与 LevelDb 解耦，Memorize/Forget 返回 StorageOp 列表由外层应用。
+// 键值格式：key=<input_digits>\t<full_code>\t<text>, value=p=<pinyin>\t<c=commits>\t<d=dee>\t<t=tick>
+class T9DigitUserDictCore {
+ public:
+  struct Entry {
+    std::string text;
+    std::string pinyin;  // 空格分隔拼音（供候选 comment）
+    double dee = 0.0;    // 衰减权重（RIME formula_d 计算）
+    int commits = 0;     // 总使用次数
+    TickCount last_tick = 0;  // 最近更新时的全局 tick
+    std::string full_code;    // C(W) 完整拼音数字码
+    std::string input_digits; // 组词时实际输入序列（lookup_key，含左选复合键）
+  };
+
+  // 落盘操作：Memorize/Forget 产生的持久化变更，由外层应用到 LevelDb。
+  struct StorageOp {
+    enum Kind { kUpdate, kErase };
+    Kind kind;
+    std::string key;
+    std::string value;
+  };
+
+  // 从 RIME input 构建查找键。格式：无左选 "54482"；左选 j "j'4482" → "54482:j"。
+  static std::string BuildLookupKey(const std::string& rime_input);
+
+  // 拼音串（如 "ji hu biao"）→ 完整数字码（如 "54482424"），含无法映射的拼音时返回空串。
+  static std::string PinyinToFullCode(const std::string& pinyin);
+
+  // key/value 序列化。
+  static std::string BuildKey(const std::string& input_digits,
+                              const std::string& full_code,
+                              const std::string& text);
+  static bool ParseKey(const std::string& key,
+                       std::string* input_digits,
+                       std::string* full_code,
+                       std::string* text);
+  static std::string PackValue(const Entry& entry);
+  static bool UnpackValue(const std::string& value, Entry* entry);
+
+  // 上屏记忆：写入/更新条目，返回需落盘的变更。
+  std::vector<StorageOp> Memorize(const std::string& digits,
+                                  const std::string& text,
+                                  const std::string& pinyin);
+  // 撤销：commits -1，归零时删除。
+  std::vector<StorageOp> Forget(const std::string& digits,
+                                const std::string& text);
+  // 召回：匹配 lookup_key，精确匹配优先，左选复合键时还原完整数字序列做前缀筛选。
+  std::vector<Entry> Lookup(const std::string& digits, size_t limit);
+
+  // 从持久化层灌入一条记录重建索引。
+  void InsertFromStorage(const std::string& key, const std::string& value);
+  // 清空全部索引与计数。
+  void Reset();
+
+  // 衰减公式：d_new = d_delta + d_old * exp((t_old - t_new) / 200)
+  // 内联实现以免引入 RIME 引擎头依赖。
+  static double FormulaD(double delta, double now, double old_dee, double old_tick);
+
+  // 排序权重公式（与 dynamics.h 的 formula_p 一致，内联实现）。
+  // s=0, u=commits/present_tick, t=present_tick, d=adj_dee
+  static double FormulaP(double s, double u, double t, double d);
+
+  TickCount tick() const { return tick_; }
+  void SetTick(TickCount tick) { tick_ = tick; }
+  size_t size() const { return entries_by_code_.size(); }
+
+ private:
+  // 主存储：C(W) → entries
+  std::unordered_map<std::string, std::vector<Entry>> entries_by_code_;
+  // 辅助索引：lookup_key → [C(W), ...]
+  std::unordered_map<std::string, std::vector<std::string>> digit_to_code_;
+
+  TickCount tick_ = 0;          // 全局 tick（Memorize/Forget 递增，持久化于 meta）
+};
+
+}  // namespace rime
+
+#endif  // T9_DIGIT_USERDICT_CORE_H_

--- a/app/src/main/jni/librime-t9/src/t9_filter.cc
+++ b/app/src/main/jni/librime-t9/src/t9_filter.cc
@@ -4,14 +4,18 @@
 #include <sstream>
 #include <vector>
 
+#include "t9_digit_userdict.h"
 #include "t9_log.h"
+#include "t9_pinyin_map.h"  // NormalizePinyinComment（声调归一化，统一入口）
 
 #ifndef T9_ALGO_ONLY_BUILD
+#include <rime/context.h>
 #include <rime/engine.h>
 #include <rime/schema.h>
 #include <rime/config.h>
 #include <rime/common.h>
 #include <rime/gear/translator_commons.h>  // Phrase（Phrase 码缓存）
+#include "t9_digit_userdict.h"  // 去重集合（T9 用户词文本）
 #include "t9_processor.h"  // T9ProcessorRequire / CachePhraseCode（Phrase 码缓存）
 #endif
 
@@ -66,76 +70,6 @@ static bool IsChinese(uint32_t cp) {
 
 static bool IsDigit(char c) {
     return c >= '0' && c <= '9';
-}
-
-// ── 声调归一化 ──
-// 带声调的拼音方案（如带声调方案）词库编码使用 Unicode 预组合声调字符
-// （如 jī huà），comment 经 spelling_hints 暴露时保留声调。
-// 逐字节 ASCII 过滤会丢弃这些多字节字符的每个字节，导致元音丢失
-// （jī→j, huà→hu）。此处逐 Unicode 码点解码，将声调元音归一化为
-// 普通 ASCII 字母，与方案 speller algebra 的 xlit 语义一致。
-// 映射表与带声调方案的 xlit 对齐（大小写声调
-// 字符统一映射为小写 ASCII 字母）：
-//   āáǎà/ĀǍÁÀ→a   ēéěè/ĒĚÉÈ→e   īíǐì/ĪǏÍÌ→i   ōóǒò/ŌǑÓÒ→o
-//   ūúǔù/ŪǓÚÙ→u   ǖǘǚǜü/ǕǗǙǛÜ→v  ńňǹ/ŃŇǸ→n   ḿ/Ḿ→m
-// 注 1：带声调方案 xlit 中的 m̀（m+组合附加符号 U+0300）不在此表——组合标记由
-//   NormalizePinyinComment 的"ASCII 字母保留 + 未识别多字节丢弃"路径隐式
-//   归一化为 m，与 xlit 语义一致（下表 ḿ/Ḿ 为预组合形式）。
-// 注 2：未识别的多字节字符（如组合用附加符号 U+0300）一律静默丢弃。
-static char ToneToAscii(uint32_t cp) {
-    switch (cp) {
-        // a: ā ǎ á à  Ā Ǎ Á À (U+0101/U+01CE/U+00E1/U+00E0/U+0100/U+01CD/U+00C1/U+00C0)
-        case 0x0101: case 0x01CE: case 0x00E1: case 0x00E0:
-        case 0x0100: case 0x01CD: case 0x00C1: case 0x00C0: return 'a';
-        // e: ē ě é è  Ē Ě É È (U+0113/U+011B/U+00E9/U+00E8/U+0112/U+011A/U+00C9/U+00C8)
-        case 0x0113: case 0x011B: case 0x00E9: case 0x00E8:
-        case 0x0112: case 0x011A: case 0x00C9: case 0x00C8: return 'e';
-        // i: ī ǐ í ì  Ī Ǐ Í Ì (U+012B/U+01D0/U+00ED/U+00EC/U+012A/U+01CF/U+00CD/U+00CC)
-        case 0x012B: case 0x01D0: case 0x00ED: case 0x00EC:
-        case 0x012A: case 0x01CF: case 0x00CD: case 0x00CC: return 'i';
-        // o: ō ǒ ó ò  Ō Ǒ Ó Ò (U+014D/U+01D2/U+00F3/U+00F2/U+014C/U+01D1/U+00D3/U+00D2)
-        case 0x014D: case 0x01D2: case 0x00F3: case 0x00F2:
-        case 0x014C: case 0x01D1: case 0x00D3: case 0x00D2: return 'o';
-        // u: ū ǔ ú ù  Ū Ǔ Ú Ù (U+016B/U+01D4/U+00FA/U+00F9/U+016A/U+01D3/U+00DA/U+00D9)
-        case 0x016B: case 0x01D4: case 0x00FA: case 0x00F9:
-        case 0x016A: case 0x01D3: case 0x00DA: case 0x00D9: return 'u';
-        // ü/v: ǖ ǘ ǚ ǜ ü  Ǖ Ǘ Ǚ Ǜ Ü (U+01D6/U+01D8/U+01DA/U+01DC/U+00FC/U+01D5/U+01D7/U+01D9/U+01DB/U+00DC)
-        case 0x01D6: case 0x01D8: case 0x01DA: case 0x01DC: case 0x00FC:
-        case 0x01D5: case 0x01D7: case 0x01D9: case 0x01DB: case 0x00DC: return 'v';
-        // n: ń ň ǹ  Ń Ň Ǹ (U+0144/U+0148/U+01F9/U+0143/U+0147/U+01F8)
-        case 0x0144: case 0x0148: case 0x01F9:
-        case 0x0143: case 0x0147: case 0x01F8: return 'n';
-        // m: ḿ Ḿ (U+1E3F/U+1E3E)
-        case 0x1E3F: case 0x1E3E: return 'm';
-        default: return 0;
-    }
-}
-
-// 将 comment 中的带声调拼音归一化为纯 ASCII 小写拼音。
-// 逐码点解码：声调字符 → 对应 ASCII 字母，ASCII 字母统一转小写，
-// 其他字符（分隔符、括号等）丢弃。非 static：供 t9_processor 复用。
-std::string NormalizePinyinComment(const std::string& comment) {
-    std::string result;
-    const char* p = comment.c_str();
-    const char* end = p + comment.size();
-    while (p < end) {
-        const char* prev = p;
-        uint32_t cp = DecodeUtf8(p, end);
-        if (cp == 0) continue;
-        if (cp < 0x80) {
-            if ((cp >= 'a' && cp <= 'z') || (cp >= 'A' && cp <= 'Z')) {
-                // 统一小写：归一化用于比较与音节选择，须大小写不敏感。
-                result += static_cast<char>(std::tolower(static_cast<unsigned char>(cp)));
-            }
-        } else {
-            char mapped = ToneToAscii(cp);
-            if (mapped != 0) {
-                result += mapped;
-            }
-            // 未识别的多字节字符（如组合用附加符号 U+0300）静默丢弃
-        }
-    }
-    return result;
 }
 
 // ── 输入分段 ──
@@ -372,13 +306,8 @@ T9Translation::T9Translation(an<Translation> translation,
       auto_delim_(auto_delim),
       manual_delim_(manual_delim),
       convert_preedit_(convert_preedit) {
-    // 不调用 translation_->Next()：Translation 创建时已定位在第一个候选
-    if (translation_->exhausted()) {
-        set_exhausted(true);
-        return;
-    }
-    cand_ = translation_->Peek();
-    ConvertCurrent();
+    // 定位到第一个候选（构造时 translation 已定位在第一个候选）。
+    Advance();
 }
 
 bool T9Translation::Next() {
@@ -387,9 +316,18 @@ bool T9Translation::Next() {
         set_exhausted(true);
         return false;
     }
-    cand_ = translation_->Peek();
-    ConvertCurrent();
-    return true;
+    Advance();
+    return !exhausted();
+}
+
+void T9Translation::Advance() {
+    while (!translation_->exhausted()) {
+        cand_ = translation_->Peek();
+        ConvertCurrent();
+        return;
+    }
+    cand_ = nullptr;
+    set_exhausted(true);
 }
 
 // ── T9Filter ──
@@ -415,8 +353,7 @@ an<Translation> T9Filter::Apply(an<Translation> translation,
                                  CandidateList* candidates) {
     T9_PERF_SCOPED_TIMER("[T9Filter] Apply");
     if (!translation) return translation;
-    // 始终包装 T9Translation：false 时转换 preedit，true 时透传但均顺带缓存
-    // Phrase 码（供右选调频捕获兜底，见 ConvertCurrent）。
+    // 去重由 filter 链末尾的 uniquifier 兜底，t9_filter 只做 preedit 转换。
     return New<T9Translation>(translation, auto_delimiter_, manual_delimiter_,
                               convert_preedit_);
 }

--- a/app/src/main/jni/librime-t9/src/t9_filter.h
+++ b/app/src/main/jni/librime-t9/src/t9_filter.h
@@ -32,11 +32,6 @@ std::string T9ConvertCandidatePreedit(const std::string& preedit,
                                       const std::string& comment,
                                       const std::string& candidate_text);
 
-// 将拼音注释中的带声调字符归一化为纯 ASCII 小写拼音（jī huà → ji hua）。
-// 供 t9_processor 调频码声调保真复用：comment 归一化匹配、无声调音节
-// → 带声调变体选择（避免命中轻声音节）。
-std::string NormalizePinyinComment(const std::string& comment);
-
 #ifndef T9_ALGO_ONLY_BUILD
 // 包装候选，覆盖 preedit() 返回转换后的拼音，
 // 不修改原始候选对象，避免跨 .so 边界的 dynamic_cast 失效问题。
@@ -73,6 +68,9 @@ public:
     an<Candidate> Peek() override { return cand_; }
 
 private:
+    // 定位到下一个可接受的候选。
+    void Advance();
+    // 转换/缓存当前候选的 preedit（原逻辑）。
     void ConvertCurrent();
 
     an<Translation> translation_;

--- a/app/src/main/jni/librime-t9/src/t9_log.h
+++ b/app/src/main/jni/librime-t9/src/t9_log.h
@@ -27,7 +27,8 @@
 // 编译选项（CMakeLists.txt）：
 //   option(T9_ENABLE_VERBOSE_LOG "Enable verbose T9 debug logging" OFF)
 //   option(T9_ENABLE_TIMING      "Enable T9 timing instrumentation" OFF)
-//   debug 构建：两者均 ON；release 构建：两者均 OFF
+//   默认两者均 OFF；通过环境变量按需开启：
+//     T9_ENABLE_VERBOSE_LOG=ON T9_ENABLE_TIMING=ON ./gradlew assembleDebug
 
 #ifndef T9_LOG_H_
 #define T9_LOG_H_

--- a/app/src/main/jni/librime-t9/src/t9_module.cc
+++ b/app/src/main/jni/librime-t9/src/t9_module.cc
@@ -5,6 +5,7 @@
 #include "t9_processor.h"
 #include "t9_filter.h"
 #include "t9_date_translator.h"
+#include "t9_user_translator.h"
 
 using namespace rime;
 
@@ -16,6 +17,9 @@ static void rime_t9_initialize() {
     r.Register("t9_processor", new Component<T9Processor>);
     r.Register("t9_filter", new Component<T9Filter>);
     r.Register("t9_date_translator", new Component<T9DateTranslator>);
+    // 九键数字序列用户词召回（按实际输入数字序列召回用户词，
+    // 解决声母简拼组词无法被 pinyin 用户词典召回的问题）。
+    r.Register("t9_user_translator", new Component<T9UserTranslator>);
 }
 
 static void rime_t9_finalize() {

--- a/app/src/main/jni/librime-t9/src/t9_pinyin_map.cc
+++ b/app/src/main/jni/librime-t9/src/t9_pinyin_map.cc
@@ -5,6 +5,89 @@
 
 namespace rime {
 
+// ── 声调归一化（内联实现，避免引入 t9_filter.cc 依赖）──
+// 与 t9_filter.cc 的 DecodeUtf8 / ToneToAscii 一致，供 PinyinToDigitCode
+// 在映射前归一化带声调拼音（如 "lì" → "li" → "54"）。
+
+static uint32_t DecodeUtf8(const char*& p, const char* end) {
+    if (p >= end) return 0;
+    unsigned char c = static_cast<unsigned char>(*p);
+    if (c < 0x80) {
+        uint32_t cp = c;
+        ++p;
+        return cp;
+    }
+    if ((c & 0xE0) == 0xC0) {
+        if (p + 1 >= end) { ++p; return 0; }
+        uint32_t cp = ((c & 0x1F) << 6) | (static_cast<unsigned char>(p[1]) & 0x3F);
+        p += 2;
+        return cp;
+    }
+    if ((c & 0xF0) == 0xE0) {
+        if (p + 2 >= end) { ++p; return 0; }
+        uint32_t cp = ((c & 0x0F) << 12)
+                    | ((static_cast<unsigned char>(p[1]) & 0x3F) << 6)
+                    | (static_cast<unsigned char>(p[2]) & 0x3F);
+        p += 3;
+        return cp;
+    }
+    if ((c & 0xF8) == 0xF0) {
+        if (p + 3 >= end) { ++p; return 0; }
+        uint32_t cp = ((c & 0x07) << 18)
+                    | ((static_cast<unsigned char>(p[1]) & 0x3F) << 12)
+                    | ((static_cast<unsigned char>(p[2]) & 0x3F) << 6)
+                    | (static_cast<unsigned char>(p[3]) & 0x3F);
+        p += 4;
+        return cp;
+    }
+    ++p;
+    return 0;
+}
+
+static char ToneToAscii(uint32_t cp) {
+    switch (cp) {
+        case 0x0101: case 0x01CE: case 0x00E1: case 0x00E0:
+        case 0x0100: case 0x01CD: case 0x00C1: case 0x00C0: return 'a';
+        case 0x0113: case 0x011B: case 0x00E9: case 0x00E8:
+        case 0x0112: case 0x011A: case 0x00C9: case 0x00C8: return 'e';
+        case 0x012B: case 0x01D0: case 0x00ED: case 0x00EC:
+        case 0x012A: case 0x01CF: case 0x00CD: case 0x00CC: return 'i';
+        case 0x014D: case 0x01D2: case 0x00F3: case 0x00F2:
+        case 0x014C: case 0x01D1: case 0x00D3: case 0x00D2: return 'o';
+        case 0x016B: case 0x01D4: case 0x00FA: case 0x00F9:
+        case 0x016A: case 0x01D3: case 0x00DA: case 0x00D9: return 'u';
+        case 0x01D6: case 0x01D8: case 0x01DA: case 0x01DC: case 0x00FC:
+        case 0x01D5: case 0x01D7: case 0x01D9: case 0x01DB: case 0x00DC: return 'v';
+        case 0x0144: case 0x0148: case 0x01F9:
+        case 0x0143: case 0x0147: case 0x01F8: return 'n';
+        case 0x1E3F: case 0x1E3E: return 'm';
+        default: return 0;
+    }
+}
+
+// 将带声调拼音归一化为纯 ASCII 小写（保留空格），供逐字符映射。
+// 统一实现：t9_filter.cc / t9_processor.cc 中的 NormalizePinyinComment 也指向此函数。
+std::string NormalizePinyinComment(const std::string& comment) {
+    std::string result;
+    const char* p = comment.c_str();
+    const char* end = p + comment.size();
+    while (p < end) {
+        uint32_t cp = DecodeUtf8(p, end);
+        if (cp == 0) continue;
+        if (cp < 0x80) {
+            if ((cp >= 'a' && cp <= 'z') || (cp >= 'A' && cp <= 'Z')) {
+                result += static_cast<char>(std::tolower(static_cast<unsigned char>(cp)));
+            } else if (cp == ' ') {
+                result += ' ';
+            }
+        } else {
+            char mapped = ToneToAscii(cp);
+            if (mapped != 0) result += mapped;
+        }
+    }
+    return result;
+}
+
 // 单字母→数字映射（对应 Kotlin LETTER_TO_DIGIT）
 static const std::unordered_map<char, char>& LetterToDigitMap() {
     static const std::unordered_map<char, char> kMap = {
@@ -182,10 +265,10 @@ std::vector<std::string> T9PinyinMap::Candidates(const std::string& digits,
 
 std::optional<std::string> T9PinyinMap::PinyinToDigitCode(
     const std::string& pinyin) const {
-    // 对应 Kotlin pinyinToDigitCode（含缓存）
-    std::string key = pinyin;
-    std::transform(key.begin(), key.end(), key.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
+    // 先归一化带声调拼音（如 "lì hù" → "li hu"），再逐字符映射。
+    std::string key = NormalizePinyinComment(pinyin);
+    if (key.empty())
+        return std::nullopt;  // 归一化后为空（如纯符号输入）
 
     auto cache_it = pinyin_code_cache_.find(key);
     if (cache_it != pinyin_code_cache_.end()) {

--- a/app/src/main/jni/librime-t9/src/t9_pinyin_map.h
+++ b/app/src/main/jni/librime-t9/src/t9_pinyin_map.h
@@ -103,6 +103,15 @@ private:
     static constexpr int kMaxPinyinLen = 6;
 };
 
+// ── 声调归一化工具（UTF-8 解码 + 声调字符映射）──
+// 统一入口：t9_pinyin_map.cc 实现，t9_filter.cc / t9_processor.cc 共用。
+
+// 将带声调拼音归一化为纯 ASCII 小写（保留空格）。
+// 如 "jì huà" → "ji hua"，"JĪ HUÀ" → "ji hua"。
+// 用途：PinyinToDigitCode 内部归一化、comment 匹配（容忍带调/无调差异）、
+// preedit 转换中的 comment 过滤。
+std::string NormalizePinyinComment(const std::string& comment);
+
 }  // namespace rime
 
 #endif  // T9_PINYIN_MAP_H_

--- a/app/src/main/jni/librime-t9/src/t9_processor.cc
+++ b/app/src/main/jni/librime-t9/src/t9_processor.cc
@@ -22,7 +22,8 @@
 
 #include "t9_log.h"
 #include "t9_right_commit_utils.h"  // ParseSyllables
-#include "t9_filter.h"              // NormalizePinyinComment（调频码声调保真）
+#include "t9_pinyin_map.h"           // NormalizePinyinComment（声调归一化，统一入口）
+#include "t9_digit_userdict.h"      // 数字序列用户词召回（方案 A）
 
 namespace rime {
 
@@ -187,9 +188,14 @@ ProcessResult T9Processor::HandleDigitKey(char ch) {
     T9_PERF_SCOPED_TIMER("[T9] HandleDigitKey");
     if (state_machine_.is_idle()) {
         state_machine_.EnterInput();
+        original_digit_sequence_.clear();
+        T9LOG(">> HandleDigitKey: idle→input, original_digit_sequence_ cleared");
     }
     undo_model_.DigitPressed(ch);  // 段模型双写
     input_buffer_ = input_buffer_.AddDigit(ch);
+    original_digit_sequence_ += ch;
+    T9LOG(">> HandleDigitKey: original_digit_sequence_='%s' (after += '%c')",
+          original_digit_sequence_.c_str(), ch);
     SendToRime();
 
     Context* ctx = engine_->context();
@@ -486,27 +492,67 @@ bool T9Processor::SelectCandidate(const std::string& candidate_pinyin,
     // 顺带捕获候选真实数据（Phrase 文本 + 音节码，含声调真相）供调频使用。
     Code captured_code;
     std::string captured_text;
+    // 识别候选是否为 T9 用户词：其 input_digits 与当前 unassigned 完全一致，
+    // 右选应全量消费（避免音节对齐不匹配导致 partial commit）。
+    bool is_t9_user = false;
     int rime_consumed =
-        QueryRimeConsumedDigits(candidate_pinyin, candidate_text, &captured_code, &captured_text);
-    T9LOG(">> SelectCandidate: rimeConsumedDigits=%d", rime_consumed);
+        QueryRimeConsumedDigits(candidate_pinyin, candidate_text, &captured_code, &captured_text,
+                                &is_t9_user);
+    // 左选场景时 RIME input 含左选拼音前缀，需加 consumed_count 得到总消费位数。
+    if (rime_consumed >= 0 && !input_buffer_.selections.empty()) {
+        rime_consumed += input_buffer_.consumed_count;
+    }
+    T9LOG(">> SelectCandidate: rimeConsumedDigits=%d (consumed=%d, isT9User=%d, hasSels=%d)",
+          rime_consumed, input_buffer_.consumed_count, is_t9_user ? 1 : 0,
+          !input_buffer_.selections.empty() ? 1 : 0);
     if (!captured_code.empty()) {
-        // 捕获随段模型同生命周期（Clear/undo 由段模型权威管理）；
-        // rime::Code → 段模型 RIME 无关表示（T9SyllableCode，同型互转）。
         undo_model_.PushCommitCapture(captured_text,
                                       T9SyllableCode(captured_code.begin(), captured_code.end()));
+        // 同步暂存调频捕获：跨异步上屏链路存活
+        pending_fullcommit_capture_ = {captured_text,
+                                       T9SyllableCode(captured_code.begin(),
+                                                      captured_code.end())};
         std::string ids;
         for (auto id : captured_code) ids += std::to_string(id) + ",";
         T9LOG(">> SelectCandidate: captured '%s' code=[%s] (%zu syl)",
               captured_text.c_str(), ids.c_str(), captured_code.size());
     }
 
+    // 构建召回索引：剩余数字序列 + 左选标记（场景 C）或纯左选（场景 D）。
+    const std::string digit_seq_before_commit = input_buffer_.digit_sequence;
+    const std::string unassigned = input_buffer_.unassigned();
+    std::string left_select_key = unassigned;
+    const bool is_first_select = last_commit_digit_sequence_.empty();
+    if (is_first_select && !input_buffer_.selections.empty()) {
+        if (!unassigned.empty())
+            left_select_key += ":";
+        for (const auto& sel : input_buffer_.selections)
+            left_select_key += sel.pinyin;
+    }
+    T9LOG(">> SelectCandidate: buf.digitSeq='%s', unassigned='%s', left_select_key='%s', selections=%zu, is_first=%d",
+          digit_seq_before_commit.c_str(),
+          unassigned.c_str(),
+          left_select_key.c_str(),
+          input_buffer_.selections.size(),
+          is_first_select ? 1 : 0);
+
     bool full_commit = right_commit_handler_.HandleRightCommit(
-        ctx, candidate_pinyin, candidate_text_length, rime_consumed);
+        ctx, candidate_pinyin, candidate_text_length, rime_consumed, is_t9_user);
 
     // 必须先把 handler 消费结果回写 input_buffer_（consumed/unassigned 更新）。
     ApplyHandlerContext(ctx);
 
-    // 调频不在此进行：由 Kotlin 在 full commit 上屏后经 MemorizeEntry 显式调用。
+    // 记录召回索引，供 MemorizeEntry 写入用户词典。
+    // partial commit 时如果 left_select_key 比已保存的短，保留之前的值不覆盖。
+    if (!last_commit_digit_sequence_.empty() &&
+        left_select_key.length() < last_commit_digit_sequence_.length()) {
+        // 被 partial commit 截断，不覆盖
+    } else {
+        last_commit_digit_sequence_ = left_select_key;
+    }
+    T9LOG(">> SelectCandidate: last_commit_digit_sequence_='%s' (left_select_key='%s', full=%d)",
+          last_commit_digit_sequence_.c_str(),
+          left_select_key.c_str(), full_commit ? 1 : 0);
 
     // ── 诊断日志：出口状态 ──
     T9LOG(">> SelectCandidate EXIT: full_commit=%d", full_commit ? 1 : 0);
@@ -686,37 +732,42 @@ bool T9Processor::UpdateDictEntry(const std::string& text,
 
 bool T9Processor::MemorizeEntry(const std::string& text,
                                 const std::string& pinyin) {
-    // 优先使用右选捕获的 (text, code)（含声调真相，见 T9UndoModel::commit_captures）：
-    // 事后无声调拼音解析会命中轻声音节（计划→ji/hua 轻声）导致调频码丢声调。
-    const auto& captures = undo_model_.commit_captures();
-    T9LOG(">> MemorizeEntry: text='%s' pinyin='%s' captures=%zu",
-          text.c_str(), pinyin.c_str(), captures.size());
-    if (!captures.empty()) {
-        auto pinyin_syllables = ParseSyllables(pinyin);
-        std::string captured_text;
-        size_t total_syllables = 0;
-        for (const auto& [seg_text, code] : captures) {
-            captured_text += seg_text;
-            total_syllables += code.size();
+    // 场景判定：full_code == input_digits → 写 RIME userdb，否则 → 写 T9 数字词典。
+    // capture 机制不再用于场景判定——多段拼接自造词的 capture 只存最后一段，文本不匹配。
+    T9LOG(">> MemorizeEntry digitSeq='%s' lastCommit='%s' consumed=%d",
+          input_buffer_.digit_sequence.c_str(),
+          last_commit_digit_sequence_.c_str(),
+          input_buffer_.consumed_count);
+    T9LOG(">> MemorizeEntry: text='%s' pinyin='%s'", text.c_str(), pinyin.c_str());
+
+    pending_fullcommit_capture_.reset();
+    undo_model_.ClearCommitCaptures();
+
+    const std::string& digits = last_commit_digit_sequence_;
+    std::string full_code_str = T9DigitUserDictCore::PinyinToFullCode(pinyin);
+
+    if (!full_code_str.empty() && !digits.empty() && full_code_str == digits) {
+        // 音节图可达 → 写 RIME userdb
+        DictEntry entry;
+        if (BuildEntryForPinyin(text, pinyin, &entry)) {
+            T9LOG(">> MemorizeEntry: full_code=='%s'==digits, write RIME userdb",
+                  full_code_str.c_str());
+            WriteDictEntry(text, entry.code, 1);
+        } else {
+            T9LOG(">> MemorizeEntry: BuildEntryForPinyin failed, fallback to T9 digit dict");
+            if (!text.empty() && !digits.empty()) {
+                T9DigitUserDict::Instance().Memorize(digits, text, pinyin);
+            }
         }
-        // 文本拼接 + 音节数双重校验：任一不符视为序列被中断的过期捕获，
-        // 作废后回退到拼音解析（避免把残留捕获误写到本次上屏文本上）。
-        if (captured_text == text && !pinyin_syllables.empty() &&
-            total_syllables == pinyin_syllables.size()) {
-            Code full_code;
-            for (const auto& [seg_text, code] : captures)
-                full_code.insert(full_code.end(), code.begin(), code.end());
-            undo_model_.ClearCommitCaptures();
-            std::string ids;
-            for (auto id : full_code) ids += std::to_string(id) + ",";
-            T9LOG(">> MemorizeEntry: USE CAPTURE code=[%s]", ids.c_str());
-            return WriteDictEntry(text, full_code, 1);
+    } else {
+        // 音节图不可达 → 写 T9 数字词典
+        if (!text.empty() && !digits.empty()) {
+            T9LOG(">> MemorizeEntry: full_code='%s' != digits='%s', write T9 digit dict",
+                  full_code_str.c_str(), digits.c_str());
+            T9DigitUserDict::Instance().Memorize(digits, text, pinyin);
         }
-        T9LOG(">> MemorizeEntry: capture mismatch (join='%s'), clear + fallback",
-              captured_text.c_str());
-        undo_model_.ClearCommitCaptures();  // 不匹配 → 作废过期捕获
     }
-    return UpdateDictEntry(text, pinyin, 1);
+    return true;
 }
 
 bool T9Processor::ForgetEntry(const std::string& text,
@@ -741,7 +792,8 @@ int T9Processor::QueryRimeConsumedDigits(
     const std::optional<std::string>& candidate_pinyin,
     const std::string& candidate_text,
     Code* captured_code,
-    std::string* captured_text) const {
+    std::string* captured_text,
+    bool* out_is_t9_user) const {
     // 方案 A：右选消费优先采用 RIME 候选的实际匹配范围。
     // RIME 已通过 schema 的 speller/algebra（含 derive/abbrev 派生规则）
     // 精确计算出候选在输入中的匹配结束位置（Candidate::end()），
@@ -775,6 +827,10 @@ int T9Processor::QueryRimeConsumedDigits(
             // 的候选（如 几股/击鼓 同注释 "ji gu"），避免捕获同注释他词的码。
             // text 为空（兼容/异常兜底）时退化为仅按注释匹配的旧行为。
             if (match_text && genuine->text() != candidate_text) continue;
+            // T9 用户词识别：候选 type=="t9_user"（T9UserTranslator 召回，
+            // SimpleCandidate，非 RIME Phrase）。其 input_digits 即组词时实际
+            // 输入序列（如 4482:j），右选时应全量消费 unassigned。
+            if (out_is_t9_user) *out_is_t9_user = (genuine->type() == "t9_user");
             // 顺带捕获 Phrase 的真实码（含声调真相），供调频保留声调。
             if (captured_code || captured_text) {
                 if (auto phrase = As<Phrase>(genuine)) {
@@ -1030,6 +1086,12 @@ void T9Processor::EnterIdle() {
     // 必须在 state_machine_ 之前清空 input_buffer_，否则 state sync 后
     // stale buffer 会导致后续 backspace 等操作在残留数据上处理。
     input_buffer_ = T9Buffer();
+    T9LOG(">> EnterIdle: clearing original_digit_sequence_='%s', last_commit='%s'",
+          original_digit_sequence_.c_str(),
+          last_commit_digit_sequence_.c_str());
+    original_digit_sequence_.clear();
+    last_commit_digit_sequence_.clear();
+    pending_fullcommit_capture_.reset();
     state_machine_.EnterIdle();
     left_column_locked_ = false;
     separator_consumed_digits_.reset();   // 修复（2026-08-06）：外部清空触发的

--- a/app/src/main/jni/librime-t9/src/t9_processor.h
+++ b/app/src/main/jni/librime-t9/src/t9_processor.h
@@ -181,14 +181,15 @@ private:
     // 换算为 T9 应消费的数字位数（RIME input[0:end) 中数字字符数，跳过分隔符）。
     // 候选按 comment 归一化匹配（容忍带调/无调差异，见 NormalizePinyinComment），
     // candidate_text 非空时再按文本双条件定位（同注释歧义防错码）。
-    // 返回 -1 表示无法确定（fallback 到现有 AlignWithBuffer 消费算法）。
-    // captured_code / captured_text（可空）：命中候选为 Phrase 时顺带捕获
-    // 其真实码（含声调真相）与文本，供 MemorizeEntry 调频保留声调。
+    // 返回 -1 表示无法确定（fallback 到现有消费算法）。
+    // captured_code / captured_text（可空）：命中候选为 Phrase 时顺带捕获其真实码。
+    // out_is_t9_user（可空）：命中候选为 T9 用户词时置 true。
     int QueryRimeConsumedDigits(
         const std::optional<std::string>& candidate_pinyin,
         const std::string& candidate_text,
         Code* captured_code = nullptr,
-        std::string* captured_text = nullptr) const;
+        std::string* captured_text = nullptr,
+        bool* out_is_t9_user = nullptr) const;
 
     // ════════════════════════════════════════
     // 状态成员（对应 Kotlin T9InputController 的私有字段）
@@ -206,6 +207,13 @@ private:
     std::string last_rime_input_;                        // 发送去重缓存
     int undone_right_commit_count_ = 0;                  // RightCommit 撤销计数（供 Kotlin 同步）
     char manual_delimiter_ = '\'';                       // 分隔符字符（从 speller.delimiter 读入）
+    std::string original_digit_sequence_;
+    std::string last_commit_digit_sequence_;
+    // 本次 FullCommit 右选的调频捕获，跨异步上屏链路存活。
+    // SelectCandidate 中同步暂存（避免 undo_model 在 EnterIdle 时被清空，
+    // 导致 MemorizeEntry 读到时为空、词典词被误判为场景 B/C）。
+    std::optional<std::pair<std::string, T9SyllableCode>>
+        pending_fullcommit_capture_;
     // 左侧候选区模式（2026-08-07，英文九键适配）：
     // 构造时按 engine/translators 是否含 script_translator 判定（auto），
     // 可被 t9/left_panel_mode: pinyin|none 显式覆盖。

--- a/app/src/main/jni/librime-t9/src/t9_right_commit_handler.cc
+++ b/app/src/main/jni/librime-t9/src/t9_right_commit_handler.cc
@@ -209,7 +209,8 @@ T9RightCommitHandler::ComputeRightCommitConsumption(
     const SyllableAlignment& alignment,
     const std::optional<std::string>& candidate_pinyin,
     RouteType route,
-    int rime_consumed_digits) {
+    int rime_consumed_digits,
+    bool is_t9_user_word) {
 
     T9_SCOPED_TIMER_TAG("T9RightCommit", "ComputeRightCommitConsumption");
     bool has_selections = !buf.selections.empty();
@@ -244,8 +245,16 @@ T9RightCommitHandler::ComputeRightCommitConsumption(
                 // S4-统一：直接使用 alignment 阶段2 的结果（unassigned_consumed 始终计算），
                 // 删除 ComputeConsumedDigitsMultiSyllable 兜底（单一算法，行为等价硬约束下
                 // 的 4 个对照场景 ZouDe/HaiHui/GuoHui/JieGouGuan 已验证一致）。
+                // T9 用户词：input_digits 即组词时的实际输入序列，与当前 unassigned
+                // 完全一致，必须全量消费（避免音节对齐不匹配导致 partial commit）。
                 int consumed_from_unassigned =
-                    align_observation.unassigned_consumed;
+                    is_t9_user_word
+                        ? static_cast<int>(unassigned.size())
+                        : align_observation.unassigned_consumed;
+                if (is_t9_user_word) {
+                    RCLOG(">>   apostrophe: t9_user word → full consume unassigned (%d)",
+                          consumed_from_unassigned);
+                }
                 RCLOG(">>   apostrophe: multi-syllable (alignment) sylCount=%zu sels=%d, unassignedConsumed=%d, unassigned='%s'",
                       syllables.size(), sel_count, consumed_from_unassigned, unassigned.c_str());
                 if (consumed_from_unassigned > 0) {
@@ -437,7 +446,8 @@ bool T9RightCommitHandler::HandleRightCommit(
     Context& ctx,
     const std::optional<std::string>& candidate_pinyin,
     int candidate_text_length,
-    int rime_consumed_digits) {
+    int rime_consumed_digits,
+    bool is_t9_user_word) {
 
     T9_SCOPED_TIMER_TAG("T9RightCommit", "HandleRightCommit");
     if (ctx.input_buffer.is_empty()) return true;
@@ -472,7 +482,8 @@ bool T9RightCommitHandler::HandleRightCommit(
     auto alignment = SyllableAlignment::FromCandidatePinyin(candidate_pinyin);
 
     auto consumption = ComputeRightCommitConsumption(
-        buf, alignment, candidate_pinyin, route, rime_consumed_digits);
+        buf, alignment, candidate_pinyin, route, rime_consumed_digits,
+        is_t9_user_word);
     const std::string& remaining_digits = consumption.second;
 
     RCLOG(">> HandleRightCommit: hasSels=%d, hasUnassigned=%d, route=%d, unassigned='%s'",

--- a/app/src/main/jni/librime-t9/src/t9_right_commit_handler.h
+++ b/app/src/main/jni/librime-t9/src/t9_right_commit_handler.h
@@ -115,10 +115,12 @@ public:
     // @param candidate_text_length 候选词文字长度（汉字数）
     // @param rime_consumed_digits 方案 A：RIME 候选 end 换算的应消费数字位数，
     //                             -1 表示无法确定（fallback 到现有消费算法）
+    // @param is_t9_user_word 候选是否为 T9 用户词：是则 unassigned 全量消费
     bool HandleRightCommit(Context& ctx,
                            const std::optional<std::string>& candidate_pinyin,
                            int candidate_text_length = 0,
-                           int rime_consumed_digits = -1);
+                           int rime_consumed_digits = -1,
+                           bool is_t9_user_word = false);
 
     // ── 策略共享公共服务 ──
     // 三个 Strategy 类通过 Context 与协调器交互所需的下层辅助。
@@ -178,12 +180,14 @@ private:
     //                  CRCC 与 ApostropheStrategy 共享，消除重复 ParseSyllables 调用
     // @param rime_consumed_digits 方案 A：RIME 候选 end 换算的应消费数字位数，
     //                             -1 表示无法确定（fallback 到现有消费算法）
+    // @param is_t9_user_word 候选是否为 T9 用户词：是则 unassigned 全量消费
     std::pair<std::string, std::string> ComputeRightCommitConsumption(
         const T9Buffer& buf,
         const SyllableAlignment& alignment,
         const std::optional<std::string>& candidate_pinyin,
         RouteType route,
-        int rime_consumed_digits = -1);
+        int rime_consumed_digits = -1,
+        bool is_t9_user_word = false);
 };
 
 }  // namespace rime

--- a/app/src/main/jni/librime-t9/src/t9_user_translator.cc
+++ b/app/src/main/jni/librime-t9/src/t9_user_translator.cc
@@ -1,0 +1,77 @@
+#include "t9_user_translator.h"
+
+#include <rime/config.h>
+#include <rime/context.h>
+#include <rime/engine.h>
+#include <rime/schema.h>
+
+#include "t9_digit_userdict.h"
+#include "t9_digit_userdict_core.h"
+#include "t9_log.h"
+
+namespace rime {
+
+int T9UserTranslation::Compare(an<Translation> other,
+                               const CandidateList& candidates) {
+  if (exhausted())
+    return 1;
+  if (!other)
+    return -1;
+  // 按 Candidate::compare（start→end→quality 降序）公平竞争。
+  // quality 由 Query 用 FormulaP 计算（与 RIME user_phrase 同公式同尺度），
+  // 点击调频有效——点"激化"多次后 weight 上升能超过"几户表"，反之亦然。
+  return Translation::Compare(other, candidates);
+}
+
+T9UserTranslator::T9UserTranslator(const Ticket& ticket) : Translator(ticket) {
+  // 从 schema config 读 initial_quality（t9 schema __include rime_ice，
+  // 继承 translator/initial_quality: 1.2）。
+  if (auto* schema = ticket.schema) {
+    if (auto* config = schema->config()) {
+      config->GetDouble("translator/initial_quality", &initial_quality_);
+    }
+  }
+}
+
+an<Translation> T9UserTranslator::Query(const string& input,
+                                        const Segment& segment) {
+  T9_LOG_DEBUG("T9UserTranslator", ">> Query input='%s'", input.c_str());
+  if (input.empty())
+    return nullptr;
+
+  std::string lookup_key = T9DigitUserDict::BuildLookupKey(input);
+  if (lookup_key.empty())
+    return nullptr;
+  T9_LOG_DEBUG("T9UserTranslator", ">> Query lookup_key='%s'", lookup_key.c_str());
+
+  auto entries = T9DigitUserDict::Instance().Lookup(lookup_key, 0);
+  T9_LOG_DEBUG("T9UserTranslator", ">> Query hits=%zu", entries.size());
+  if (entries.empty())
+    return nullptr;
+
+  // present_tick = T9 全局 tick + 1（对齐 RIME CreateDictEntry 的 tick_+1）。
+  double present_tick = (double)T9DigitUserDict::Instance().tick() + 1;
+
+  auto result = New<T9UserTranslation>();
+  for (const auto& e : entries) {
+    auto cand = New<SimpleCandidate>("t9_user", segment.start, segment.end,
+                                     e.text, e.pinyin, e.pinyin);
+    // quality 对齐 RIME user_phrase（script_translator.cc:657-659）：
+    //   formula_p(0, commits/present_tick, present_tick, adj_dee) +
+    //   initial_quality + quality_len/full_code_length
+    // T9 数字词典的词消费整个输入序列（exact match），quality_len/full_code = 1.0。
+    double adj_dee = T9DigitUserDictCore::FormulaD(
+        0.0, present_tick, e.dee, (double)e.last_tick);
+    double u = (double)e.commits / present_tick;
+    double p = T9DigitUserDictCore::FormulaP(0.0, u, present_tick, adj_dee);
+    double quality = p + initial_quality_ + 1.0;
+    cand->set_quality(quality);
+    T9_LOG_DEBUG("T9UserTranslator",
+                 ">> Query: cand text='%s' quality=%.6f (commits=%d dee=%.4f)",
+                 e.text.c_str(), quality, e.commits, e.dee);
+    result->Append(cand);
+  }
+  return result;
+}
+
+}  // namespace rime

--- a/app/src/main/jni/librime-t9/src/t9_user_translator.h
+++ b/app/src/main/jni/librime-t9/src/t9_user_translator.h
@@ -1,0 +1,33 @@
+#ifndef T9_USER_TRANSLATOR_H_
+#define T9_USER_TRANSLATOR_H_
+
+#include <rime/candidate.h>
+#include <rime/common.h>
+#include <rime/translation.h>
+#include <rime/translator.h>
+
+namespace rime {
+
+// T9UserTranslation — T9 数字词典候选 Translation。
+// quality 由 T9UserTranslator::Query 用 FormulaP 计算，在 Candidate::compare 中
+// 与 RIME 候选在同一 quality 尺度内公平竞争。层内排序由 Lookup 的 dee 降序保证。
+// 去重由 filter 链末尾的 uniquifier 兜底。
+class T9UserTranslation : public FifoTranslation {
+ public:
+  T9UserTranslation() = default;
+  int Compare(an<Translation> other,
+              const CandidateList& candidates) override;
+};
+
+class T9UserTranslator : public Translator {
+ public:
+  explicit T9UserTranslator(const Ticket& ticket);
+  an<Translation> Query(const string& input, const Segment& segment) override;
+
+ private:
+  double initial_quality_ = 0.0;  // 从 schema config 读取（继承 rime_ice 的 1.2）
+};
+
+}  // namespace rime
+
+#endif  // T9_USER_TRANSLATOR_H_

--- a/app/src/main/jni/librime-t9/test/t9_digit_userdict_core_test.cc
+++ b/app/src/main/jni/librime-t9/test/t9_digit_userdict_core_test.cc
@@ -1,0 +1,387 @@
+// T9DigitUserDictCore 单元测试
+// 覆盖：BuildLookupKey、PinyinToFullCode、序列化 roundtrip、
+// Memorize/Forget 索引维护、调频、召回排序、InsertFromStorage/Reset。
+#include <gtest/gtest.h>
+
+#include "t9_digit_userdict_core.h"
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+using rime::T9DigitUserDictCore;
+
+namespace {
+
+// 便捷：取 Lookup 结果文本列表
+std::vector<std::string> LookupTexts(T9DigitUserDictCore* core,
+                                     const std::string& key) {
+  std::vector<std::string> texts;
+  for (const auto& e : core->Lookup(key, 0))
+    texts.push_back(e.text);
+  return texts;
+}
+
+std::string GetValueOf(const std::vector<T9DigitUserDictCore::StorageOp>& ops,
+                       const std::string& key) {
+  for (const auto& op : ops) {
+    if (op.kind == T9DigitUserDictCore::StorageOp::kUpdate &&
+        op.key == key)
+      return op.value;
+  }
+  return {};
+}
+
+bool HasEraseOf(const std::vector<T9DigitUserDictCore::StorageOp>& ops,
+                const std::string& key) {
+  for (const auto& op : ops) {
+    if (op.kind == T9DigitUserDictCore::StorageOp::kErase &&
+        op.key == key)
+      return true;
+  }
+  return false;
+}
+
+// 找同 key 下某 text 的条目
+bool FindEntry(const std::vector<T9DigitUserDictCore::Entry>& entries,
+               const std::string& text,
+               T9DigitUserDictCore::Entry* out) {
+  for (const auto& e : entries) {
+    if (e.text == text) {
+      *out = e;
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+// ── BuildLookupKey ──
+
+TEST(T9DigitUserDictCoreTest, BuildLookupKey_PureDigits) {
+  EXPECT_EQ(T9DigitUserDictCore::BuildLookupKey("54482"), "54482");
+  EXPECT_EQ(T9DigitUserDictCore::BuildLookupKey(""), "");
+}
+
+TEST(T9DigitUserDictCoreTest, BuildLookupKey_WithLeftSelect) {
+  EXPECT_EQ(T9DigitUserDictCore::BuildLookupKey("j'4482"), "4482:j");
+  EXPECT_EQ(T9DigitUserDictCore::BuildLookupKey("ji'4482"), "4482:ji");
+  EXPECT_EQ(T9DigitUserDictCore::BuildLookupKey("JI'4482"), "4482:ji");
+}
+
+TEST(T9DigitUserDictCoreTest, BuildLookupKey_NoDigits) {
+  EXPECT_EQ(T9DigitUserDictCore::BuildLookupKey("km"), "km");
+  EXPECT_EQ(T9DigitUserDictCore::BuildLookupKey("k'm'"), "km");
+  EXPECT_EQ(T9DigitUserDictCore::BuildLookupKey("'"), "");
+}
+
+// ── PinyinToFullCode ──
+
+TEST(T9DigitUserDictCoreTest, PinyinToFullCode_MultiSyllable) {
+  EXPECT_EQ(T9DigitUserDictCore::PinyinToFullCode("ji hu biao"),
+            "54482426");
+  EXPECT_EQ(T9DigitUserDictCore::PinyinToFullCode("ji hua"), "54482");
+}
+
+TEST(T9DigitUserDictCoreTest, PinyinToFullCode_Invalid) {
+  EXPECT_EQ(T9DigitUserDictCore::PinyinToFullCode(""), "");
+}
+
+// ── 序列化 roundtrip ──
+
+TEST(T9DigitUserDictCoreTest, KeyValueRoundtrip) {
+  T9DigitUserDictCore::Entry e;
+  e.text = "几户表";
+  e.pinyin = "ji hu biao";
+  e.dee = 3.14159265358979;
+  e.commits = 7;
+  e.last_tick = 123456789;
+  e.full_code = "54482426";
+  e.input_digits = "54482";
+
+  std::string key =
+      T9DigitUserDictCore::BuildKey(e.input_digits, e.full_code, e.text);
+  EXPECT_EQ(key, "54482\t54482426\t几户表");
+
+  std::string input_digits, full_code, text;
+  ASSERT_TRUE(T9DigitUserDictCore::ParseKey(key, &input_digits, &full_code,
+                                            &text));
+  EXPECT_EQ(input_digits, "54482");
+  EXPECT_EQ(full_code, "54482426");
+  EXPECT_EQ(text, "几户表");
+
+  // 复合键（含左选）也可解析
+  std::string compound_key =
+      T9DigitUserDictCore::BuildKey("54482:ji", "54482426", "几户表");
+  std::string d2, c2, t2;
+  ASSERT_TRUE(T9DigitUserDictCore::ParseKey(compound_key, &d2, &c2, &t2));
+  EXPECT_EQ(d2, "54482:ji");
+
+  std::string value = T9DigitUserDictCore::PackValue(e);
+  T9DigitUserDictCore::Entry unpacked;
+  ASSERT_TRUE(T9DigitUserDictCore::UnpackValue(value, &unpacked));
+  EXPECT_EQ(unpacked.pinyin, "ji hu biao");
+  EXPECT_EQ(unpacked.commits, 7);
+  EXPECT_EQ(unpacked.last_tick, 123456789u);
+  EXPECT_DOUBLE_EQ(unpacked.dee, 3.14159265358979);
+}
+
+TEST(T9DigitUserDictCoreTest, UnpackValue_Invalid) {
+  T9DigitUserDictCore::Entry e;
+  EXPECT_FALSE(T9DigitUserDictCore::UnpackValue("garbage", &e));
+  EXPECT_FALSE(T9DigitUserDictCore::UnpackValue("p=x c=bad d=1.0 t=1", &e));
+}
+
+// ── Memorize / Lookup ──
+
+TEST(T9DigitUserDictCoreTest, Memorize_NewWord_LookupByDee) {
+  T9DigitUserDictCore core;
+  auto ops = core.Memorize("54482", "几户表", "ji hu biao");
+  ASSERT_EQ(ops.size(), 1u);
+  EXPECT_EQ(ops[0].kind, T9DigitUserDictCore::StorageOp::kUpdate);
+  EXPECT_EQ(ops[0].key, "54482\t54482426\t几户表");
+  EXPECT_FALSE(ops[0].value.empty());
+
+  auto entries = core.Lookup("54482", 0);
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].text, "几户表");
+  EXPECT_EQ(entries[0].commits, 1);
+  EXPECT_DOUBLE_EQ(entries[0].dee, 1.0);
+
+  auto again = core.Lookup("54482", 0);
+  ASSERT_EQ(again.size(), 1u);
+  EXPECT_EQ(again[0].text, "几户表");
+}
+
+TEST(T9DigitUserDictCoreTest, Lookup_EmptyForUnmatchedKey) {
+  T9DigitUserDictCore core;
+  core.Memorize("54482", "几户表", "ji hu biao");
+
+  // 无关序列的 Lookup：不命中
+  EXPECT_TRUE(core.Lookup("5432", 0).empty());
+  EXPECT_TRUE(core.Lookup("abc555", 0).empty());
+
+  // 命中原序列
+  auto entries = core.Lookup("54482", 0);
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].text, "几户表");
+}
+
+TEST(T9DigitUserDictCoreTest, Memorize_Repeat_UpdatesCommitsAndDee) {
+  T9DigitUserDictCore core;
+  core.Memorize("54482", "几户表", "ji hu biao");
+  auto ops = core.Memorize("54482", "几户表", "ji hu biao");
+  // 同 key 更新：仅 1 条 kUpdate（无旧 key erase）
+  ASSERT_EQ(ops.size(), 1u);
+  EXPECT_EQ(ops[0].kind, T9DigitUserDictCore::StorageOp::kUpdate);
+
+  auto entries = core.Lookup("54482", 0);
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].commits, 2);
+  // dee = 1 + 1*exp((t1-t2)/200) = 1 + exp(-0.005) ≈ 1.99501
+  EXPECT_NEAR(entries[0].dee, 1.0 + std::exp(-0.005), 1e-9);
+}
+
+TEST(T9DigitUserDictCoreTest, Memorize_InputDigitsMigration) {
+  T9DigitUserDictCore core;
+  core.Memorize("54482", "几户表", "ji hu biao");
+  // 之后用完整码上屏同一词 → input_digits 从 54482 迁移到 54482426
+  auto ops = core.Memorize("54482426", "几户表", "ji hu biao");
+  ASSERT_EQ(ops.size(), 2u);
+  EXPECT_TRUE(HasEraseOf(ops, "54482\t54482426\t几户表"));
+  EXPECT_FALSE(GetValueOf(ops, "54482426\t54482426\t几户表").empty());
+
+  // 旧键不可召回，新键可召回
+  EXPECT_TRUE(core.Lookup("54482", 0).empty());
+  EXPECT_EQ(LookupTexts(&core, "54482426").size(), 1u);
+}
+
+TEST(T9DigitUserDictCoreTest, Lookup_SortByDeeThenCommits) {
+  T9DigitUserDictCore core;
+  // 几户表：使用两次（dee≈1.995, commits=2）
+  core.Memorize("54482", "几户表", "ji hu biao");
+  core.Memorize("54482", "几户表", "ji hu biao");
+  // 几户啊：使用一次（dee=1, commits=1）
+  core.Memorize("54482", "几户啊", "ji hu a");
+
+  auto texts = LookupTexts(&core, "54482");
+  ASSERT_EQ(texts.size(), 2u);
+  EXPECT_EQ(texts[0], "几户表");  // dee 更高者在前
+  EXPECT_EQ(texts[1], "几户啊");
+}
+
+// ── 左选复合键还原前缀筛选（场景 B 词经左选路径召回）──
+
+TEST(T9DigitUserDictCoreTest, Lookup_LeftSelectRestoresFullDigits) {
+  T9DigitUserDictCore core;
+  core.Memorize("54482", "几户啊", "ji hu a");
+  core.Memorize("54482", "梨花", "li hua");
+  core.Memorize("482:ji", "里股草", "li gu cao");
+
+  // 左选 ji：精确匹配 "482:ji"（里股草，rank=0）+ 还原 "54482" 命中场景 B 词
+  auto texts = LookupTexts(&core, "482:ji");
+  ASSERT_EQ(texts.size(), 2u);
+  EXPECT_EQ(texts[0], "里股草");
+  EXPECT_EQ(texts[1], "几户啊");
+
+  // 左选 j（声母简拼，长度=1）：不做完整首音节还原，无精确匹配 → 命中 0
+  auto texts2 = LookupTexts(&core, "4482:j");
+  EXPECT_EQ(texts2.size(), 0u);
+
+  core.Memorize("4482:j", "三户地", "san hu di");
+  auto texts2b = LookupTexts(&core, "4482:j");
+  ASSERT_EQ(texts2b.size(), 1u);
+  EXPECT_EQ(texts2b[0], "三户地");
+
+  // 左选 li：还原 "54482"，首音节过滤：梨花(li)保留，几户啊(ji)过滤
+  auto texts3 = LookupTexts(&core, "482:li");
+  ASSERT_EQ(texts3.size(), 1u);
+  EXPECT_EQ(texts3[0], "梨花");
+}
+
+TEST(T9DigitUserDictCoreTest, Lookup_LeftSelectNoRestoreForPureDigits) {
+  T9DigitUserDictCore core;
+  core.Memorize("54482", "几户啊", "ji hu a");
+
+  // 纯数字 key（无冒号）：不触发左选还原，精确匹配
+  auto texts = LookupTexts(&core, "54482");
+  ASSERT_EQ(texts.size(), 1u);
+  EXPECT_EQ(texts[0], "几户啊");
+
+  // 纯左选 key（场景 D，无冒号）：精确匹配场景 D 词，不触发还原
+  core.Memorize("km", "昆明", "kun ming");
+  auto texts2 = LookupTexts(&core, "km");
+  ASSERT_EQ(texts2.size(), 1u);
+  EXPECT_EQ(texts2[0], "昆明");
+}
+
+// ── Forget ──
+
+TEST(T9DigitUserDictCoreTest, Forget_DecrementAndRemove) {
+  T9DigitUserDictCore core;
+  core.Memorize("54482", "几户表", "ji hu biao");
+  core.Memorize("54482", "几户表", "ji hu biao");  // commits=2
+
+  // 撤销一次：未归零，kUpdate + dee 下降
+  auto ops = core.Forget("54482", "几户表");
+  ASSERT_EQ(ops.size(), 1u);
+  EXPECT_EQ(ops[0].kind, T9DigitUserDictCore::StorageOp::kUpdate);
+  auto entries = core.Lookup("54482", 0);
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].commits, 1);
+  // dee = 0 + dee_old * exp((t_old - t_new)/200)：
+  //   dee_old（2次使用后）≈ 1.995，t_old=2 → t_new=3
+  double dee_after_two =
+      1.0 + std::exp(-0.005);  // 两次 Memorize 后的 dee
+  EXPECT_NEAR(entries[0].dee, dee_after_two * std::exp(-0.005), 1e-9);
+
+  // 再撤销一次：归零，kErase 删除
+  auto ops2 = core.Forget("54482", "几户表");
+  ASSERT_EQ(ops2.size(), 1u);
+  EXPECT_EQ(ops2[0].kind, T9DigitUserDictCore::StorageOp::kErase);
+  EXPECT_TRUE(core.Lookup("54482", 0).empty());
+}
+
+TEST(T9DigitUserDictCoreTest, Forget_UnknownKeyNoop) {
+  T9DigitUserDictCore core;
+  EXPECT_TRUE(core.Forget("99999", "不存在").empty());
+}
+
+// ── FormulaP quality 计算 ──
+
+TEST(T9DigitUserDictCoreTest, FormulaP_MatchesRIMEFormula) {
+  // 首次造词 commits=1, dee=1.0, tick=1, present_tick=2
+  double dee = T9DigitUserDictCore::FormulaD(1.0, 1.0, 0.0, 0.0);
+  EXPECT_NEAR(dee, 1.0, 0.001);
+  double adj_dee = T9DigitUserDictCore::FormulaD(0.0, 2.0, dee, 1.0);
+  double u = 1.0 / 2.0;
+  double p = T9DigitUserDictCore::FormulaP(0.0, u, 2.0, adj_dee);
+  double quality = p + 1.2 + 1.0;
+  EXPECT_GT(quality, 2.19);
+  EXPECT_LT(quality, 2.21);
+
+  // 点击 10 次 commits=10, dee≈9.78, tick=10, present_tick=11
+  dee = 0.0;
+  for (int i = 1; i <= 10; ++i) {
+    dee = T9DigitUserDictCore::FormulaD(1.0, (double)i, dee, (double)(i - 1));
+  }
+  adj_dee = T9DigitUserDictCore::FormulaD(0.0, 11.0, dee, 10.0);
+  u = 10.0 / 11.0;
+  p = T9DigitUserDictCore::FormulaP(0.0, u, 11.0, adj_dee);
+  quality = p + 1.2 + 1.0;
+  EXPECT_GT(quality, 2.21);
+  EXPECT_LT(quality, 2.23);
+}
+
+TEST(T9DigitUserDictCoreTest, FormulaP_QualityScaleAlignment) {
+  // T9 数字词典词与 RIME 候选在同一 quality 尺度内竞争：
+  // 点击次数越多 quality 越高，两者可互相超越。
+  auto compute_quality = [](int commits, int tick) {
+    double dee = 0.0;
+    for (int i = 1; i <= commits; ++i) {
+      dee = T9DigitUserDictCore::FormulaD(1.0, (double)i, dee, (double)(i - 1));
+    }
+    double present = (double)tick + 1;
+    double adj = T9DigitUserDictCore::FormulaD(0.0, present, dee, (double)tick);
+    double u = (double)commits / present;
+    double p = T9DigitUserDictCore::FormulaP(0.0, u, present, adj);
+    return p + 1.2 + 1.0;
+  };
+
+  // 几户表 commits=1 < 激化 commits=2 → 激化 quality 更高
+  double q_jihubiao_1 = compute_quality(1, 1);
+  double q_jihua_2 = compute_quality(2, 2);
+  EXPECT_GT(q_jihua_2, q_jihubiao_1);
+
+  // 几户表 commits=3 > 激化 commits=2 → 几户表 quality 更高
+  double q_jihubiao_3 = compute_quality(3, 3);
+  EXPECT_GT(q_jihubiao_3, q_jihua_2);
+}
+
+// ── InsertFromStorage / Reset（持久化加载路径） ──
+
+TEST(T9DigitUserDictCoreTest, InsertFromStorage_RebuildIndex) {
+  T9DigitUserDictCore core;
+  // 模拟 LevelDb 里已存在的两条记录
+  T9DigitUserDictCore::Entry e1;
+  e1.text = "几户表";
+  e1.pinyin = "ji hu biao";
+  e1.dee = 1.995;
+  e1.commits = 2;
+  e1.last_tick = 5;
+  e1.full_code = "54482426";
+  e1.input_digits = "54482";
+  core.InsertFromStorage(
+      T9DigitUserDictCore::BuildKey(e1.input_digits, e1.full_code, e1.text),
+      T9DigitUserDictCore::PackValue(e1));
+
+  T9DigitUserDictCore::Entry e2;
+  e2.text = "几户啊";
+  e2.pinyin = "ji hu a";
+  e2.dee = 1.0;
+  e2.commits = 1;
+  e2.last_tick = 3;
+  e2.full_code = "544822";  // ji hu a = 54 48 2
+  e2.input_digits = "54482";
+  core.InsertFromStorage(
+      T9DigitUserDictCore::BuildKey(e2.input_digits, e2.full_code, e2.text),
+      T9DigitUserDictCore::PackValue(e2));
+
+  // 可召回，且按 dee 降序
+  auto texts = LookupTexts(&core, "54482");
+  ASSERT_EQ(texts.size(), 2u);
+  EXPECT_EQ(texts[0], "几户表");
+  EXPECT_EQ(texts[1], "几户啊");
+
+  // Reset 后清空
+  core.Reset();
+  EXPECT_TRUE(core.Lookup("54482", 0).empty());
+  EXPECT_EQ(core.tick(), 0u);
+}
+
+TEST(T9DigitUserDictCoreTest, InsertFromStorage_IgnoresBadValue) {
+  T9DigitUserDictCore core;
+  core.InsertFromStorage("54482\t54482426\t几户表", "not-a-value");
+  EXPECT_TRUE(core.Lookup("54482", 0).empty());
+}

--- a/app/src/main/jni/librime-t9/test/t9_preedit_converter_test.cc
+++ b/app/src/main/jni/librime-t9/test/t9_preedit_converter_test.cc
@@ -4,7 +4,8 @@
 // 覆盖场景：常规多音节、末尾简拼、单段多音节、中文混合、空 comment
 #include <gtest/gtest.h>
 
-#include "t9_filter.h"
+#include "t9_filter.h"            // T9ConvertPreedit / T9ConvertCandidatePreedit
+#include "t9_pinyin_map.h"        // NormalizePinyinComment
 
 using rime::T9ConvertPreedit;
 using rime::T9ConvertCandidatePreedit;
@@ -205,15 +206,16 @@ TEST(NormalizePinyinCommentTest, TonedAndTonelessEquivalent) {
 }
 
 TEST(NormalizePinyinCommentTest, Basic) {
-    EXPECT_EQ(rime::NormalizePinyinComment("jì huà"), "jihua");
-    EXPECT_EQ(rime::NormalizePinyinComment("ji hua"), "jihua");
-    EXPECT_EQ(rime::NormalizePinyinComment("jī guā"), "jigua");
+    // 保留空格（音节分隔符），声调归一化为无声调 ASCII
+    EXPECT_EQ(rime::NormalizePinyinComment("jì huà"), "ji hua");
+    EXPECT_EQ(rime::NormalizePinyinComment("ji hua"), "ji hua");
+    EXPECT_EQ(rime::NormalizePinyinComment("jī guā"), "ji gua");
 }
 
 TEST(NormalizePinyinCommentTest, NeutralTonePreserved) {
-    // 轻声音节（簸箕 ji / 笑话 hua）全 ASCII，归一化原样保留
-    EXPECT_EQ(rime::NormalizePinyinComment("bò ji"), "boji");
-    EXPECT_EQ(rime::NormalizePinyinComment("xiào hua"), "xiaohua");
+    // 轻声音节（簸箕 ji / 笑话 hua）全 ASCII，归一化原样保留（含空格）
+    EXPECT_EQ(rime::NormalizePinyinComment("bò ji"), "bo ji");
+    EXPECT_EQ(rime::NormalizePinyinComment("xiào hua"), "xiao hua");
     EXPECT_EQ(rime::NormalizePinyinComment("ji"), "ji");
     EXPECT_EQ(rime::NormalizePinyinComment("hua"), "hua");
 }
@@ -225,6 +227,6 @@ TEST(NormalizePinyinCommentTest, NonLetterCharsDropped) {
 }
 
 TEST(NormalizePinyinCommentTest, UppercaseNormalized) {
-    EXPECT_EQ(rime::NormalizePinyinComment("JĪ HUÀ"), "jihua");
-    EXPECT_EQ(rime::NormalizePinyinComment("JI HUA"), "jihua");
+    EXPECT_EQ(rime::NormalizePinyinComment("JĪ HUÀ"), "ji hua");
+    EXPECT_EQ(rime::NormalizePinyinComment("JI HUA"), "ji hua");
 }

--- a/app/src/main/jni/librime_jni/rime_jni.cc
+++ b/app/src/main/jni/librime_jni/rime_jni.cc
@@ -6,6 +6,7 @@
 #include <rime/dict/reverse_lookup_dictionary.h>
 #include "t9_processor.h"
 #include "t9_patch_utils.h"
+#include "t9_digit_userdict.h"
 #include <jni.h>
 #include <android/log.h>
 #include <memory>
@@ -937,7 +938,18 @@ Java_com_kingzcheung_xime_rime_RimeEngine_nativeInitialize(
     
     LOGI("Initializing Rime engine with user_dir=%s, shared_dir=%s", user_dir, shared_dir);
     Rime::Instance().startup(user_dir, shared_dir);
-    
+
+    // 初始化 T9 数字序列用户词典持久化路径（全局唯一，不依赖 schema 部署）。
+    // SetFilePath 内部 loaded_ 标志防重复 Open。
+    {
+        static bool t9_db_initialized = false;
+        if (!t9_db_initialized) {
+            rime::T9DigitUserDict::SetFilePath(
+                std::string(user_dir) + "/t9_digit.userdb");
+            t9_db_initialized = true;
+        }
+    }
+
     env->ReleaseStringUTFChars(user_data_dir, user_dir);
     env->ReleaseStringUTFChars(shared_data_dir, shared_dir);
 }
@@ -1355,29 +1367,6 @@ static bool T9PackTableBinMissing(const std::string& user_data_dir,
     return true;
 }
 
-// 从文本中解析布尔开关（如 "enable_abbrev_recall: false"）。
-// 找不到关键字或值无法识别时返回 default_val；支持 "true/false" 与 "1/0"。
-static bool ParseBoolSetting(const std::string& text,
-                             const std::string& key,
-                             bool default_val) {
-    auto pos = text.find(key);
-    if (pos == std::string::npos)
-        return default_val;
-    auto colon = text.find(':', pos);
-    auto nl = text.find('\n', pos);
-    if (colon == std::string::npos)
-        return default_val;
-    if (nl != std::string::npos && colon >= nl)
-        return default_val;
-    std::string val = text.substr(
-        colon + 1, (nl == std::string::npos ? text.size() : nl) - colon - 1);
-    if (val.find("false") != std::string::npos || val.find('0') != std::string::npos)
-        return false;
-    if (val.find("true") != std::string::npos || val.find('1') != std::string::npos)
-        return true;
-    return default_val;
-}
-
 // 读取文件全文到 out（文件不存在或读取失败返回 false）。
 static bool ReadFileToString(const std::string& path, std::string& out) {
     FILE* f = fopen(path.c_str(), "r");
@@ -1391,7 +1380,7 @@ static bool ReadFileToString(const std::string& path, std::string& out) {
     return true;
 }
 
-// 从文本中剔除含任一 needle 的行（用于移除已注入的 derive 简拼补丁）。
+// 从文本中剔除含任一 needle 的行。
 static std::string StripLinesContaining(const std::string& text,
                                         const std::vector<std::string>& needles) {
     std::string result;
@@ -1421,7 +1410,6 @@ static std::string StripLinesContaining(const std::string& text,
 //   - 判定 T9 方案：schema_id 含 "t9"，或 schema.yaml 的 schema_id 字段含 "t9"。
 //   - 补齐缺失组件：t9_processor / t9_filter / t9_date_translator /
 //     t9/isDisplayOriginalPreedit / t9/enable_date_translator（schema 已有则尊重）。
-//   - 拼音方案（含 script_translator）按 t9/enable_abbrev_recall 注入/移除 derive 简拼长词。
 //   - 修复畸形 translator/packs（个人词库），合法补丁尊重、缺失交由 PersonalDictManager。
 // 返回 true 表示写入后词库/补丁尚未编译，调用方可据此触发部署。
 static jboolean DoEnsureT9SchemaPatches(
@@ -1498,60 +1486,28 @@ static jboolean DoEnsureT9SchemaPatches(
         patch_lines.push_back(
             std::string("  \"t9/isDisplayOriginalPreedit\": ") + preedit_default);
     }
+    // t9_user_translator 占据 translators 首位。
+    // 旧版 t9_date_translator 注入在 @before 0，与新 user 冲突，迁移到 @after 0。
+    const bool legacy_date_before0 =
+        existing_content.find("\"engine/translators/@before 0\": t9_date_translator") != std::string::npos;
+    if (schema_content.find("t9_user_translator") == std::string::npos &&
+        existing_content.find("t9_user_translator") == std::string::npos) {
+        patch_lines.push_back("  \"engine/translators/@before 0\": t9_user_translator");
+    }
     if (schema_content.find("t9_date_translator") == std::string::npos &&
-        existing_content.find("t9_date_translator") == std::string::npos) {
-        patch_lines.push_back("  \"engine/translators/@before 0\": t9_date_translator");
+        (existing_content.find("t9_date_translator") == std::string::npos ||
+         legacy_date_before0)) {
+        patch_lines.push_back("  \"engine/translators/@after 0\": t9_date_translator");
+    }
+    if (schema_content.find("t9/enable_date_translator") == std::string::npos &&
+        existing_content.find("t9/enable_date_translator") == std::string::npos) {
         patch_lines.push_back("  \"t9/enable_date_translator\": true");
     }
 
-    // 简拼长词召回（t9/enable_abbrev_recall）：作为 t9 段一等开关，与
-    // isDisplayOriginalPreedit / enable_date_translator 对齐——schema 未声明时写入 custom。
-    // 仅拼音方案（含 script_translator）支持；英文 T9 方案剥离简拼召回。
-    //
-    // 为什么默认 true：九键输入的是数字序列，用户期望短序列命中长词（如输入 54482
-    // 打出"几乎把"）。若只靠完整拼音匹配，"几乎把"（ji hu ba = 544822）必须输完 6 位
-    // 才出现，5 位输入时在 RIME 原生 SyllableGraph 中不可达，体验差。注入 derive 简拼
-    // 让完整拼音词派生首字母（j h b）与 zh/ch/sh 双字母简拼，使 54482 即可召回这类长词。
-    //
-    // 如何工作：向 speller/algebra 注入两条 derive 规则，派生编码经方案既有的九宫格
-    // 数字映射（derive/[abc]/2/ 等）可被数字序列输入命中；Script::Merge 对同 spelling
-    // 取更优类型（normal 优先），简拼边不遮蔽正常拼写。
-    //
-    // 开启表现：54482 候选含"几乎把/几乎从/连环画"等简拼长词，右选后可调频置顶。
-    // 关闭表现：仅全拼词组与单字（输入序列 = 完整拼音数字序列）出现，且仍可正常调频；
-    // 但"几乎吧"（544822，序列长于 54482）这类简拼长词不会出现，无法右选调频——
-    // 调频仅对"输入序列完整覆盖其编码"的词生效。
-    const bool is_pinyin_schema = schema_content.find("script_translator") != std::string::npos;
-    const bool has_abbrev_schema = schema_content.find("enable_abbrev_recall") != std::string::npos;
-    const bool has_abbrev_custom = existing_content.find("enable_abbrev_recall") != std::string::npos;
+    // 清理已废弃的 enable_abbrev_recall 产物
     const bool has_derive = existing_content.find("derive/^([a-z])") != std::string::npos;
-
-    bool enable_abbrev_recall = false;
-    if (is_pinyin_schema) {
-        enable_abbrev_recall = ParseBoolSetting(schema_content, "enable_abbrev_recall", true);
-        enable_abbrev_recall =
-            ParseBoolSetting(existing_content, "enable_abbrev_recall", enable_abbrev_recall);
-        if (!has_abbrev_schema && !has_abbrev_custom) {
-            patch_lines.push_back(std::string("  \"t9/enable_abbrev_recall\": ") +
-                                  (enable_abbrev_recall ? "true" : "false"));
-        }
-    }
-
-    // derive 简拼长词补丁的注入/移除：开关 true 且未注入 → 注入；false 且已注入 → 移除。
-    bool need_remove_derive = false;
-    bool abbrev_patch_changed = false;  // derive 注入或移除，需重新编译 speller
-    if (enable_abbrev_recall) {
-        if (!has_derive) {
-            // 两条 derive 必须用不同 @before 索引（YAML map key 不能重复），
-            // 否则后者覆盖前者导致普通简拼 derive 丢失。
-            patch_lines.push_back("  \"speller/algebra/@before 0\": \"derive/^([a-z]).+$/$1/\"");
-            patch_lines.push_back("  \"speller/algebra/@before 1\": \"derive/^([zcs]h).+$/$1/\"");
-            abbrev_patch_changed = true;
-        }
-    } else if (has_derive) {
-        need_remove_derive = true;
-        abbrev_patch_changed = true;
-    }
+    const bool has_abbrev_custom = existing_content.find("enable_abbrev_recall") != std::string::npos;
+    bool need_remove_derive = has_derive || has_abbrev_custom;
 
     // translator/packs 个人词库：合法保留 / 畸形修复 / 缺失交由 PersonalDictManager。
     const std::string packs_name = "user_" + rime::t9_patch_utils::SanitizePackName(schema);
@@ -1578,10 +1534,14 @@ static jboolean DoEnsureT9SchemaPatches(
         return need_deploy ? JNI_TRUE : JNI_FALSE;
     }
 
-    // 开关关闭时移除已注入的 derive 行。
+    // 清理废弃的 enable_abbrev_recall 产物：移除 derive 简拼行和开关行。
     std::string base = existing_content;
     if (need_remove_derive) {
-        base = StripLinesContaining(base, {"derive/^([a-z])", "derive/^([zcs]h)"});
+        base = StripLinesContaining(base, {"derive/^([a-z])", "derive/^([zcs]h)", "enable_abbrev_recall"});
+    }
+    // 迁移旧版 translators/@before 0 的 date 行（与 user 冲突）
+    if (legacy_date_before0) {
+        base = StripLinesContaining(base, {"engine/translators/@before 0"});
     }
 
     // 剥离末尾 "..." 与空白，使追加的 patch 被 RIME 正常解析。
@@ -1628,12 +1588,12 @@ static jboolean DoEnsureT9SchemaPatches(
         actual_pack_name = packs_name;
     }
 
-    LOGI("T9Patches: applied '%s' (abbrev=%d, packs=%s)", schema,
-         enable_abbrev_recall ? 1 : 0, actual_pack_name.c_str());
+    LOGI("T9Patches: applied '%s' (packs=%s)", schema,
+         actual_pack_name.c_str());
 
     // 返回 true 表示词库/补丁尚未编译，调用方可据此触发部署。
     const bool need_deploy =
-        T9PackTableBinMissing(user_data_dir, actual_pack_name) || abbrev_patch_changed;
+        T9PackTableBinMissing(user_data_dir, actual_pack_name);
     return need_deploy ? JNI_TRUE : JNI_FALSE;
 }
 
@@ -1829,6 +1789,8 @@ Java_com_kingzcheung_xime_rime_RimeEngine_nativeDestroy(
     jobject thiz
 ) {
     LOGI("Destroying Rime engine");
+    // Compact T9 数字词典（flush WAL 为 .ldb），确保进程退出时数据持久化。
+    rime::T9DigitUserDict::CompactDb();
     Rime::Instance().destroy();
 }
 


### PR DESCRIPTION
@kingzcheung 请协助审阅下，目前解决九键用户词典无法召回长词的缺陷，详细解决方案见关联issue中最新描述。

## 概述

  为解决目前用户词典输入过词语召回上缺陷，无法召回自造词的输入序列大于造词时输入序列，决定采用新思路实现。目前已经实现，对(内建九键/雾凇/白霜/万象)等做了支持。完整的设计方案见 关联issue中详细描述。

## 关联 Issue

Closes #681 

## 改动类型

- [x] 新功能
- [ ] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
