### PR TITLE
fix(keyboard): 调整T9键盘候选词项的内边距

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
@@ -909,7 +909,7 @@ private fun CandidateItem(
                 modifier = Modifier
                     .clip(RoundedCornerShape(5.dp))
                     .background(accentColor.copy(alpha = 0.2f))
-                    .padding(horizontal = 8.dp, vertical = 2.dp)
+                    .padding(horizontal = 3.dp, vertical = 1.dp)
             ) {
                 Text(
                     text = text,


### PR DESCRIPTION
减少候选词项的水平和垂直内边距，使界面更加紧凑

- 水平内边距从8dp调整为3dp
- 垂直内边距从2dp调整为1dp

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
