### PR TITLE
fix(association): 修复联想引擎服务绑定泄漏和服务崩溃恢复问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/association/OnnxAssociationEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/association/OnnxAssociationEngine.kt
@@ -59,6 +59,9 @@ object OnnxAssociationEngine {
             FileLogger.d(TAG, "Using model: ${modelFile.name} (${modelFile.length()} bytes)")
 
             val client = InferenceClient(context)
+            // 先释放旧 client 的绑定，避免每次 initialize 泄漏一个 ServiceConnection
+            // （ServiceConnectionLeaked：切换预测设置时反复 initialize 累积泄漏）
+            inferenceClient?.unbind()
             inferenceClient = client
 
             if (!client.ensureBound()) {
@@ -86,14 +89,25 @@ object OnnxAssociationEngine {
     }
 
     suspend fun predict(inputText: String, topK: Int = 20): List<AssociationCandidate> = withContext(Dispatchers.Default) {
-        if (!isInitialized) {
+        val client = inferenceClient
+        if (!isInitialized || client == null) {
             FileLogger.e(TAG, "Engine not initialized")
             return@withContext emptyList()
         }
 
+        // 服务进程崩溃后 binder 失效：这里必须重置本地"已初始化"假象，
+        // 否则联想将永远空转（无法重新 bind + loadModel）。重置后由
+        // AssociationManager.predict 的现有重试路径自动重新加载，实现自愈。
+        if (!client.isBound()) {
+            FileLogger.w(TAG, "InferenceService not bound, resetting engine state for recovery")
+            release()
+            return@withContext emptyList()
+        }
+
         try {
-            val client = inferenceClient ?: return@withContext emptyList()
-            client.predict(inputText, topK)
+            val result = client.predict(inputText, topK)
+            FileLogger.d(TAG, "Model predict '${inputText.takeLast(10)}' -> ${result.size} candidates (bound=${client.isBound()})")
+            result
         } catch (e: Exception) {
             FileLogger.e(TAG, "Prediction failed: ${e.message}", e)
             emptyList()

--- a/app/src/main/java/com/kingzcheung/xime/service/InferenceClient.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/InferenceClient.kt
@@ -4,6 +4,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
+import android.os.DeadObjectException
 import android.os.IBinder
 import com.kingzcheung.xime.association.AssociationCandidate
 import com.kingzcheung.xime.util.FileLogger
@@ -22,7 +23,9 @@ class InferenceClient(private val context: Context) {
 
     private var service: IInferenceService? = null
     private var bound = false
-    private val connectLatch = CountDownLatch(1)
+
+    @Volatile
+    private var connectLatch = CountDownLatch(1)
 
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName, binder: IBinder) {
@@ -46,15 +49,24 @@ class InferenceClient(private val context: Context) {
         }
     }
 
-    suspend fun ensureBound(): Boolean = withContext(Dispatchers.IO) {
-        if (bound && service != null) return@withContext true
+    /** 服务是否处于可用绑定状态（进程存活且 binder 有效）。 */
+    fun isBound(): Boolean = bound && service != null
 
-        val intent = Intent(context, InferenceService::class.java)
-        val ok = context.bindService(intent, connection, Context.BIND_AUTO_CREATE)
-        if (!ok) return@withContext false
+    suspend fun ensureBound(): Boolean = withContext(Dispatchers.IO) {
+        if (isBound()) return@withContext true
+
+        // 服务进程可能崩溃重启：latch 是一次性的，重绑前必须重建，
+        // 否则旧 latch 已 countDown 会让 await 立即假成功（实际未连接）
+        synchronized(this@InferenceClient) {
+            if (isBound()) return@withContext true
+            connectLatch = CountDownLatch(1)
+            val intent = Intent(context, InferenceService::class.java)
+            val ok = context.bindService(intent, connection, Context.BIND_AUTO_CREATE)
+            if (!ok) return@withContext false
+        }
 
         val connected = connectLatch.await(3, TimeUnit.SECONDS)
-        connected
+        connected && isBound()
     }
 
     fun unbind() {
@@ -69,9 +81,19 @@ class InferenceClient(private val context: Context) {
         return service ?: throw IllegalStateException("InferenceService not bound")
     }
 
+    /** binder 调用失败后重置绑定状态；下一次 ensureBound 会重新 bindService。 */
+    private fun invalidateBinding() {
+        service = null
+        bound = false
+    }
+
     suspend fun loadModel(modelId: String, modelPath: String, extraPath: String = ""): Boolean = withContext(Dispatchers.IO) {
         try {
             requireService().loadModel(modelId, modelPath, extraPath)
+        } catch (e: DeadObjectException) {
+            invalidateBinding()
+            FileLogger.e(TAG, "loadModel($modelId) failed: service died", e)
+            false
         } catch (e: Exception) {
             FileLogger.e(TAG, "loadModel($modelId) failed", e)
             false
@@ -102,6 +124,11 @@ class InferenceClient(private val context: Context) {
                 candidates.add(AssociationCandidate(word, score))
             }
             candidates
+        } catch (e: DeadObjectException) {
+            // 服务进程已死：重置绑定状态，让上层（OnnxAssociationEngine）感知失联并自愈
+            invalidateBinding()
+            FileLogger.e(TAG, "predict failed: service died", e)
+            emptyList()
         } catch (e: Exception) {
             FileLogger.e(TAG, "predict failed", e)
             emptyList()

--- a/app/src/main/java/com/kingzcheung/xime/service/InferenceService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/InferenceService.kt
@@ -70,6 +70,12 @@ class InferenceService : Service() {
 
         override fun predict(modelId: String, text: String, topK: Int): MutableList<String> {
             if (modelId != MODEL_PREDICTION) return mutableListOf()
+            // 模型未加载时（如进程重启后客户端状态未同步）直接返回空，
+            // 避免在未初始化的 native 引擎上推理导致进程崩溃
+            if (!NativeOnnxEngine.isInitialized()) {
+                Log.w(TAG, "predict called before model loaded, returning empty")
+                return mutableListOf()
+            }
             val candidates = NativeOnnxEngine.predict(text, topK)
             val result = mutableListOf<String>()
             for (c in candidates) {
@@ -156,6 +162,11 @@ class InferenceService : Service() {
             return false
         }
 
+        // 先释放旧 session：切换联想模型（small/base）或重复加载时，
+        // 避免 ORT 双 session 并存导致内存峰值过高、进程被系统查杀
+        if (NativeOnnxEngine.isInitialized()) {
+            NativeOnnxEngine.release()
+        }
         if (!NativeOnnxEngine.initialize(this, modelPath)) {
             Log.e(TAG, "NativeOnnxEngine.initialize failed")
             return false

--- a/app/src/main/java/com/kingzcheung/xime/service/PredictionManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/PredictionManager.kt
@@ -120,7 +120,8 @@ class PredictionManager(
                 }
                 
                 val candidates = AssociationManager.predict(contextText, MAX_ASSOCIATION_COUNT)
-                
+                FileLogger.d(TAG, "Prediction returned ${candidates.size} candidates for '$contextText' (epoch ok: ${epoch == requestEpoch})")
+
                 withContext(Dispatchers.Main) {
                     // 代际过期说明上下文已被退格/清空修改，丢弃过期结果避免候选栏闪动
                     if (epoch == requestEpoch) {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidateBar.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidateBar.kt
@@ -414,6 +414,8 @@ fun CandidateBar(
 
                 // 仅当左侧存在打字候选时才需要分隔线；纯联想态（无打字候选）下
                 // 该竖线会孤悬列表最左缘，属多余元素。
+                // 注意：分隔线在条件内，联想词 items 必须在条件外——纯联想态
+                // displayCandidates 为空，若一并包进条件会导致联想词整个不渲染。
                 if (displayCandidates.isNotEmpty() && displayAssociation.isNotEmpty()) {
                     item(key = "divider") {
                         Box(
@@ -424,21 +426,21 @@ fun CandidateBar(
                                 .padding(horizontal = 4.dp)
                         )
                     }
+                }
 
-                    itemsIndexed(displayAssociation, key = { index, _ -> "assoc-$index" }) { index, candidate ->
-                        val assocState = state as? CandidateBarState.AssociationOnly
-                        CandidateItem(
-                            text = candidate,
-                            index = -1,
-                            onClick = { callbacks.onAssociationSelect?.invoke(index) },
-                            textColor = visuals.textColor,
-                            comment = displayComments.getOrElse(index) { "" },
-                            isSelected = assocState?.highlightIndex == index,
-                            accentColor = visuals.accentColor,
-                            selectedTextColor = visuals.selectedTextColor,
-                            fontSize = candidateTextSize.sp
-                        )
-                    }
+                itemsIndexed(displayAssociation, key = { index, _ -> "assoc-$index" }) { index, candidate ->
+                    val assocState = state as? CandidateBarState.AssociationOnly
+                    CandidateItem(
+                        text = candidate,
+                        index = -1,
+                        onClick = { callbacks.onAssociationSelect?.invoke(index) },
+                        textColor = visuals.textColor,
+                        comment = displayComments.getOrElse(index) { "" },
+                        isSelected = assocState?.highlightIndex == index,
+                        accentColor = visuals.accentColor,
+                        selectedTextColor = visuals.selectedTextColor,
+                        fontSize = candidateTextSize.sp
+                    )
                 }
             }
 

--- a/app/src/main/jni/onnx_env.cc
+++ b/app/src/main/jni/onnx_env.cc
@@ -2,6 +2,7 @@
 #include <android/log.h>
 #include <mutex>
 #include <dlfcn.h>
+#include <sys/system_properties.h>
 
 static OrtEnv* g_shared_env = nullptr;
 static std::mutex g_env_mutex;
@@ -76,6 +77,17 @@ void OnnxReleaseSharedEnv() {
 bool OnnxTryEnableNnapi(OrtSessionOptions* options) {
     const OrtApi* api = OnnxGetApi();
     if (!api || !options) return false;
+
+    // 默认禁用 NNAPI：联想模型是动态形状（输出 [1, seq, 8000]，seq 随上下文增长），
+    // nnapi-reference 后端在推理中会触发 SIGSEGV（tombstone: libonnxruntime.so 内
+    // fault addr 0x600000002），导致 :inference 进程死亡、联想永久失效。
+    // int8 动态量化模型在 CPU 上推理耗时仅毫秒级，NNAPI 收益可忽略。
+    // 调试需要时设置系统属性 setprop debug.xime.nnapi 1 重新启用。
+    char value[2] = {0};
+    if (__system_property_get("debug.xime.nnapi", value) == 0 || value[0] != '1') {
+        LOGD("NNAPI EP disabled by default (debug.xime.nnapi not set)");
+        return false;
+    }
 
     typedef OrtStatus* (*NnapiProviderFn)(OrtSessionOptions*, uint32_t);
     NnapiProviderFn nnapi_fn = (NnapiProviderFn)dlsym(


### PR DESCRIPTION
- 在 OnnxAssociationEngine 初始化时先释放旧 client 绑定，避免 ServiceConnection 泄漏
- 当服务进程崩溃后检测 binder 失效状态，重置引擎状态实现自动恢复
- 修复 InferenceClient 中 CountDownLatch 一次性问题，确保服务重启 后能正确重新绑定
- 添加 DeadObjectException 处理，服务死亡时重置绑定状态
- 在 InferenceService 中添加模型加载检查，避免未初始化时崩溃
- 优化 NativeOnnxEngine 切换模型时先释放旧 session 避免内存峰值
- 修复 CandidateBar 联想词显示逻辑，确保纯联想状态下正常渲染
- 默认禁用 NNAPI 执行提供者避免动态形状模型触发崩溃

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
