### PR TITLE
fix(t9): 右选末音节数字码前缀匹配误判 full commit

### DIFF
--- a/app/src/main/jni/librime-t9/src/t9_apostrophe_strategy.cc
+++ b/app/src/main/jni/librime-t9/src/t9_apostrophe_strategy.cc
@@ -184,12 +184,15 @@ bool ApostropheStrategy::HandleCanCoverAll(
         if (unassigned_syl_index < alignment.syllable_count()) {
             const std::string& syl_code = alignment.syllable_codes[unassigned_syl_index];
             if (!syl_code.empty()) {
+                // S9：改用"完整消费"语义——unassigned 被完整消费才算覆盖，
+                // 不允许候选音节数字码更长（如"hen"→"436"以"43"为前缀但≠"43"）。
+                // 简拼 unassigned（1 位）首字母匹配即覆盖；全拼级要求 syl_code 更短或相等。
                 if (unassigned_str.size() == 1 &&
                     syl_code[0] == unassigned_str[0]) {
                     unassigned_covered = true;
                 } else if (unassigned_str.size() > 1 &&
-                           syl_code.size() >= unassigned_str.size() &&
-                           syl_code.compare(0, unassigned_str.size(), unassigned_str) == 0) {
+                           syl_code.size() <= unassigned_str.size() &&
+                           unassigned_str.compare(0, syl_code.size(), syl_code) == 0) {
                     unassigned_covered = true;
                 }
             }

--- a/app/src/main/jni/librime-t9/src/t9_letter_buffer_strategy.cc
+++ b/app/src/main/jni/librime-t9/src/t9_letter_buffer_strategy.cc
@@ -43,19 +43,52 @@ ExtraSyllableCommitCheck LetterBufferStrategy::CheckExtraSyllableCommit(
         selection_count, static_cast<int>(comment_syllables.size())) - 1;
     if (cover_idx < 0) cover_idx = 0;
     const std::string& syl_covering_prev_opt = comment_syllables[cover_idx];
-    check.last_syl_covers_prev_opt =
-        syl_covering_prev_opt == prev_selected_option.pinyin ||
-        StartsWith(syl_covering_prev_opt, prev_selected_option.pinyin);
-    // 公共前缀长度：末音节是末选择真前缀（如 'gu' ⊂ 'gua'）时，
-    // 该长度决定退还未消费位数（initials-only 分支据此计算，替代固定 digit_length-1）。
-    // T9 数字码与拼音字母 1:1，字母前缀长度即已消费的数字位数。
+
+    // S9：覆盖判定改用数字码而非字母前缀。
+    // 字母前缀（StartsWith("hen","he")）会把更长的不同音节误判为覆盖，
+    // 但"hen"→"436"≠"he"→"43"，用户从未输入末音节所需的额外数字。
+    // 覆盖仅当：数字码相等（同一音节），或末选择是简拼且末音节以该字母开头（补全）。
+    const auto& pmap = T9PinyinMap::Instance();
+    auto syl_code_opt = pmap.PinyinToDigitCode(syl_covering_prev_opt);
+    auto opt_code_opt = pmap.PinyinToDigitCode(prev_selected_option.pinyin);
+    bool syl_digit_eq_opt =
+        syl_code_opt.has_value() && opt_code_opt.has_value() &&
+        *syl_code_opt == *opt_code_opt;
+    bool prev_opt_is_abbrev = prev_selected_option.pinyin.size() == 1;
+    bool syl_starts_with_opt_letter = prev_opt_is_abbrev &&
+        !syl_covering_prev_opt.empty() &&
+        syl_covering_prev_opt[0] == prev_selected_option.pinyin[0];
+    check.last_syl_covers_prev_opt = syl_digit_eq_opt || syl_starts_with_opt_letter;
+
+    // 公共前缀长度：用数字码计算，供 initials-only 分支退还未消费位数。
+    // 末音节更长（数字码以末选择为前缀但不等）时，仅首字母匹配，限制为 1。
     int overlap = 0;
-    int max_overlap = std::min(
-        static_cast<int>(syl_covering_prev_opt.size()),
-        static_cast<int>(prev_selected_option.pinyin.size()));
-    while (overlap < max_overlap &&
-           syl_covering_prev_opt[overlap] == prev_selected_option.pinyin[overlap]) {
-        ++overlap;
+    if (syl_code_opt.has_value() && opt_code_opt.has_value()) {
+        const std::string& syl_code = *syl_code_opt;
+        const std::string& opt_code = *opt_code_opt;
+        int max_overlap = std::min(
+            static_cast<int>(syl_code.size()),
+            static_cast<int>(opt_code.size()));
+        while (overlap < max_overlap &&
+               syl_code[overlap] == opt_code[overlap]) {
+            ++overlap;
+        }
+        // 末音节更长且以末选择数字码为前缀 → 仅首字母匹配，限制 overlap 为 1
+        bool syl_code_longer_starts_with_opt =
+            syl_code.size() > opt_code.size() &&
+            syl_code.compare(0, opt_code.size(), opt_code) == 0;
+        if (syl_code_longer_starts_with_opt && overlap > 1) {
+            overlap = 1;
+        }
+    } else {
+        // 数字码查询失败时回退到字母公共前缀
+        int max_overlap = std::min(
+            static_cast<int>(syl_covering_prev_opt.size()),
+            static_cast<int>(prev_selected_option.pinyin.size()));
+        while (overlap < max_overlap &&
+               syl_covering_prev_opt[overlap] == prev_selected_option.pinyin[overlap]) {
+            ++overlap;
+        }
     }
     check.covered_prefix_len = overlap;
 

--- a/app/src/main/jni/librime-t9/test/t9_right_commit_handler_test.cc
+++ b/app/src/main/jni/librime-t9/test/t9_right_commit_handler_test.cc
@@ -1704,5 +1704,163 @@ TEST(T9RightCommitHandlerTest, LetterBufferPartialCommit_8268426_Tiao_Duplicated
     EXPECT_FALSE(result);   // partial commit — history 重复导致 full commit 判定失败
 }
 
+// ── 场景 [Bug-fix]: letterBuffer 末音节数字码前缀误判 full commit ──
+// 输入5143→左选k→左选he，右选"可恨 ke hen"。
+// 末音节"hen"→"436"是末选择"he"→"43"的字母超集但数字码不等，不应 full commit。
+// 修复前：StartsWith("hen","he")=true 误判覆盖 → full commit。
+// 修复后：改用数字码判定 → partial commit，剩余"3"→预编辑"可恨e"。
+TEST(T9RightCommitHandlerTest, LetterBufferSyllablePrefixMismatch_543_KeHen) {
+    std::vector<SyllableOption> sels{
+        SyllableOption("k", 1), SyllableOption("he", 2)};
+    std::vector<SyllableOption> history{sels[0], sels[1]};
+    auto ctx = MakeContext({
+        .digits = "543",
+        .selections = sels,
+        .consumed_count = 3,
+        .state = T9StateMachine::State::kSelection,
+        .selected_option = sels[1],
+        .selection_candidate_digits = std::optional<std::string>("43"),
+        .confirmed_pinyin = "k",
+        .selection_history = history,
+        .has_separator = true,
+        .separator_position = 1
+    });
+    T9RightCommitHandler handler;
+    bool result = handler.HandleRightCommit(ctx, std::optional<std::string>("ke hen"), 2);
+    EXPECT_FALSE(result);                                  // partial commit（非 full commit）
+    EXPECT_FALSE(ctx.input_buffer.is_empty());
+    EXPECT_FALSE(ctx.state_machine.is_idle());
+    EXPECT_EQ(0, ctx.input_buffer.selections.size());      // he 被消费，不保留
+    EXPECT_EQ("3", ctx.input_buffer.unassigned());         // 剩余 '3' → 预编辑 "可恨e"
+}
+
+// 同类：右选"匡衡 kuang heng"（末音节"heng"→"4364"同理），应 partial commit。
+TEST(T9RightCommitHandlerTest, LetterBufferSyllablePrefixMismatch_543_KuangHeng) {
+    std::vector<SyllableOption> sels{
+        SyllableOption("k", 1), SyllableOption("he", 2)};
+    std::vector<SyllableOption> history{sels[0], sels[1]};
+    auto ctx = MakeContext({
+        .digits = "543",
+        .selections = sels,
+        .consumed_count = 3,
+        .state = T9StateMachine::State::kSelection,
+        .selected_option = sels[1],
+        .selection_candidate_digits = std::optional<std::string>("43"),
+        .confirmed_pinyin = "k",
+        .selection_history = history,
+        .has_separator = true,
+        .separator_position = 1
+    });
+    T9RightCommitHandler handler;
+    bool result = handler.HandleRightCommit(ctx, std::optional<std::string>("kuang heng"), 2);
+    EXPECT_FALSE(result);                                  // partial commit
+    EXPECT_FALSE(ctx.input_buffer.is_empty());
+    EXPECT_FALSE(ctx.state_machine.is_idle());
+    EXPECT_EQ(0, ctx.input_buffer.selections.size());
+    EXPECT_EQ("3", ctx.input_buffer.unassigned());
+}
+
+// 同类（ge 分支）：左选 k+ge，右选"快跟 kuai gen"（末音节"gen"→"436"同理），应 partial commit。
+TEST(T9RightCommitHandlerTest, LetterBufferSyllablePrefixMismatch_543_KuaiGen) {
+    std::vector<SyllableOption> sels{
+        SyllableOption("k", 1), SyllableOption("ge", 2)};
+    std::vector<SyllableOption> history{sels[0], sels[1]};
+    auto ctx = MakeContext({
+        .digits = "543",
+        .selections = sels,
+        .consumed_count = 3,
+        .state = T9StateMachine::State::kSelection,
+        .selected_option = sels[1],
+        .selection_candidate_digits = std::optional<std::string>("43"),
+        .confirmed_pinyin = "k",
+        .selection_history = history,
+        .has_separator = true,
+        .separator_position = 1
+    });
+    T9RightCommitHandler handler;
+    bool result = handler.HandleRightCommit(ctx, std::optional<std::string>("kuai gen"), 2);
+    EXPECT_FALSE(result);                                  // partial commit
+    EXPECT_FALSE(ctx.input_buffer.is_empty());
+    EXPECT_FALSE(ctx.state_machine.is_idle());
+    EXPECT_EQ(0, ctx.input_buffer.selections.size());
+    EXPECT_EQ("3", ctx.input_buffer.unassigned());
+}
+
+// ── 场景 [Bug-fix]: apostrophe 末音节数字码前缀误判 full commit ──
+// 输入5143→只左选k（unassigned="43"），右选"可恨 ke hen"。
+// 末音节"hen"→"436"以"43"为前缀但≠"43"，不应 full commit。
+// 修复前：HandleCanCoverAll 用 syl_code 以 unassigned 为前缀判定 → 误判 full commit。
+// 修复后：改用"完整消费"语义 → partial commit，剩余"3"→预编辑"可恨e"。
+TEST(T9RightCommitHandlerTest, ApostropheSyllablePrefixMismatch_543_KeHen) {
+    std::vector<SyllableOption> sels{SyllableOption("k", 1)};
+    std::vector<SyllableOption> history{sels[0]};
+    auto ctx = MakeContext({
+        .digits = "543",
+        .selections = sels,
+        .consumed_count = 1,
+        .state = T9StateMachine::State::kSelection,
+        .selected_option = sels[0],
+        .selection_candidate_digits = std::optional<std::string>("43"),
+        .confirmed_pinyin = "k",
+        .selection_history = history,
+        .has_separator = true,
+        .separator_position = 1
+    });
+    T9RightCommitHandler handler;
+    bool result = handler.HandleRightCommit(ctx, std::optional<std::string>("ke hen"), 2);
+    EXPECT_FALSE(result);                                  // partial commit（非 full commit）
+    EXPECT_FALSE(ctx.input_buffer.is_empty());
+    EXPECT_FALSE(ctx.state_machine.is_idle());
+    EXPECT_EQ("3", ctx.input_buffer.unassigned());         // 剩余 '3' → 预编辑 "可恨e"
+}
+
+// 同类：右选"抗衡 kang heng"（末音节"heng"→"4364"同理），应 partial commit。
+TEST(T9RightCommitHandlerTest, ApostropheSyllablePrefixMismatch_543_KuangHeng) {
+    std::vector<SyllableOption> sels{SyllableOption("k", 1)};
+    std::vector<SyllableOption> history{sels[0]};
+    auto ctx = MakeContext({
+        .digits = "543",
+        .selections = sels,
+        .consumed_count = 1,
+        .state = T9StateMachine::State::kSelection,
+        .selected_option = sels[0],
+        .selection_candidate_digits = std::optional<std::string>("43"),
+        .confirmed_pinyin = "k",
+        .selection_history = history,
+        .has_separator = true,
+        .separator_position = 1
+    });
+    T9RightCommitHandler handler;
+    bool result = handler.HandleRightCommit(ctx, std::optional<std::string>("kang heng"), 2);
+    EXPECT_FALSE(result);                                  // partial commit
+    EXPECT_FALSE(ctx.input_buffer.is_empty());
+    EXPECT_FALSE(ctx.state_machine.is_idle());
+    EXPECT_EQ("3", ctx.input_buffer.unassigned());
+}
+
+// 同类（ge 分支）：右选"快跟 kuai gen"（末音节"gen"→"436"同理），应 partial commit。
+TEST(T9RightCommitHandlerTest, ApostropheSyllablePrefixMismatch_543_KuaiGen) {
+    std::vector<SyllableOption> sels{SyllableOption("k", 1)};
+    std::vector<SyllableOption> history{sels[0]};
+    auto ctx = MakeContext({
+        .digits = "543",
+        .selections = sels,
+        .consumed_count = 1,
+        .state = T9StateMachine::State::kSelection,
+        .selected_option = sels[0],
+        .selection_candidate_digits = std::optional<std::string>("43"),
+        .confirmed_pinyin = "k",
+        .selection_history = history,
+        .has_separator = true,
+        .separator_position = 1
+    });
+    T9RightCommitHandler handler;
+    bool result = handler.HandleRightCommit(ctx, std::optional<std::string>("kuai gen"), 2);
+    EXPECT_FALSE(result);                                  // partial commit
+    EXPECT_FALSE(ctx.input_buffer.is_empty());
+    EXPECT_FALSE(ctx.state_machine.is_idle());
+    EXPECT_EQ("3", ctx.input_buffer.unassigned());
+}
+
 }  // namespace
 }  // namespace rime


### PR DESCRIPTION
@kingzcheung 在目前九键输入中针对简拼和全拼混合输入场景，存在消费异常，具体见关联issue完整复现和修复计划，请协助审核。

## 概述

左选 selections选择的拼音或者字母 是唯一信源——候选词音节只有真正对应已输入数字才算覆盖。
原逻辑用前缀匹配判断覆盖关系，导致更长的不同音节（如 hen→436 与 he→43、
heng→4364 与 ge→43）被误判为覆盖，右选: `可恨/抗衡/快跟` 等词语错误触发完全消费上屏。

- LetterBufferStrategy: CheckExtraSyllableCommit 的 last_syl_covers_prev_opt 改用数字码精确匹配 + 简拼补全语义，covered_prefix_len 用数字码公共前缀
- ApostropheStrategy: HandleCanCoverAll 的 unassigned_covered 改用 完整消费语义，不允许候选音节数字码更长

新增 6 个测试覆盖两条路径的变体场景，全部 318 个测试通过。

## 关联 Issue

Closes #740 

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
