### PR TITLE
fix(keyboard): 修复长按后点击事件丢失问题

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,8 +43,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 20260827
-        versionName = "2.7.1"
+        versionCode = 20260828
+        versionName = "2.7.2"
 
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
@@ -1038,6 +1038,11 @@ fun SwipeableIconKeyButton(
                             isPressed = false
                             currentOnRelease?.invoke()
                             isLongPress = false
+                            // 长按结束后必须重置：onTap 不会在长按后触发，
+                            // 若残留 true 会吞掉下一次点击（退格键吃键）。
+                            // onDragEnd/onDragCancel 虽也重置，但仅 drag 激活时触发，
+                            // 长按无位移（drag 未激活）时走不到那里。
+                            hasTriggeredLongPress = false
                         }
                     },
                     onTap = {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
@@ -1798,7 +1798,11 @@ fun SwipeableKeyButtonLandscape(
                                         if (selected != null) {
                                             currentOnLongPressSelect?.invoke(selected)
                                         }
-                                    } else if (!swipeDetected && !dragActivated) {
+                                    } else if (!dragActivated) {
+                                        // 不能用 swipeDetected 抑制点击：swipeDetected 由 5dp 位移触发，
+                                        // 而 dragActivated 由 touch slop（更大）触发。5dp~touchSlop 区间
+                                        // 若被 swipeDetected 吞掉点击且 drag 未激活，会造成快速打字漏键。
+                                        // 5dp 位移只用于取消长按（longPressJob）。
                                         currentOnClick()
                                     }
                                 }


### PR DESCRIPTION
长按结束后必须重置 hasTriggeredLongPress 标志，否则会吞掉下一次点击事件，
导致退格键等按键出现吃键现象。

同时修复了滑动检测逻辑，不再使用 swipeDetected 抑制点击事件，
因为 swipeDetected 由 5dp 位移触发而 dragActivated 由更大的 touch slop 触发，在 5dp~touchSlop 区间若被 swipeDetected 吞掉点击且
drag 未激活时，会造成快速打字漏键的问题。

feat(version): 更新版本号至 2.7.2

更新 versionCode 至 20260828，versionName 至 2.7.2

chore(deps): 更新子项目依赖状态

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
