### PR TITLE
fix(input-method): 修复快速打字时按键被吞的问题

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,8 +43,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 20260825
-        versionName = "2.7.0"
+        versionCode = 20260826
+        versionName = "2.7.1"
 
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
@@ -414,8 +414,12 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                                 val processed = service.rimeEngine.processKey(charCode, 0)
                                 if (processed) {
                                     val result = service.rimeEngine.getProcessResult(processed)
+                                    // commitText 不走 CONFLATED channel：channel 会覆盖丢弃未消费事件，
+                                    // 快速打字时中间的 commitText 会被吞（吃键）。
+                                    if (result.committedText.isNotEmpty()) {
+                                        withContext(Dispatchers.Main) { service.commitText(result.committedText) }
+                                    }
                                     service.uiEventChannel.trySend {
-                                        if (result.committedText.isNotEmpty()) service.commitText(result.committedText)
                                         service.sessionController.updateUIWithResult(result)
                                         if (service.calculatorEngine.isActive()) updateCalculatorCandidates()
                                     }
@@ -450,8 +454,10 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                                             if (service.calculatorEngine.isActive()) updateCalculatorCandidates()
                                         }
                                     } else {
+                                        if (committed.isNotEmpty()) {
+                                            withContext(Dispatchers.Main) { service.commitText(committed) }
+                                        }
                                         service.uiEventChannel.trySend {
-                                            if (committed.isNotEmpty()) service.commitText(committed)
                                             service.sessionController.updateUIWithResult(result)
                                             if (service.calculatorEngine.isActive()) updateCalculatorCandidates()
                                         }
@@ -496,10 +502,10 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                 val result = pendingResult
                 val textToCommit = committedText
                 if (result != null) {
+                    if (textToCommit != null) {
+                        withContext(Dispatchers.Main) { service.commitText(textToCommit) }
+                    }
                     service.uiEventChannel.trySend {
-                        if (textToCommit != null) {
-                            service.commitText(textToCommit)
-                        }
                         service.sessionController.updateUIWithResult(result)
                         if (service.calculatorEngine.isActive()) {
                             updateCalculatorCandidates()
@@ -511,10 +517,10 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                     val capturedIsAscii = service.rimeEngine.isAsciiMode()
                     val capturedHasNext = service.rimeEngine.hasNextPage()
                     val capturedHasPrev = service.rimeEngine.hasPrevPage()
+                    if (textToCommit != null) {
+                        withContext(Dispatchers.Main) { service.commitText(textToCommit) }
+                    }
                     service.uiEventChannel.trySend {
-                        if (textToCommit != null) {
-                            service.commitText(textToCommit)
-                        }
                         val pendingEnglish = service.candidateState.value.pendingEnglishText
                         val (filteredTexts, filteredComments) = if (capturedIsAscii) {
                             val filtered = capturedCandidates.filterNot { candidate ->

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -979,9 +979,8 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                               KeyboardResizeOverlay(
                                      initialHeightDp = state.resizePreviewHeightDp,
                                      defaultHeightDp = SettingsPreferences.getDefaultKeyboardHeightDp(this@XimeInputMethodService, isLandscape),
-                                    maxContainerHeightDp = state.resizePreviewHeightDp + state.keyboardBottomPaddingDp,
-                                   currentBottomPaddingDp = state.keyboardBottomPaddingDp,
-                                  onHeightChange = { newHeight ->
+                                     currentBottomPaddingDp = state.keyboardBottomPaddingDp,
+                                     onHeightChange = { newHeight ->
                                        uiState.value = uiState.value.copy(
                                            resizePreviewHeightDp = newHeight
                                        )

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
@@ -143,8 +143,10 @@ fun KeyButton(
     val swipeDownThreshold = with(density) { 50.dp.toPx() }
     val bubbleShowThresholdUp = swipeUpThreshold
     val bubbleShowThresholdDown = swipeDownThreshold
-    // 水平位移超过该值视为横向手势（如键盘区滑动移动光标），不再触发点击
-    val horizontalClickCancelThreshold = with(density) { 30.dp.toPx() }
+    // 水平位移超过该值视为横向手势（如键盘区滑动移动光标），不再触发点击。
+    // 与 KeyboardView 光标手势激活阈值（activationThresholdPx = 60dp）对齐，
+    // 消除 30~60dp 位移区间"点击被取消但光标手势未激活"的死区（打字吃键）。
+    val horizontalClickCancelThreshold = with(density) { 60.dp.toPx() }
 
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, backgroundColor) {
         if (shadowEnabled) {
@@ -260,9 +262,14 @@ fun KeyButton(
                             onPress = {
                                 isPressed = true
                                 onPress?.invoke()
-                                tryAwaitRelease()
-                                isPressed = false
-                                currentOnRelease?.invoke()
+                                val released = tryAwaitRelease()
+                                // 位移/消费导致的取消：保留按压效果，由 onDragEnd/onDragCancel 统一清理，
+                                // 避免快速打字时按压反馈提前消失（无气泡感）。
+                                // outOfBounds 取消但拖动未激活时立即清理，防止状态泄漏。
+                                if (released || !dragActivated) {
+                                    isPressed = false
+                                    currentOnRelease?.invoke()
+                                }
                             },
                             onTap = {
                                 if (!dragActivated && !hasTriggeredSwipeUp && !hasTriggeredSwipeDown) currentOnClick()
@@ -274,9 +281,11 @@ fun KeyButton(
                                 isPressed = true
                                 longPressActivated = false
                                 onPress?.invoke()
-                                tryAwaitRelease()
-                                isPressed = false
-                                currentOnRelease?.invoke()
+                                val released = tryAwaitRelease()
+                                if (released || !dragActivated) {
+                                    isPressed = false
+                                    currentOnRelease?.invoke()
+                                }
                             },
                             onTap = {
                                 if (!dragActivated && !hasTriggeredSwipeUp && !hasTriggeredSwipeDown && !longPressActivated) {
@@ -402,8 +411,10 @@ fun SwipeableKeyButton(
     val swipeDownThreshold = with(density) { 50.dp.toPx() }
     val bubbleShowThresholdUp = swipeUpThreshold
     val bubbleShowThresholdDown = swipeDownThreshold
-    // 水平位移超过该值视为横向手势（如键盘区滑动移动光标），不再触发点击
-    val horizontalClickCancelThreshold = with(density) { 30.dp.toPx() }
+    // 水平位移超过该值视为横向手势（如键盘区滑动移动光标），不再触发点击。
+    // 与 KeyboardView 光标手势激活阈值（activationThresholdPx = 60dp）对齐，
+    // 消除 30~60dp 位移区间"点击被取消但光标手势未激活"的死区（打字吃键）。
+    val horizontalClickCancelThreshold = with(density) { 60.dp.toPx() }
 
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, backgroundColor) {
         if (shadowEnabled) {
@@ -514,10 +525,12 @@ fun SwipeableKeyButton(
                             isPressed = true
                             currentOnSwipeStateChange?.invoke(SwipeState(isPressed = true, pressedText = currentText), buttonBounds)
                             currentOnPress?.invoke()
-                            tryAwaitRelease()
-                            isPressed = false
-                            currentOnRelease?.invoke()
-                            currentOnSwipeStateChange?.invoke(SwipeState(false, null, false, emptyList(), false, null), buttonBounds)
+                            val released = tryAwaitRelease()
+                            if (released || !dragActivated) {
+                                isPressed = false
+                                currentOnRelease?.invoke()
+                                currentOnSwipeStateChange?.invoke(SwipeState(false, null, false, emptyList(), false, null), buttonBounds)
+                            }
                         },
                         onTap = {
                             if (!dragActivated && !hasTriggeredSwipeUp && !hasTriggeredSwipeDown) currentOnClick()
@@ -961,8 +974,10 @@ fun SwipeableIconKeyButton(
     // 上滑清空/下滑撤回需要更大的滑动距离，防止误触
     val clearActionThreshold = with(density) { (-50).dp.toPx() }
     val undoActionThreshold = with(density) { 50.dp.toPx() }
-    // 水平位移超过该值视为横向手势（如键盘区滑动移动光标），不再触发点击
-    val horizontalClickCancelThreshold = with(density) { 30.dp.toPx() }
+    // 水平位移超过该值视为横向手势（如键盘区滑动移动光标），不再触发点击。
+    // 与 KeyboardView 光标手势激活阈值（activationThresholdPx = 60dp）对齐，
+    // 消除 30~60dp 位移区间"点击被取消但光标手势未激活"的死区（打字吃键）。
+    val horizontalClickCancelThreshold = with(density) { 60.dp.toPx() }
     
     LaunchedEffect(isLongPress) {
         if (isLongPress && onLongClick != null) {
@@ -1012,10 +1027,12 @@ fun SwipeableIconKeyButton(
                     onPress = {
                         isPressed = true
                         onPress?.invoke()
-                        tryAwaitRelease()
-                        isPressed = false
-                        currentOnRelease?.invoke()
-                        isLongPress = false
+                        val released = tryAwaitRelease()
+                        if (released || !dragActivated) {
+                            isPressed = false
+                            currentOnRelease?.invoke()
+                            isLongPress = false
+                        }
                     },
                     onTap = {
                         if (!dragActivated && !isDragging && !hasTriggeredLongPress) {
@@ -1034,7 +1051,6 @@ fun SwipeableIconKeyButton(
                         dragActivated = true
                         isDragging = true
                         isPressed = true
-                        isLongPress = false
                         dragOffsetY = 0f
                         dragOffsetX = 0f
                         hasTriggeredSwipe = false
@@ -1059,7 +1075,7 @@ fun SwipeableIconKeyButton(
                         } else if (dragOffsetY < swipeUpThreshold && !hasTriggeredSwipe && onSwipe != null) {
                             hasTriggeredSwipe = true
                             onSwipe()
-                        } else if (!hasTriggeredSwipeLeft && abs(dragOffsetX) < horizontalClickCancelThreshold) {
+                        } else if (!hasTriggeredLongPress && !hasTriggeredSwipeLeft) {
                             currentOnClick()
                         }
                         dragActivated = false
@@ -1077,6 +1093,8 @@ fun SwipeableIconKeyButton(
                         hasReachedClearThreshold = false
                         hasReachedUndoThreshold = false
                         isLongPress = false
+                        // 手势结束（含位移场景 tap 取消）必须重置，否则残留 true 会吞掉后续点击
+                        hasTriggeredLongPress = false
                         onSwipeStateChange?.invoke(SwipeState(), buttonBounds)
                     },
                     onDragCancel = {
@@ -1095,11 +1113,18 @@ fun SwipeableIconKeyButton(
                         hasReachedClearThreshold = false
                         hasReachedUndoThreshold = false
                         isLongPress = false
+                        hasTriggeredLongPress = false
                         onSwipeStateChange?.invoke(SwipeState(), buttonBounds)
                     },
                     onDrag = { change, dragAmount ->
                         dragOffsetY += dragAmount.y
                         dragOffsetX += dragAmount.x
+                        
+                        // 位移超过手势阈值才打断长按（轻微抖动不中断重复删除），
+                        // 阈值与各手势触发阈值一致（左滑 -50dp / 上滑 -50dp / 下滑 50dp / 右滑 60dp）
+                        if (isLongPress && (dragOffsetY < swipeUpThreshold || dragOffsetY > swipeDownThreshold || dragOffsetX < swipeLeftThreshold || dragOffsetX > horizontalClickCancelThreshold)) {
+                            isLongPress = false
+                        }
                         
                         if (dragOffsetX < swipeLeftThreshold && !hasTriggeredSwipeLeft && onSwipeLeft != null) {
                             hasTriggeredSwipeLeft = true

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardResizeOverlay.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardResizeOverlay.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
@@ -40,7 +39,6 @@ import kotlin.math.roundToInt
 fun KeyboardResizeOverlay(
     initialHeightDp: Int,
     defaultHeightDp: Int,
-    maxContainerHeightDp: Int,
     currentBottomPaddingDp: Int,
     onHeightChange: (Int) -> Unit,
     onBottomPaddingChange: (Int) -> Unit,
@@ -77,14 +75,9 @@ fun KeyboardResizeOverlay(
     val currentOnBottomPaddingChange by rememberUpdatedState(onBottomPaddingChange)
     val currentOnReset by rememberUpdatedState(onReset)
 
-    val dragThrottleMs = 50L
-    var lastHeightCallbackMs by remember { mutableLongStateOf(0L) }
-    var lastPaddingCallbackMs by remember { mutableLongStateOf(0L) }
-
     Box(
         modifier = modifier
             .background(Color.Transparent)
-            .height(maxContainerHeightDp.dp)
             .fillMaxWidth()
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
@@ -94,7 +87,7 @@ fun KeyboardResizeOverlay(
     ) {
         Box(
             modifier = Modifier
-                .align(Alignment.TopCenter)
+                .align(Alignment.BottomCenter)
                 .height((currentHeightDp + currentBottomPaddingDpState).roundToInt().dp)
                 .fillMaxWidth()
                 .background(Color.Black.copy(alpha = 0.5f))
@@ -105,11 +98,6 @@ fun KeyboardResizeOverlay(
                             val paddingChangeDp = with(density) { -dragAmount.y.toDp().value }
                             currentBottomPaddingDpState = (currentBottomPaddingDpState + paddingChangeDp)
                                 .coerceIn(0f, maxBottomPaddingDp.toFloat())
-                            val now = System.currentTimeMillis()
-                            if (now - lastPaddingCallbackMs >= dragThrottleMs) {
-                                currentOnBottomPaddingChange(currentBottomPaddingDpState.roundToInt())
-                                lastPaddingCallbackMs = now
-                            }
                         },
                         onDragEnd = {
                             currentOnBottomPaddingChange(currentBottomPaddingDpState.roundToInt())
@@ -130,11 +118,6 @@ fun KeyboardResizeOverlay(
                                 val heightChangeDp = with(density) { -dragAmount.y.toDp().value }
                                 currentHeightDp = (currentHeightDp + heightChangeDp)
                                     .coerceIn(minKeyboardHeightDp.toFloat(), maxKeyboardHeightDp.toFloat())
-                                val now = System.currentTimeMillis()
-                                if (now - lastHeightCallbackMs >= dragThrottleMs) {
-                                    currentOnHeightChange(currentHeightDp.roundToInt())
-                                    lastHeightCallbackMs = now
-                                }
                             },
                             onDragEnd = {
                                 currentOnHeightChange(currentHeightDp.roundToInt())


### PR DESCRIPTION
- 在 ImeKeyRouter 中将 commitText 操作移到 Main dispatcher， 避免 CONFLATED channel 覆盖未消费事件导致按键丢失
- 统一 key button 按压状态管理逻辑，确保在拖拽激活时正确处理释放状态
- 调整水平点击取消阈值从 30dp 到 60dp，与键盘光标手势激活阈值对齐， 消除 30~60dp 位移区间的死区问题

fix(keyboard): 优化键盘按钮手势处理

- 修正 SwipeableKeyButton 和 SwipeableIconKeyButton 的按压状态清理逻辑
- 调整水平点击取消阈值以消除打字吃键现象
- 改进长按与拖拽手势的交互，避免状态冲突

refactor(resize): 简化键盘调整组件实现

- 移除不必要的高度限制参数
- 调整预览框对齐方式为底部对齐
- 移除拖拽节流机制简化性能

chore(release): 更新版本号至 2.7.1

- 版本号从 2.7.0 升级到 2.7.1
- versionCode 从 20260825 增加到 20260826
- 更新 rime 子模块提交引用

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
