### PR TITLE
feat(input): 实现英文直接上屏模式并优化候选词替换机制

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/CandidateState.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/CandidateState.kt
@@ -10,5 +10,7 @@ data class CandidateState(
     val hasPrevPage: Boolean = false,
     val associationCandidates: List<String> = emptyList(),
     val pendingEnglishText: String = "",
-    val isShowingRecentClipboard: Boolean = false
+    val isShowingRecentClipboard: Boolean = false,
+    /** 当前宿主是否支持英文候选的"回删替换"（终端等受限宿主为 false，不展示英文候选）。 */
+    val englishReplaceSupported: Boolean = true
 )

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
@@ -106,9 +106,23 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                         // 需在 clearInputStateForKeys() 之前记录（该函数会清空 preeditText/inputText）。
                         val codeInInputBox = SettingsPreferences.getInputTextLocation(service) ==
                             SettingsPreferences.INPUT_TEXT_INPUT_BOX
-                        service.lastClearedText = when {
-                            codeInInputBox -> candState.preeditText + candState.pendingEnglishText
-                            else -> candState.inputText + candState.pendingEnglishText
+                        val pendingEnglish = candState.pendingEnglishText
+                        if (pendingEnglish.isNotEmpty()) {
+                            // 直接上屏模式：英文编码已逐字落盘，"清输入态"需回删屏上对应字符；
+                            // 校验光标前文本一致才删除并记录撤回，否则只清状态不动已上屏文本。
+                            val removed = withContext(Dispatchers.Main) {
+                                val ic = service.currentInputConnection ?: return@withContext false
+                                val before = runCatching {
+                                    ic.getTextBeforeCursor(pendingEnglish.length, 0)?.toString()
+                                }.getOrNull()
+                                before == pendingEnglish && ic.deleteSurroundingText(pendingEnglish.length, 0)
+                            }
+                            if (removed) service.lastClearedText = pendingEnglish
+                        } else {
+                            service.lastClearedText = when {
+                                codeInInputBox -> candState.preeditText
+                                else -> candState.inputText
+                            }
                         }
                         clearInputStateForKeys()
                     } else {
@@ -236,8 +250,9 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                     val pendingEnglish = candState.pendingEnglishText
 
                     if (pendingEnglish.isNotEmpty()) {
+                        // 直接上屏模式：词已逐字落盘，此处只提交空格并结束本轮英文输入。
                         withContext(Dispatchers.Main) {
-                            service.commitText(pendingEnglish + " ")
+                            service.commitText(" ")
                             service.candidateState.value = service.candidateState.value.copy(
                                 pendingEnglishText = "",
                                 associationCandidates = emptyList()
@@ -384,11 +399,8 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                     if ((state.isAsciiMode || pendingEnglish.isNotEmpty()) && !key.matches(Regex("[a-zA-Z]"))) {
                         val finalKey = key
                         withContext(Dispatchers.Main) {
-                            if (pendingEnglish.isNotEmpty()) {
-                                service.commitText(pendingEnglish + finalKey)
-                            } else {
-                                service.commitText(finalKey)
-                            }
+                            // 直接上屏模式：pendingEnglish 对应字符已逐字落盘，只提交增量键值。
+                            service.commitText(finalKey)
                             service.candidateState.value = service.candidateState.value.copy(
                                 pendingEnglishText = "",
                                 associationCandidates = emptyList()
@@ -446,8 +458,10 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                                         val current = candState.pendingEnglishText
                                         val newPending = current + committed
                                         service.candidateState.value = service.candidateState.value.copy(pendingEnglishText = newPending)
+                                        // 直接上屏模式：只提交 Rime 返回的增量字符（如智能引号转换结果），
+                                        // 整段 pending 对应的文本已逐字上屏，不可重复提交。
                                         withContext(Dispatchers.Main) {
-                                            service.currentInputConnection?.setComposingText(newPending, 1)
+                                            service.currentInputConnection?.commitText(committed, 1)
                                         }
                                         service.uiEventChannel.trySend {
                                             service.sessionController.updateUIWithResult(result)
@@ -470,13 +484,15 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                                                         val charToCommit = if (isShifted) char.uppercase() else char.lowercase()
                                                         val currentPending = candState.pendingEnglishText
                                                         val newPending = currentPending + charToCommit
-                                                        // 用 setComposingText 建立 composing region，选关联候选时 service.commitText 自然替换
+                                                        // 英文直接上屏模式：字符不经 composing region，即输即落盘；
+                                                        // pendingEnglishText 仅作编码记录（供联想与选中候选后回删替换校验）。
                                                         withContext(Dispatchers.Main) {
-                                                            service.currentInputConnection?.setComposingText(newPending, 1)
+                                                            service.currentInputConnection?.commitText(charToCommit, 1)
                                                         }
                                                         service.candidateState.value = service.candidateState.value.copy(
                                                             pendingEnglishText = newPending,
-                                                            associationCandidates = emptyList()
+                                                            associationCandidates = emptyList(),
+                                                            englishReplaceSupported = service.supportsEnglishCandidateReplace()
                                                         )
                                                         needsUIUpdate = true
                                     } else {
@@ -544,7 +560,7 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                             FileLogger.i(XimeInputMethodService.TAG, "keyRouter UI refresh: ascii ${service.uiState.value.isAsciiMode}->$capturedIsAscii")
                         }
                         service.uiState.value = service.uiState.value.copy(isAsciiMode = capturedIsAscii)
-                        if (pendingEnglish.isNotEmpty()) {
+                        if (pendingEnglish.isNotEmpty() && service.supportsEnglishCandidateReplace()) {
                             service.serviceScope.launch {
                                 val candidates = service.predictionManager.getEnglishAssociations(pendingEnglish, PredictionManager.MAX_ASSOCIATION_COUNT)
                                 withContext(Dispatchers.Main) {
@@ -639,9 +655,8 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
         } else when {
             // 1. 英文待处理文本：逐个删除字符，重新加载联想
             candState.pendingEnglishText.isNotEmpty() -> {
-                val pendingLen = candState.pendingEnglishText.length
-                if (pendingLen > 1) {
-                    val newPending = candState.pendingEnglishText.dropLast(1)
+                val newPending = candState.pendingEnglishText.dropLast(1)
+                if (newPending.isNotEmpty()) {
                     withContext(Dispatchers.Main) {
                         service.sendDownUpKeyEvents(KeyEvent.KEYCODE_DEL)
                         service.candidateState.value = service.candidateState.value.copy(
@@ -651,10 +666,12 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                             associationCandidates = emptyList()
                         )
                     }
-                    service.serviceScope.launch {
-                        val candidates = service.predictionManager.getEnglishAssociations(newPending, PredictionManager.MAX_ASSOCIATION_COUNT)
-                        withContext(Dispatchers.Main) {
-                            service.candidateState.value = service.candidateState.value.copy(associationCandidates = candidates)
+                    if (service.supportsEnglishCandidateReplace()) {
+                        service.serviceScope.launch {
+                            val candidates = service.predictionManager.getEnglishAssociations(newPending, PredictionManager.MAX_ASSOCIATION_COUNT)
+                            withContext(Dispatchers.Main) {
+                                service.candidateState.value = service.candidateState.value.copy(associationCandidates = candidates)
+                            }
                         }
                     }
                 } else {

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
@@ -9,6 +9,7 @@ import com.kingzcheung.xime.rime.T9InputController
 import com.kingzcheung.xime.settings.SettingsPreferences
 import com.kingzcheung.xime.ui.keyboard.KeyboardCallbacks
 import com.kingzcheung.xime.ui.keyboard.isT9Schema
+import com.kingzcheung.xime.util.FileLogger
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlinx.coroutines.Dispatchers
@@ -47,7 +48,7 @@ internal fun rememberImeKeyboardCallbacks(
             onAssociationSelect = { index ->
                 service.feedbackManager.performKeyPressEffect(view = view)
                 val cs = service.candidateState.value
-                val adjustedCandidates = if (cs.pendingEnglishText.isNotEmpty()) {
+                val adjustedCandidates = if (cs.pendingEnglishText.isNotEmpty() && cs.englishReplaceSupported) {
                     listOf(cs.pendingEnglishText) + cs.associationCandidates
                 } else {
                     cs.associationCandidates
@@ -56,16 +57,38 @@ internal fun rememberImeKeyboardCallbacks(
                     val text = adjustedCandidates[index]
                     val pendingEnglish = cs.pendingEnglishText
                     if (pendingEnglish.isNotEmpty()) {
+                        // 英文直接上屏模式：编码已逐字落盘，选中候选词时需回删屏上编码再提交候选词。
+                        // 第 0 项即当前已键入文本本身（上屏确认），无需替换。
                         if (index == 0 && text == pendingEnglish) {
-                            service.commitText(text)
                             service.candidateState.value = service.candidateState.value.copy(
                                 pendingEnglishText = "",
                                 associationCandidates = emptyList()
                             )
                         } else {
-                            // 键入时已用 setComposingText 建立 composing region，
-                            // commitText 自然替换 composing 文本，终端也兼容。
-                            service.commitText(text)
+                            val ic = service.currentInputConnection
+                            var replaced = false
+                            if (ic != null) {
+                                val before = runCatching {
+                                    ic.getTextBeforeCursor(pendingEnglish.length, 0)?.toString()
+                                }.getOrNull()
+                                if (before == pendingEnglish) {
+                                    ic.beginBatchEdit()
+                                    try {
+                                        replaced = ic.deleteSurroundingText(pendingEnglish.length, 0)
+                                        ic.commitText(text, 1)
+                                    } finally {
+                                        ic.endBatchEdit()
+                                    }
+                                } else {
+                                    // 光标位置与编码不对应（用户移动过光标）：放弃替换，
+                                    // 候选词降级为直接追加上屏，避免误删用户文本。
+                                    ic.commitText(text, 1)
+                                }
+                            }
+                            FileLogger.d(
+                                XimeInputMethodService.TAG,
+                                "english candidate replace: replaced=$replaced, expected=${pendingEnglish.length} chars"
+                            )
                             service.candidateState.value = service.candidateState.value.copy(
                                 pendingEnglishText = "",
                                 associationCandidates = emptyList()
@@ -290,7 +313,8 @@ internal fun rememberImeKeyboardCallbacks(
             onCommitCandidateBeforeModeChange = {
                 val cs = service.candidateState.value
                 if (cs.pendingEnglishText.isNotEmpty()) {
-                    service.commitText(cs.pendingEnglishText)
+                    // 英文直接上屏模式：编码字符已逐字落盘，切模式只需结束本轮输入（清状态），
+                    // 不可再 commitText 否则会重复输出整个词。
                     service.candidateState.value = cs.copy(
                         pendingEnglishText = "",
                         associationCandidates = emptyList()

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeSchemaController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeSchemaController.kt
@@ -34,8 +34,9 @@ internal class ImeSchemaController(private val service: XimeInputMethodService) 
         val pendingEnglish = candState.pendingEnglishText
         FileLogger.i(XimeInputMethodService.TAG, "switchInputMethod: start, pendingEnglish='${if (pendingEnglish.isEmpty()) '-' else pendingEnglish}', isComposing=${candState.isComposing}, candidates=${candState.candidates.size}")
         if (pendingEnglish.isNotEmpty()) {
+            // 英文直接上屏模式：编码字符已逐字落盘，切模式只需结束本轮输入（清状态），
+            // 不可再 commitText 否则会重复输出整个词。
             withContext(Dispatchers.Main) {
-                service.commitText(pendingEnglish)
                 service.candidateState.value = service.candidateState.value.copy(
                     pendingEnglishText = "",
                     associationCandidates = emptyList()

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeSessionController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeSessionController.kt
@@ -91,7 +91,7 @@ internal class ImeSessionController(private val service: XimeInputMethodService)
         }
         service.uiState.value = service.uiState.value.copy(isAsciiMode = isAsciiMode)
 
-        if (pendingEnglish.isNotEmpty()) {
+        if (pendingEnglish.isNotEmpty() && service.supportsEnglishCandidateReplace()) {
             service.serviceScope.launch {
                 val candidates = service.predictionManager.getEnglishAssociations(pendingEnglish, PredictionManager.MAX_ASSOCIATION_COUNT)
                 withContext(Dispatchers.Main) {
@@ -190,7 +190,7 @@ internal class ImeSessionController(private val service: XimeInputMethodService)
         )
         service.uiState.value = service.uiState.value.copy(isAsciiMode = isAsciiMode)
         
-        if (pendingEnglish.isNotEmpty()) {
+        if (pendingEnglish.isNotEmpty() && service.supportsEnglishCandidateReplace()) {
             service.serviceScope.launch {
                 val candidates = service.predictionManager.getEnglishAssociations(pendingEnglish, PredictionManager.MAX_ASSOCIATION_COUNT)
                 withContext(Dispatchers.Main) {

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1543,7 +1543,8 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             associationCandidates = emptyList(),
             pendingEnglishText = "",
             hasNextPage = false,
-            hasPrevPage = false
+            hasPrevPage = false,
+            englishReplaceSupported = true
         )
         endComposingInputBox()
     }
@@ -1551,15 +1552,27 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     /**
      * 结束输入框中的 composing span，先清空内容再结束，避免转为 committed text。
      *
-     * 无论输入位置设置（输入框/候选栏）都执行：英文输入（pendingEnglishText）始终通过
-     * setComposingText 写入编辑器，清空时若跳过会残留英文 composing 文本。
-     * 中文候选栏模式下编辑器无 composing 文本，本方法为空操作。
+     * 无论输入位置设置（输入框/候选栏）都执行。
+     * 英文输入改为直接上屏模式后不再写入 composing 文本（本方法对英文变为空操作），
+     * 但中文输入框模式仍会产生 composing 区，需在此清理。
      */
     internal fun endComposingInputBox() {
         currentInputConnection?.let {
             it.setComposingText("", 0)
             it.finishComposingText()
         }
+    }
+
+    /**
+     * 当前宿主是否支持英文候选的"回删替换"机制。
+     *
+     * 英文直接上屏模式下，选中候选词需要 deleteSurroundingText 回删已上屏编码再提交候选词；
+     * 终端等受限宿主对该能力（含文本探测接口）通常不支持，探针返回 null。
+     * 此类宿主直接不提供英文联想候选。
+     */
+    internal fun supportsEnglishCandidateReplace(): Boolean {
+        val ic = currentInputConnection ?: return false
+        return runCatching { ic.getTextBeforeCursor(1, 0) != null }.getOrDefault(false)
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -253,7 +253,7 @@ fun KeyboardView(
                         inputText = cs.inputText,
                         preeditText = cs.preeditText,
                         isComposing = cs.isComposing,
-                        associationCandidates = if (cs.pendingEnglishText.isNotEmpty()) {
+                        associationCandidates = if (cs.pendingEnglishText.isNotEmpty() && cs.englishReplaceSupported) {
                             listOf(cs.pendingEnglishText) + cs.associationCandidates
                         } else {
                             cs.associationCandidates


### PR DESCRIPTION
- 新增 englishReplaceSupported 字段用于标识宿主是否支持英文候选回删替换功能
- 实现英文直接上屏模式，字符即输即落盘，不再使用 composing region
- 优化英文候选词选择逻辑，支持回删已上屏编码再提交候选词
- 添加宿主兼容性检测，终端等受限环境不显示英文联想候选
- 修复切换模式时英文编码重复提交的问题
- 优化回退键处理逻辑，确保英文输入状态正确清除

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [x] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
