### PR TITLE
perf(t9): 九键快速输入长序列性能优化——wordgraph 双向增量缓存 + 插入式快通道

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
@@ -93,6 +93,16 @@ class T9InputController(
     }
 
     /**
+     * 数字键合帧序号：每次 onDigitPressed 在主线程递增并捕获。
+     * 任务执行时若发现自己之后已有更新的数字键入队，则跳过本帧的 flush——
+     * set_input 是全量语义，中间帧的 compose 结果会被后续键完全覆盖，属纯浪费
+     * （长序列单次 compose 可达 400ms+，远超按键间隔，会持续堆积队列）。
+     * 仅数字键合帧：左选/右选/清空等低频路径保持原语义。
+     */
+    @Volatile
+    private var digitSeq = 0L
+
+    /**
      * 同步等待后台队列排空（仅 onRightCandidateSelected 使用）。
      * 该方法必须且只会被**非主线程**调用（服务层 keyProcessingDispatcher），
      * 阻塞的是该后台线程而非 UI；队列空闲时立即返回。
@@ -284,13 +294,20 @@ class T9InputController(
 
     fun onDigitPressed(digit: String) {
         val code = digit[0].code
+        val seq = ++digitSeq
         enqueue {
             rimeEngine.processKey(code, 0)
             // C++ T9Processor 采用异步 flush 模型：processKey 只标记 pending 动作，
             // 必须调用 FlushRimeInput 才能真正触发 set_input → compose。
             // 全程在后台线程执行，引擎 compose（2-23ms）不阻塞 UI 线程。
-            rimeEngine.t9FlushRimeInput()
-            refreshOnBackground()
+            //
+            // 合帧：快速连打时，非队尾的数字键帧跳过 flush（compose 结果会被后续键的
+            // 全量 set_input 完全覆盖）；队尾帧执行 flush 并刷新 UI。processKey 每键
+            // 照常执行（C++ pending_input_ 追加，微秒级），不丢按键、不延迟处理。
+            if (seq == digitSeq) {
+                rimeEngine.t9FlushRimeInput()
+                refreshOnBackground()
+            }
         }
     }
 

--- a/app/src/main/jni/librime-t9/CMakeLists.txt
+++ b/app/src/main/jni/librime-t9/CMakeLists.txt
@@ -64,9 +64,10 @@ if(T9_BUILD_TESTS)
 
     # 纯算法源文件（不依赖 RIME 引擎，避免链接 rime-static 导致依赖 OpenCC/marisa 等第三方库）
     # 排除 t9_processor.cc / t9_module.cc（依赖 RIME Context/Menu/Candidate 等）
+    # t9_script_translator.cc：完整翻译器复刻（依赖 gear/script_translator.h，无纯算法子集）
     # t9_filter.cc 保留：通过 T9_ALGO_ONLY_BUILD 编译守卫，仅编译 converter 部分（无 RIME 依赖）
     file(GLOB T9_ALGO_SRC CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc)
-    list(FILTER T9_ALGO_SRC EXCLUDE REGEX "t9_processor\\.cc$|t9_module\\.cc$|t9_date_translator\\.cc$|t9_user_translator\\.cc$|t9_digit_userdict\\.cc$")
+list(FILTER T9_ALGO_SRC EXCLUDE REGEX "t9_processor\\.cc$|t9_module\\.cc$|t9_date_translator\\.cc$|t9_user_translator\\.cc$|t9_digit_userdict\\.cc$|t9_script_translator\\.cc$")
     add_library(t9-algo-objs OBJECT ${T9_ALGO_SRC})
     target_include_directories(t9-algo-objs PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src

--- a/app/src/main/jni/librime-t9/src/t9_module.cc
+++ b/app/src/main/jni/librime-t9/src/t9_module.cc
@@ -6,6 +6,7 @@
 #include "t9_filter.h"
 #include "t9_date_translator.h"
 #include "t9_user_translator.h"
+#include "t9_script_translator.h"
 
 using namespace rime;
 
@@ -20,6 +21,9 @@ static void rime_t9_initialize() {
     // 九键数字序列用户词召回（按实际输入数字序列召回用户词，
     // 解决声母简拼组词无法被 pinyin 用户词典召回的问题）。
     r.Register("t9_user_translator", new Component<T9UserTranslator>);
+    // T9 快速词组翻译器：wordgraph 跨键增量缓存，由 T9 patch 管线以
+    // 插入式两条 patch 接入（@after 1 + 哨兵 tag），不覆盖 translators 列表。
+    r.Register("t9_script_translator", new Component<T9ScriptTranslator>);
 }
 
 static void rime_t9_finalize() {

--- a/app/src/main/jni/librime-t9/src/t9_patch_utils.cc
+++ b/app/src/main/jni/librime-t9/src/t9_patch_utils.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cctype>
 #include <sstream>
+#include <vector>
 
 namespace rime {
 namespace t9_patch_utils {
@@ -122,6 +123,51 @@ bool HasPreeditLuaFilter(const std::string& content) {
     }
   }
   return false;
+}
+
+std::vector<std::string> BuildFastTranslatorPatchLines(
+    const std::string& schema_yaml_content) {
+  // 防御：schema 显式自定义 translator/tags（列表）时，tag 哨兵会被追加的
+  // abc 绕过（tags_ = [哨兵, abc, ...]），原 script_translator 仍查询 abc 段
+  // 造成双计算——保守不干预。YAML 嵌套形式：translator: 块内的 tags: 键。
+  size_t pos = 0;
+  bool in_translator_block = false;
+  size_t translator_indent = 0;
+  while (pos < schema_yaml_content.size()) {
+    const size_t eol = schema_yaml_content.find('\n', pos);
+    const size_t end =
+        eol == std::string::npos ? schema_yaml_content.size() : eol;
+    std::string line = schema_yaml_content.substr(pos, end - pos);
+    const size_t s = line.find_first_not_of(" \t\r");
+    if (s != std::string::npos) {
+      const size_t indent = s;
+      const std::string content = line.substr(s);
+      if (!in_translator_block) {
+        if (content.rfind("translator:", 0) == 0) {
+          in_translator_block = true;
+          translator_indent = indent;
+        }
+      } else {
+        if (indent > translator_indent) {
+          if (content.rfind("tags:", 0) == 0) {
+            return {};
+          }
+        } else {
+          in_translator_block = false;  // 块结束
+          if (content.rfind("translator:", 0) == 0) {
+            in_translator_block = true;
+            translator_indent = indent;
+          }
+        }
+      }
+    }
+    if (eol == std::string::npos) break;
+    pos = eol + 1;
+  }
+  return {
+      "  \"engine/translators/@after 1\": \"t9_script_translator@translator\"",
+      std::string("  \"translator/tag\": \"") + kT9FastOnlyTag + "\"",
+  };
 }
 
 }  // namespace t9_patch_utils

--- a/app/src/main/jni/librime-t9/src/t9_patch_utils.h
+++ b/app/src/main/jni/librime-t9/src/t9_patch_utils.h
@@ -17,6 +17,7 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace rime {
 namespace t9_patch_utils {
@@ -49,6 +50,25 @@ std::string StripPacksLines(const std::string& custom_yaml_content);
 // 扫描，不误伤仅含 preedit_format / 注释提及 preedit 的三方方案。
 // 命中时 DoEnsureT9SchemaPatches 默认 t9/isDisplayOriginalPreedit: true。
 bool HasPreeditLuaFilter(const std::string& content);
+
+// 生成词组快通道 translators 补丁行（插入式）：
+// 以两条单键 patch 接入 t9_script_translator（不覆盖 translators 列表，
+// 不冻结方案快照——用户对方案的 translators 补丁不受影响）：
+//   "engine/translators/@after 1": "t9_script_translator@translator"
+//     ↑ 插入第二位（首位是 t9_user_translator @before 0、第二位
+//       t9_date_translator @after 0，同 key 会互相覆盖）；@translator
+//       复用原 script_translator 的词典配置 namespace
+//   "translator/tag": "_t9_fast_only_"
+//     ↑ 哨兵 tag 禁用原 script_translator（避免同段双计算；tags_ 读到哨兵
+//       后不匹配 abc 段——空列表方式会自动回填 abc，故必须用单数 tag）
+// t9_script_translator::Query 固定处理 abc tag，不受哨兵影响。
+// 防御：schema 显式自定义 translator/tags（列表）时哨兵会被追加的 abc 绕过
+// → 返回空（不干预，保守回退）。
+// 返回 0 或 2 行（含缩进）；纯文本算法，纳入单测。
+std::vector<std::string> BuildFastTranslatorPatchLines(const std::string& schema_yaml_content);
+
+// 哨兵 tag 常量（与 t9_script_translator 接入约定一致）。
+inline constexpr const char* kT9FastOnlyTag = "_t9_fast_only_";
 
 }  // namespace t9_patch_utils
 }  // namespace rime

--- a/app/src/main/jni/librime-t9/src/t9_processor.cc
+++ b/app/src/main/jni/librime-t9/src/t9_processor.cc
@@ -68,13 +68,17 @@ T9Processor::T9Processor(const Ticket& ticket) : Processor(ticket) {
             //     → 拼音音节消歧；否则（英文 table_translator，如 melt_eng_t9）
             //     → 无左栏候选（kNone）。
             //   显式 t9/left_panel_mode: pinyin|none 覆盖 auto 判定。
+            //   t9_script_translator（词组快通道，perf/t9-fast-input-flush）是
+            //   script_translator 的复刻替换，同样具备拼音音节消歧能力，需一并
+            //   判定为拼音方案——否则左栏误判英文方案落入 kNone（空闲态）。
             std::string panel_mode;
             config->GetString("t9/left_panel_mode", &panel_mode);
             bool has_script_translator = false;
             if (auto translators = config->GetList("engine/translators")) {
                 for (auto it = translators->begin(); it != translators->end(); ++it) {
                     auto value = As<ConfigValue>(*it);
-                    if (value && value->str() == "script_translator") {
+                    if (value && (value->str() == "script_translator" ||
+                                  value->str() == "t9_script_translator")) {
                         has_script_translator = true;
                         break;
                     }

--- a/app/src/main/jni/librime-t9/src/t9_script_translator.cc
+++ b/app/src/main/jni/librime-t9/src/t9_script_translator.cc
@@ -1,0 +1,581 @@
+// T9 快速词组翻译器实现（设计文档见同目录 .h 注释）。
+//
+// 词组路径与整句 wordgraph 构建复刻自 librime src/rime/gear/script_translator.cc
+// （ScriptTranslation/ScriptSyllabifier 定义于 .cc 内，无法跨翻译单元引用，
+// 故按行为复刻；上游演进时需人工同步）。与上游的有意差异见 .h 头注释。
+
+#include "t9_script_translator.h"
+
+#include <algorithm>
+#include <cmath>
+#include <stack>
+#include <utility>
+#include <vector>
+
+#include <boost/range/adaptor/reversed.hpp>
+
+#include <rime/candidate.h>
+#include <rime/config.h>
+#include <rime/context.h>
+#include <rime/dict/corrector.h>
+#include <rime/dict/dictionary.h>
+#include <rime/dict/user_dictionary.h>
+#include <rime/engine.h>
+#include <rime/gear/poet.h>
+#include <rime/gear/translator_commons.h>
+#include <rime/schema.h>
+#include <rime/translation.h>
+#include <rime/algo/syllabifier.h>
+
+namespace rime {
+
+namespace {
+
+// ── T9 性能埋点（对齐 librime-t9 RimePerf 模式）──
+#if defined(RIME_ENABLE_LOGGING) && defined(__ANDROID__)
+#include <android/log.h>
+#include <chrono>
+struct T9ScriptPerfTimer {
+  using Clock = std::chrono::steady_clock;
+  const char* name;
+  Clock::time_point start;
+  explicit T9ScriptPerfTimer(const char* n) : name(n), start(Clock::now()) {}
+  ~T9ScriptPerfTimer() {
+    auto us = std::chrono::duration_cast<std::chrono::microseconds>(
+                  Clock::now() - start)
+                  .count();
+    __android_log_print(ANDROID_LOG_DEBUG, "RimePerf",
+                        "[TIMING] [T9Script] %s: %lld us", name,
+                        static_cast<long long>(us));
+  }
+};
+#define T9_SCRIPT_PERF_TIMER(name) \
+  T9ScriptPerfTimer _t9_script_perf_timer_##__LINE__(name)
+#else
+#define T9_SCRIPT_PERF_TIMER(name) ((void)0)
+#endif
+
+// 复刻自 script_translator.cc 匿名命名空间：音节图 DFS 边遍历。
+struct SyllabifyTask {
+  const Code& code;
+  const SyllableGraph& graph;
+  size_t target_pos;
+  function<void(SyllabifyTask* task,
+                size_t depth,
+                size_t current_pos,
+                size_t next_pos)>
+      push;
+  function<void(SyllabifyTask* task, size_t depth)> pop;
+};
+
+static bool syllabify_dfs(SyllabifyTask* task,
+                          size_t depth,
+                          size_t current_pos) {
+  if (depth == task->code.size()) {
+    return current_pos == task->target_pos;
+  }
+  SyllableId syllable_id = task->code.at(depth);
+  auto z = task->graph.edges.find(current_pos);
+  if (z == task->graph.edges.end())
+    return false;
+  // favor longer spellings
+  for (const auto& y : boost::adaptors::reverse(z->second)) {
+    size_t end_vertex_pos = y.first;
+    if (end_vertex_pos > task->target_pos)
+      continue;
+    auto x = y.second.find(syllable_id);
+    if (x != y.second.end()) {
+      task->push(task, depth, current_pos, end_vertex_pos);
+      if (syllabify_dfs(task, depth + 1, end_vertex_pos))
+        return true;
+      task->pop(task, depth);
+    }
+  }
+  return false;
+}
+
+// 复刻自 ScriptSyllabifier（不含纠错路径）。
+class T9ScriptSyllabifier : public PhraseSyllabifier {
+ public:
+  T9ScriptSyllabifier(ScriptTranslator* translator,
+                      const string& input,
+                      size_t start)
+      : translator_(translator),
+        input_(input),
+        start_(start),
+        syllabifier_(translator->delimiters(),
+                     translator->enable_completion(),
+                     translator->strict_spelling()) {}
+
+  Spans Syllabify(const Phrase* phrase) override;
+  size_t BuildSyllableGraph(Prism& prism);
+  string GetPreeditString(const Phrase& cand) const;
+  string GetOriginalSpelling(const Phrase& cand) const;
+
+  const SyllableGraph& syllable_graph() const { return syllable_graph_; }
+
+ protected:
+  ScriptTranslator* translator_;
+  string input_;
+  size_t start_;
+  Syllabifier syllabifier_;
+  SyllableGraph syllable_graph_;
+};
+
+Spans T9ScriptSyllabifier::Syllabify(const Phrase* phrase) {
+  Spans result;
+  vector<size_t> vertices;
+  vertices.push_back(start_);
+  SyllabifyTask task{
+      phrase->code(), syllable_graph_, phrase->end() - start_,
+      [&](SyllabifyTask* task, size_t depth, size_t current_pos,
+          size_t next_pos) { vertices.push_back(start_ + next_pos); },
+      [&](SyllabifyTask* task, size_t depth) { vertices.pop_back(); }};
+  if (syllabify_dfs(&task, 0, phrase->start() - start_)) {
+    result.set_vertices(std::move(vertices));
+  }
+  return result;
+}
+
+size_t T9ScriptSyllabifier::BuildSyllableGraph(Prism& prism) {
+  return (size_t)syllabifier_.BuildSyllableGraph(input_, prism,
+                                                 &syllable_graph_);
+}
+
+string T9ScriptSyllabifier::GetPreeditString(const Phrase& cand) const {
+  const auto& delimiters = translator_->delimiters();
+  std::stack<size_t> lengths;
+  string output;
+  SyllabifyTask task{cand.matching_code(), syllable_graph_, cand.end() - start_,
+                     [&](SyllabifyTask* task, size_t depth, size_t current_pos,
+                         size_t next_pos) {
+                       size_t len = output.length();
+                       if (depth > 0 && len > 0 &&
+                           delimiters.find(output[len - 1]) == string::npos) {
+                         output += delimiters.at(0);
+                       }
+                       output +=
+                           input_.substr(current_pos, next_pos - current_pos);
+                       lengths.push(len);
+                     },
+                     [&](SyllabifyTask* task, size_t depth) {
+                       output.resize(lengths.top());
+                       lengths.pop();
+                     }};
+  if (syllabify_dfs(&task, 0, cand.start() - start_)) {
+    return translator_->FormatPreedit(output);
+  } else {
+    return string();
+  }
+}
+
+string T9ScriptSyllabifier::GetOriginalSpelling(const Phrase& cand) const {
+  if (translator_ &&
+      static_cast<int>(cand.code().size()) <= translator_->spelling_hints()) {
+    return translator_->Spell(cand.code());
+  }
+  return string();
+}
+
+template <class Ptr, class Iter>
+static bool has_exact_match_phrase(Ptr ptr, Iter iter, size_t consumed) {
+  return ptr && iter->first == consumed && !iter->second.exhausted() &&
+         iter->second.Peek()->IsExactMatch();
+}
+
+static bool always_true() {
+  return true;
+}
+
+template <typename T>
+inline static bool prefer_user_phrase(
+    T user_phrase_weight,
+    T sys_phrase_weight,
+    function<bool()> compare_on_tie = always_true) {
+  return user_phrase_weight > sys_phrase_weight ||
+         (user_phrase_weight == sys_phrase_weight && compare_on_tie());
+}
+
+// 词组 + 增量整句翻译流（复刻 ScriptTranslation；wordgraph 经 translator
+// 跨键增量缓存，整句生成保持上游时机与候选排序）。
+class T9FastTranslation : public Translation {
+ public:
+  T9FastTranslation(T9ScriptTranslator* translator,
+                    Poet* poet,
+                    const string& input,
+                    size_t start,
+                    size_t end_of_input)
+      : translator_(translator),
+        poet_(poet),
+        input_(input),
+        start_(start),
+        end_of_input_(end_of_input),
+        syllabifier_(
+            New<T9ScriptSyllabifier>(translator, input, start)) {
+    set_exhausted(true);
+  }
+
+  bool Evaluate(Dictionary* dict, UserDictionary* user_dict);
+
+  bool Next() override;
+  an<Candidate> Peek() override;
+
+ protected:
+  bool CheckEmpty();
+  bool PrepareCandidate();
+  an<Sentence> MakeSentence(Dictionary* dict, UserDictionary* user_dict);
+
+  T9ScriptTranslator* translator_;
+  Poet* poet_;
+  string input_;
+  size_t start_;
+  size_t end_of_input_;
+  an<T9ScriptSyllabifier> syllabifier_;
+
+  an<DictEntryCollector> phrase_;
+  an<UserDictEntryCollector> user_phrase_;
+  an<Sentence> sentence_;
+
+  an<Phrase> candidate_ = nullptr;
+  size_t candidate_index_ = 0;
+  enum CandidateSource {
+    kUninitialized,
+    kUserPhrase,
+    kSysPhrase,
+    kSentence,
+  };
+  CandidateSource candidate_source_ = kUninitialized;
+
+  DictEntryCollector::reverse_iterator phrase_iter_;
+  UserDictEntryCollector::reverse_iterator user_phrase_iter_;
+};
+
+bool T9FastTranslation::Evaluate(Dictionary* dict, UserDictionary* user_dict) {
+  T9_SCRIPT_PERF_TIMER("T9FastTranslation::Evaluate");
+  size_t consumed = syllabifier_->BuildSyllableGraph(*dict->prism());
+  const auto& syllable_graph = syllabifier_->syllable_graph();
+  bool predict_word = translator_->enable_word_completion() &&
+                      start_ + consumed == end_of_input_;
+
+  {
+    T9_SCRIPT_PERF_TIMER("T9FastTranslation::dict.Lookup");
+    phrase_ = dict->Lookup(syllable_graph, 0, &translator_->blacklist(),
+                           predict_word);
+  }
+  if (user_dict) {
+    const size_t kUnlimitedDepth = 0;
+    const size_t kNumSyllablesToPredictWord = 4;
+    T9_SCRIPT_PERF_TIMER("T9FastTranslation::user_dict.Lookup");
+    user_phrase_ =
+        user_dict->Lookup(syllable_graph, 0, kUnlimitedDepth,
+                          predict_word ? kNumSyllablesToPredictWord : 0);
+  }
+  if (phrase_)
+    phrase_iter_ = phrase_->rbegin();
+  if (user_phrase_)
+    user_phrase_iter_ = user_phrase_->rbegin();
+
+  auto has_reliable = [&](auto ptr, auto iter) {
+    return ptr && iter->first == consumed && !iter->second.exhausted() &&
+           iter->second.Peek()->IsExactMatch();
+  };
+  bool has_reliable_phrase = has_reliable(phrase_, phrase_iter_);
+  bool has_reliable_user_phrase = has_reliable(user_phrase_, user_phrase_iter_);
+  bool has_at_least_two_syllables = syllable_graph.edges.size() >= 2;
+  // make sentences when there is no exact-matching phrase candidate
+  // （上游时机：整句候选回到流头部，随尾部输入变化——用户核心诉求；
+  // wordgraph 由 translator 增量缓存加速，见 MakeSentence）
+  if (has_at_least_two_syllables && !has_reliable_phrase &&
+      !has_reliable_user_phrase) {
+    T9_SCRIPT_PERF_TIMER("T9FastTranslation::MakeSentence");
+    sentence_ = MakeSentence(dict, user_dict);
+  } else {
+    // 追加方向（可靠词组存在但输入增长）：保留缓存，下次 MakeSentence 走增量。
+    // 非前缀关联（退格/改字/右选重发）：清空缓存元数据，防陈旧缓存导致
+    // prefix_related 误判为 true 而复用过期条目。
+    const string& cached = translator_->cached_input();
+    const size_t common = std::min(input_.size(), cached.size());
+    const bool prefix_related = !cached.empty() && input_.size() != cached.size() &&
+        input_.compare(0, common, cached, 0, common) == 0;
+    if (!prefix_related) {
+      translator_->ClearWordGraphCache();
+    }
+  }
+
+  return !CheckEmpty();
+}
+
+bool T9FastTranslation::Next() {
+  if (exhausted())
+    return false;
+  if (candidate_source_ == kUninitialized) {
+    PrepareCandidate();  // to determine candidate_source_
+  }
+  switch (candidate_source_) {
+    case kUninitialized:
+      break;
+    case kSentence:
+      sentence_.reset();
+      break;
+    case kUserPhrase: {
+      UserDictEntryIterator& uter(user_phrase_iter_->second);
+      if (!uter.Next()) {
+        ++user_phrase_iter_;
+      }
+    } break;
+    case kSysPhrase: {
+      DictEntryIterator& iter(phrase_iter_->second);
+      if (!iter.Next()) {
+        ++phrase_iter_;
+      }
+    } break;
+  }
+  candidate_.reset();
+  candidate_source_ = kUninitialized;
+  if (!CheckEmpty()) {
+    ++candidate_index_;
+    return true;
+  }
+  return false;
+}
+
+an<Candidate> T9FastTranslation::Peek() {
+  if (candidate_source_ == kUninitialized && !PrepareCandidate()) {
+    return nullptr;
+  }
+  if (candidate_->preedit().empty()) {
+    candidate_->set_preedit(syllabifier_->GetPreeditString(*candidate_));
+  }
+  if (candidate_->comment().empty()) {
+    auto spelling = syllabifier_->GetOriginalSpelling(*candidate_);
+    if (!spelling.empty() && (translator_->always_show_comments() ||
+                              spelling != candidate_->preedit())) {
+      candidate_->set_comment(spelling);
+    }
+  }
+  candidate_->set_syllabifier(syllabifier_);
+  return candidate_;
+}
+
+bool T9FastTranslation::PrepareCandidate() {
+  if (exhausted()) {
+    candidate_source_ = kUninitialized;
+    candidate_ = nullptr;
+    return false;
+  }
+  if (sentence_) {
+    // 上游排序：整句候选优先（随尾部输入变化，快速输入的动态内容来源）。
+    candidate_source_ = kSentence;
+    candidate_ = sentence_;
+    return true;
+  }
+  const size_t full_code_length = end_of_input_ - start_;
+  size_t user_phrase_code_length = 0;
+  if (user_phrase_ && user_phrase_iter_ != user_phrase_->rend()) {
+    user_phrase_code_length = user_phrase_iter_->first;
+  }
+  size_t phrase_code_length = 0;
+  if (phrase_ && phrase_iter_ != phrase_->rend()) {
+    phrase_code_length = phrase_iter_->first;
+  }
+  if (user_phrase_code_length > 0 &&
+      prefer_user_phrase(
+          user_phrase_code_length, phrase_code_length,
+          // 編碼長度相同時, 用戶詞優先
+          [this, full_code_length]() {
+            // 長詞聯想之前須至少出一個嚴格匹配的候選
+            // 故確定首選之際, 系統嚴格匹配 > 用戶長詞聯想
+            const int kNumExactMatchOnTop = 1;
+            return candidate_index_ >= kNumExactMatchOnTop ||
+                   prefer_user_phrase(
+                       has_exact_match_phrase(user_phrase_, user_phrase_iter_,
+                                              full_code_length),
+                       has_exact_match_phrase(phrase_, phrase_iter_,
+                                              full_code_length));
+          })) {
+    UserDictEntryIterator& uter = user_phrase_iter_->second;
+    const auto& entry = uter.Peek();
+    candidate_source_ = kUserPhrase;
+    candidate_ =
+        New<Phrase>(translator_->language(),
+                    entry->IsPredictiveMatch() ? "completion" : "user_phrase",
+                    start_, start_ + user_phrase_code_length, entry);
+    candidate_->set_quality(std::exp(entry->weight) +
+                            translator_->initial_quality() +
+                            (entry->quality_len / full_code_length));
+    return true;
+  } else if (phrase_code_length > 0) {
+    DictEntryIterator& iter = phrase_iter_->second;
+    const auto& entry = iter.Peek();
+    candidate_source_ = kSysPhrase;
+    candidate_ =
+        New<Phrase>(translator_->language(),
+                    entry->IsPredictiveMatch() ? "completion" : "phrase",
+                    start_, start_ + phrase_code_length, entry);
+    candidate_->set_quality(std::exp(entry->weight) +
+                            translator_->initial_quality() +
+                            (entry->quality_len / full_code_length));
+    return true;
+  } else {
+    candidate_source_ = kUninitialized;
+    candidate_ = nullptr;
+    return false;
+  }
+}
+
+bool T9FastTranslation::CheckEmpty() {
+  set_exhausted((!phrase_ || phrase_iter_ == phrase_->rend()) &&
+                (!user_phrase_ || user_phrase_iter_ == user_phrase_->rend()) &&
+                !sentence_);
+  return exhausted();
+}
+
+// 复刻自 ScriptTranslation::MakeSentence：wordgraph 构建委托 translator 的
+  // 跨键增量缓存（见 T9ScriptTranslator::BuildWordGraphIncremental），
+  // Viterbi/评分部分与上游一致。
+  an<Sentence> T9FastTranslation::MakeSentence(Dictionary* dict, UserDictionary* user_dict) {
+    if (!poet_)
+      return nullptr;
+    const auto& syllable_graph = syllabifier_->syllable_graph();
+  WordGraph graph;
+  {
+    T9_SCRIPT_PERF_TIMER("T9FastTranslation::MakeSentence.wordgraph(incremental)");
+    translator_->BuildWordGraphIncremental(dict, user_dict, syllable_graph,
+                                           input_, start_, graph);
+  }
+  if (auto sentence =
+          poet_->MakeSentence(graph, syllable_graph.interpreted_length,
+                              translator_->GetPrecedingText(start_))) {
+    sentence->Offset(start_);
+    sentence->set_syllabifier(syllabifier_);
+    return sentence;
+  }
+  return nullptr;
+}
+
+}  // anonymous namespace
+
+// ── T9ScriptTranslator ──
+
+T9ScriptTranslator::T9ScriptTranslator(const Ticket& ticket)
+    : ScriptTranslator(ticket) {}
+
+// 文件级模板（translation 与 translator 共用）：消费 collector 至 max_homophones。
+template <class QueryResult>
+static void EnrollEntriesInto(map<int, DictEntryList>& entries_by_end_pos,
+                               const an<QueryResult>& query_result,
+                               int max_homophones) {
+  if (query_result) {
+    for (auto& y : *query_result) {
+      DictEntryList& homophones = entries_by_end_pos[y.first];
+      while (homophones.size() < (size_t)max_homophones &&
+             !y.second.exhausted()) {
+        homophones.push_back(y.second.Peek());
+        if (!y.second.Next())
+          break;
+      }
+    }
+  }
+}
+
+void T9ScriptTranslator::BuildWordGraphIncremental(
+    Dictionary* dict, UserDictionary* user_dict,
+    const SyllableGraph& syllable_graph, const string& input,
+    size_t segment_start, WordGraph& graph) {
+  const size_t cache_len = wordgraph_cache_.input.size();
+  // 前缀关联判定（双向）：追加（九键连打）或缩短（退格删除）都构成前缀关联
+  // ——音节图边 (s,e) 由子串 [s,e) 决定，两版本共有的边完全一致，Lookup(s)
+  // 结果一致，可复用词条快照。非前缀关联（改字/清空/右选重发）或段起点变化
+  // → 缓存整体失效全量重建。
+  const size_t common_len = std::min(cache_len, input.size());
+  const bool prefix_related =
+      cache_len > 0 && cache_len != input.size() &&
+      wordgraph_cache_.start == segment_start &&
+      input.compare(0, common_len, wordgraph_cache_.input, 0, common_len) == 0;
+  if (!prefix_related) {
+    wordgraph_cache_.graph.clear();
+  }
+
+  const int kMaxSyllablesForUserPhraseQuery = 5;
+  size_t reused_starts = 0;
+  size_t queried_starts = 0;
+  for (const auto& x : syllable_graph.edges) {
+    const int s = x.first;
+    // 复用判定：该起点在缓存中存在，且当前音节图里它的全部邻接终点都未
+    // 超出两版本输入的公共长度——这些边在两版图中完全一致，Lookup(s)
+    // 结果不变。缩短方向（退格）缓存条目可能含更长终点的词条，按当前
+    // 最大终点截断后复用。
+    if (prefix_related) {
+      const size_t max_end = x.second.rbegin()->first;
+      auto cit = wordgraph_cache_.graph.find(s);
+      if (max_end <= common_len && cit != wordgraph_cache_.graph.end()) {
+        auto& dst = graph[s];
+        for (const auto& e : cit->second) {
+          if ((size_t)e.first <= max_end) {
+            dst[e.first] = e.second;
+          }
+        }
+        ++reused_starts;
+        continue;
+      }
+    }
+    auto& same_start_pos = graph[s];
+    if (user_dict) {
+      EnrollEntriesInto(same_start_pos,
+                        user_dict->Lookup(syllable_graph, s,
+                                          kMaxSyllablesForUserPhraseQuery),
+                        max_homophones());
+    }
+    // merge lookup results
+    EnrollEntriesInto(
+        same_start_pos,
+        dict->Lookup(syllable_graph, s, &blacklist()),
+        max_homophones());
+    ++queried_starts;
+  }
+#if defined(RIME_ENABLE_LOGGING) && defined(__ANDROID__)
+  __android_log_print(ANDROID_LOG_DEBUG, "RimePerf",
+                      "[TIMING] [T9Script] wordgraph incremental: "
+                      "input_len=%zu cache_len=%zu reused=%zu queried=%zu",
+                      input.size(), cache_len, reused_starts, queried_starts);
+#endif
+  // 回写缓存（含失效后的全量重建结果）。
+  wordgraph_cache_.input = input;
+  wordgraph_cache_.start = segment_start;
+  wordgraph_cache_.graph = graph;
+}
+
+an<Translation> T9ScriptTranslator::Query(const string& input,
+                                          const Segment& segment) {
+  if (!dict_ || !dict_->loaded())
+    return nullptr;
+  // 不依赖 translator/tags 配置：t9 patch 以 "translator/tags": [] 禁用原
+  // script_translator（同 namespace，避免双计算），该 patch 会连带清空本组件
+  // 读到的 tags_——故此处固定处理 abc tag（拼音方案的默认翻译 tag），并兼容
+  // 方案自定义 tags（tags_ 保留时按其判定）。
+  if (!segment.HasTag("abc") && !segment.HasAnyTagIn(tags_))
+    return nullptr;
+  DLOG(INFO) << "t9 input = '" << input << "', [" << segment.start << ", "
+             << segment.end << ")";
+
+  FinishSession();
+
+  bool enable_user_dict =
+      user_dict_ && user_dict_->loaded() && !IsUserDictDisabledFor(input);
+
+  size_t end_of_input = engine_->context()->input().length();
+  // the translator should survive translations it creates
+  auto result = New<T9FastTranslation>(this, poet_.get(),
+                                       input, segment.start, end_of_input);
+  if (!result || !result->Evaluate(
+                     dict_.get(), enable_user_dict ? user_dict_.get() : NULL)) {
+    return nullptr;
+  }
+  auto deduped = New<DistinctTranslation>(result);
+  if (contextual_suggestions_ && poet_) {
+    return poet_->ContextualWeighted(deduped, input, segment.start, this);
+  }
+  return deduped;
+}
+
+}  // namespace rime

--- a/app/src/main/jni/librime-t9/src/t9_script_translator.h
+++ b/app/src/main/jni/librime-t9/src/t9_script_translator.h
@@ -1,0 +1,80 @@
+// T9 快速词组翻译器——wordgraph 跨键增量缓存。
+//
+// 设计文档：docs/issues/2026-08-16-t9-快速输入性能优化方案.md
+//
+// 问题：librime ScriptTranslator::Query 创建 ScriptTranslation 后立即 Evaluate，
+// 长数字串（无全串词组精确匹配）时强制整句生成 MakeSentence——对音节图每条边
+// 做一次词典 Lookup（实测 18 位单键 wordgraph 213-335ms），且 Sentence 候选
+// 位于流头部，Menu 取第一页即触发全部计算 → 九键快速输入视觉卡顿。
+//
+// 方案：整句生成保持上游时机与排序（Evaluate 内、候选流头部）——整句候选是
+// 随尾部输入变化的动态内容，不能砍，只能加速。加速手段：wordgraph 构建改为
+// 跨键增量缓存（挂在 translator，非每次 Query 重建）：
+//  - 音节图边 (s,e) 由输入子串 [s,e) 决定——追加/删除尾部输入不改变旧边；
+//  - 起点查询 dict->Lookup(syllable_graph, s) 的结果只依赖 s 的邻接边集；
+//  - 若起点 s 的全部邻接终点 ≤ 两版本输入公共长度 → 结果不变，直接复用
+//    （缩短方向按当前终点截断条目）；只有边界起点需要重查；
+//  - 非前缀关联（改字/右选重发/清空）或段起点变化 → 缓存整体失效全量重建。
+//  - 缓存内容为已 Enroll 的 an<DictEntry> 词条快照（shared_ptr 保活），
+//    输入期间 user_dict 不变（仅 commit 时更新），快照安全。
+//  - Evaluate 跳过 MakeSentence 时（有可靠词组）清除缓存元数据，防止跨
+//    输入序列的陈旧缓存（cache_len 与当前输入不匹配）在下次触发全量重建。
+//
+// 与 librime 上游 script_translator.cc 的差异（有意为之）：
+//  1. wordgraph 增量缓存（见上）；MakeSentence 其余复刻不变。
+//  2. 不支持纠错（Corrector）：T9 九键输入为数字串，与 QWERTY 键盘布局的
+//     keyboard_map 不兼容，开启不会产生有意义的结果；若需 T9 纠错应在
+//     词级别独立设计。其余行为（词组优先序、quality 计算、preedit/comment
+//     格式化、completion、DistinctTranslation 去重、contextual_suggestions）
+//     与上游保持一致。
+//
+// 接入：T9 patch 管线以插入式两条 patch 接入（@after 1 + 哨兵 tag），
+// 不覆盖 translators 列表。上游词组路径演进时需同步本复刻。
+
+#ifndef T9_SCRIPT_TRANSLATOR_H_
+#define T9_SCRIPT_TRANSLATOR_H_
+
+#include <string>
+
+#include <rime/gear/poet.h>
+#include <rime/gear/script_translator.h>
+
+namespace rime {
+
+struct SyllableGraph;
+
+class T9ScriptTranslator : public ScriptTranslator {
+ public:
+  explicit T9ScriptTranslator(const Ticket& ticket);
+
+  an<Translation> Query(const string& input, const Segment& segment) override;
+
+  // 增量构建 wordgraph（T9FastTranslation::MakeSentence 调用）：
+  // 优先复用上一键缓存中「邻接终点未超出缓存输入长度」的起点条目，
+  // 仅重查边界/新起点。segment_start 用于段坐标一致性校验（音节图边为
+  // 段内相对坐标，段起点变化时缓存必须失效）。graph 为输出参数（已清空）。
+  void BuildWordGraphIncremental(Dictionary* dict,
+                                 UserDictionary* user_dict,
+                                 const SyllableGraph& syllable_graph,
+                                 const string& input,
+                                 size_t segment_start,
+                                 WordGraph& graph);
+
+  // 清除 wordgraph 缓存元数据：当 Evaluate 未生成整句时调用，
+  // 防止跨输入序列的陈旧缓存引起下次 MakeSentence 全量重建。
+  void ClearWordGraphCache() { wordgraph_cache_.input.clear(); }
+  // 获取缓存对应的输入串（空 = 无缓存）。
+  const string& cached_input() const { return wordgraph_cache_.input; }
+
+ private:
+  struct WordGraphCache {
+    string input;   // 缓存对应的段输入（空 = 无缓存）
+    size_t start = 0;  // 缓存对应的段起点（段内坐标系基准）
+    WordGraph graph;
+  };
+  WordGraphCache wordgraph_cache_;
+};
+
+}  // namespace rime
+
+#endif  // T9_SCRIPT_TRANSLATOR_H_

--- a/app/src/main/jni/librime-t9/test/t9_patch_utils_test.cc
+++ b/app/src/main/jni/librime-t9/test/t9_patch_utils_test.cc
@@ -12,6 +12,7 @@ using rime::t9_patch_utils::EvaluatePacksState;
 using rime::t9_patch_utils::HasPreeditLuaFilter;
 using rime::t9_patch_utils::PacksState;
 using rime::t9_patch_utils::SanitizePackName;
+using rime::t9_patch_utils::BuildFastTranslatorPatchLines;
 using rime::t9_patch_utils::StripPacksLines;
 
 // ── SanitizePackName ──
@@ -167,4 +168,35 @@ TEST(T9PatchUtilsTest, PreeditFilter_Ignores_Doc_Example_In_Comment) {
 
 TEST(T9PatchUtilsTest, PreeditFilter_Empty_Content) {
   EXPECT_FALSE(HasPreeditLuaFilter(""));
+}
+
+// ── BuildFastTranslatorPatchLines（v3 插入式）──
+
+TEST(T9PatchUtilsTest, FastTranslator_InsertionTwoLines) {
+  const std::string schema =
+      "engine:\n"
+      "  translators:\n"
+      "    - punct_translator  #注释\n"
+      "    - script_translator\n";
+  const auto lines = BuildFastTranslatorPatchLines(schema);
+  ASSERT_EQ(lines.size(), 2u);
+  EXPECT_EQ(lines[0],
+            "  \"engine/translators/@after 1\": \"t9_script_translator@translator\"");
+  EXPECT_EQ(lines[1], "  \"translator/tag\": \"_t9_fast_only_\"");
+}
+
+TEST(T9PatchUtilsTest, FastTranslator_SkipWhenCustomTags) {
+  // schema 显式自定义 translator/tags：哨兵会被追加的 abc 绕过 → 保守不干预
+  const std::string schema =
+      "translator:\n"
+      "  dictionary: wanxiang\n"
+      "  tags:\n"
+      "    - abc\n"
+      "    - custom_tag\n";
+  EXPECT_TRUE(BuildFastTranslatorPatchLines(schema).empty());
+}
+
+TEST(T9PatchUtilsTest, FastTranslator_PlainSchemaNoTags) {
+  const std::string schema = "schema_id: t9_x\nengine:\n  translators:\n    - script_translator\n";
+  EXPECT_EQ(BuildFastTranslatorPatchLines(schema).size(), 2u);
 }

--- a/app/src/main/jni/librime_jni/rime_jni.cc
+++ b/app/src/main/jni/librime_jni/rime_jni.cc
@@ -226,12 +226,14 @@ public:
         result.inputText = input ? input : "";
         result.preeditText = context.composition.preedit ?
             context.composition.preedit : "";
-        LOGI("readCurrentState: input='%s' num_candidates=%d", result.inputText.c_str(), context.menu.num_candidates);
+        // 汇总一条（逐候选日志已删：每键 20 条 logcat 写入与字符串创建
+        // 在快速输入热路径上非必要）
+        LOGI("readCurrentState: input='%s' num_candidates=%d",
+             result.inputText.c_str(), context.menu.num_candidates);
         if (context.menu.num_candidates > 0) {
             for (int i = 0; i < context.menu.num_candidates; ++i) {
                 const char* text = context.menu.candidates[i].text;
                 const char* comment = context.menu.candidates[i].comment;
-                LOGI("Candidate[%d]: text='%s' comment='%s'", i, text ? text : "", comment ? comment : "");
                 result.candidates.push_back(std::make_pair(
                     text ? text : "",
                     comment ? comment : ""
@@ -323,7 +325,6 @@ public:
             for (int i = 0; i < context.menu.num_candidates; ++i) {
                 const char* text = context.menu.candidates[i].text;
                 const char* comment = context.menu.candidates[i].comment;
-                LOGI("Candidate[%d]: text='%s' comment='%s'", i, text ? text : "", comment ? comment : "");
                 result.candidates.push_back(std::make_pair(
                     text ? text : "",
                     comment ? comment : ""
@@ -1504,10 +1505,36 @@ static jboolean DoEnsureT9SchemaPatches(
         patch_lines.push_back("  \"t9/enable_date_translator\": true");
     }
 
+    // 拼音方案判定：含 script_translator 的 schema 才支持词组快通道注入。
+    const bool is_pinyin_schema =
+        schema_content.find("script_translator") != std::string::npos;
+
     // 清理已废弃的 enable_abbrev_recall 产物
     const bool has_derive = existing_content.find("derive/^([a-z])") != std::string::npos;
     const bool has_abbrev_custom = existing_content.find("enable_abbrev_recall") != std::string::npos;
     bool need_remove_derive = has_derive || has_abbrev_custom;
+
+    // T9 拼音方案词组快通道：以两条单键 patch 接入 t9_script_translator
+    //（@after 1 插入第三位——首位 t9_user_translator @before 0、第二位
+    // t9_date_translator @after 0，同 key 会互相覆盖；@translator 复用原
+    // script_translator 的词典配置 namespace），不覆盖 translators 列表
+    //——用户对方案的 translators 补丁不受影响。
+    // 哨兵 tag（_t9_fast_only_）禁用原 script_translator 防同段双计算
+    //（空列表方式会自动回填 abc，故必须用单数 tag）；Query 固定处理 abc tag
+    // 不受哨兵影响。
+    // 幂等：custom 已含哨兵跳过；用户显式配置 translator/tag 或
+    // t9/disable_fast_translator 时跳过。
+    bool fast_translator_patch_changed = false;
+    if (is_pinyin_schema &&
+        existing_content.find(rime::t9_patch_utils::kT9FastOnlyTag) == std::string::npos &&
+        existing_content.find("\"translator/tag\"") == std::string::npos &&
+        existing_content.find("t9/disable_fast_translator") == std::string::npos) {
+        for (const auto& line :
+             rime::t9_patch_utils::BuildFastTranslatorPatchLines(schema_content)) {
+            patch_lines.push_back(line);
+            fast_translator_patch_changed = true;
+        }
+    }
 
     // translator/packs 个人词库：合法保留 / 畸形修复 / 缺失交由 PersonalDictManager。
     const std::string packs_name = "user_" + rime::t9_patch_utils::SanitizePackName(schema);
@@ -1588,12 +1615,13 @@ static jboolean DoEnsureT9SchemaPatches(
         actual_pack_name = packs_name;
     }
 
-    LOGI("T9Patches: applied '%s' (packs=%s)", schema,
-         actual_pack_name.c_str());
+    LOGI("T9Patches: applied '%s' (fast_translator=%d, packs=%s)", schema,
+         fast_translator_patch_changed ? 1 : 0, actual_pack_name.c_str());
 
     // 返回 true 表示词库/补丁尚未编译，调用方可据此触发部署。
     const bool need_deploy =
-        T9PackTableBinMissing(user_data_dir, actual_pack_name);
+        T9PackTableBinMissing(user_data_dir, actual_pack_name) ||
+        fast_translator_patch_changed;
     return need_deploy ? JNI_TRUE : JNI_FALSE;
 }
 


### PR DESCRIPTION
@kingzcheung 目前九键快速输入长序列时会出现明显卡顿，特别是开启了简拼(    `- abbrev/^([a-z]).*/$1/
   ` `- abbrev/^([A-Z]).*/$1/`), 本轮旨在解决此问题，具体方案描述见关联issue中方案描述，请协助审阅，目前实现，绝大部分都在librime-t9中。已跟进了主线变动。
   
## 概述

解决九键快速输入长数字序列时预编辑与候选列表无法实时同步刷新（部分输入序列测试: 单键 438-459ms）的问题。

- T9InputController: 数字键 flush 合帧，跳过非队尾帧的全量 compose
- t9_script_translator(新文件):基于librime源码直接 复刻 ScriptTranslation，wordgraph 跨键双向增量缓存 （追加/退格都复用词条快照，首键冷启动全量），修复 poet_ 空指针与 user_phrase_iter_ 初始化错误
- t9_patch_utils: 插入式两条 patch 接入（@after 1 + 哨兵 tag），不覆盖 translators 列表中：`script_translator`，但防止防它与：`t9_script_translator`重复计算
- t9_processor: 左栏拼音模式判定兼容新组件名
- rime_jni: 快通道 patch 管线 + readCurrentState/getComposition 逐候选日志精简

## 关联 Issue

Closes #677

## 改动类型

- [ ] 新功能
- [x] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注
目前在不修改librime源码前提下，仅能通过在librime-t9中去优化，后续将继续探索优化：`librime` 中：`dict.Lookup`、`Poet`，以应对简拼开启后性能波动，或者找寻找新的简拼打开方式。