### PR TITLE
feat(keyboard): 添加表情符号和符号键盘的最近使用功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/data/RecentUsageStore.kt
+++ b/app/src/main/java/com/kingzcheung/xime/data/RecentUsageStore.kt
@@ -1,0 +1,42 @@
+package com.kingzcheung.xime.data
+
+import android.content.Context
+import org.json.JSONArray
+
+/**
+ * 最近使用记录（LRU）：点击即置顶去重，最久未用的排末尾，超出上限截断。
+ * emoji 与符号面板各自独立记录（key 区分），持久化到 SharedPreferences（JSON 数组，
+ * 兼容 emoji ZWJ 组合序列与任意符号字符）。
+ */
+object RecentUsageStore {
+    const val MAX_COUNT = 32
+    private const val PREFS_NAME = "recent_usage"
+    const val KEY_RECENT_EMOJIS = "recent_emojis"
+    const val KEY_RECENT_SYMBOLS = "recent_symbols"
+
+    /**
+     * LRU 核心逻辑（纯函数，便于单测）：置顶去重 + 上限截断。
+     * 不按点击次数排序——"最近使用"语义是时间序，早期高频项按次数排序会固化霸榜。
+     */
+    fun record(list: List<String>, value: String, maxCount: Int = MAX_COUNT): List<String> =
+        (listOf(value) + list.filter { it != value }).take(maxCount)
+
+    fun get(context: Context, key: String): List<String> {
+        val raw = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString(key, null) ?: return emptyList()
+        return runCatching {
+            val arr = JSONArray(raw)
+            List(arr.length()) { arr.getString(it) }
+        }.getOrDefault(emptyList())
+    }
+
+    /** 记录一次使用并持久化，返回更新后的列表（供 UI 状态直接刷新） */
+    fun record(context: Context, key: String, value: String): List<String> {
+        val updated = record(get(context, key), value)
+        val arr = JSONArray()
+        updated.forEach { arr.put(it) }
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().putString(key, arr.toString()).apply()
+        return updated
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/EmojiKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/EmojiKeyboardLayout.kt
@@ -53,6 +53,7 @@ import coil.request.ImageRequest
 import com.kingzcheung.xime.clipboard.ClipboardManager
 import com.kingzcheung.xime.data.EmojiCategory
 import com.kingzcheung.xime.data.EmojiData
+import com.kingzcheung.xime.data.RecentUsageStore
 import com.kingzcheung.xime.plugin.ExtensionManager
 import com.kingzcheung.xime.plugin.core.api.PluginResultItem
 import com.kingzcheung.xime.plugin.core.api.PluginIcon
@@ -85,6 +86,15 @@ fun EmojiKeyboardLayout(
     val pluginCategories = allCategories.filter { it.isPlugin }
     val builtinCategories = allCategories.filter { !it.isPlugin }
 
+    // 最近使用（LRU）：作为内置分区的第一个子分类页，点击 emoji 时置顶记录
+    var recentEmojis by remember {
+        mutableStateOf(RecentUsageStore.get(context, RecentUsageStore.KEY_RECENT_EMOJIS))
+    }
+    val recentCategory = EmojiCategory(name = "最近使用", icon = "🕘", emojis = recentEmojis)
+    val displayBuiltinCategories = remember(builtinCategories, recentEmojis) {
+        listOf(recentCategory) + builtinCategories
+    }
+
     // 按 pluginId 分组插件子分类（用于顶层 tab 和底部子分类 tab）
     val pluginGroupEntries = remember(pluginCategories) {
         pluginCategories.groupBy { it.pluginId ?: it.name }.entries.toList()
@@ -92,7 +102,7 @@ fun EmojiKeyboardLayout(
 
     // 当前顶层 tab 对应的子分类列表
     val currentSubCategories = if (selectedTopTabIndex == 0) {
-        builtinCategories
+        displayBuiltinCategories
     } else {
         val groupIdx = selectedTopTabIndex - 1
         if (groupIdx < pluginGroupEntries.size) pluginGroupEntries[groupIdx].value
@@ -101,14 +111,14 @@ fun EmojiKeyboardLayout(
 
     // 所有页面的扁平索引（用于动画过渡）
     val currentPageIndex = if (selectedTopTabIndex == 0) {
-        selectedSubCategoryIndex.coerceIn(0, maxOf(0, builtinCategories.lastIndex))
+        selectedSubCategoryIndex.coerceIn(0, maxOf(0, displayBuiltinCategories.lastIndex))
     } else {
         val groupIdx = selectedTopTabIndex - 1
-        val startPage = builtinCategories.size + pluginGroupEntries.take(groupIdx).sumOf { it.value.size }
+        val startPage = displayBuiltinCategories.size + pluginGroupEntries.take(groupIdx).sumOf { it.value.size }
         val groupSize = if (groupIdx < pluginGroupEntries.size) pluginGroupEntries[groupIdx].value.lastIndex else 0
         startPage + selectedSubCategoryIndex.coerceIn(0, maxOf(0, groupSize))
     }
-    val totalPages = builtinCategories.size + pluginCategories.size
+    val totalPages = displayBuiltinCategories.size + pluginCategories.size
 
     val configuration = LocalConfiguration.current
     val isLandscape =
@@ -118,7 +128,7 @@ fun EmojiKeyboardLayout(
     // 当前显示的类别
     val currentCategory =
         if (selectedTopTabIndex == 0) {
-            if (builtinCategories.isNotEmpty()) builtinCategories[selectedSubCategoryIndex.coerceIn(0, builtinCategories.lastIndex)]
+            if (displayBuiltinCategories.isNotEmpty()) displayBuiltinCategories[selectedSubCategoryIndex.coerceIn(0, displayBuiltinCategories.lastIndex)]
             else EmojiData.categories.first()
         } else {
             val groupIdx = selectedTopTabIndex - 1
@@ -256,7 +266,7 @@ fun EmojiKeyboardLayout(
         LaunchedEffect(pagerState.currentPage, pagerState.isScrollInProgress) {
             val page = pagerState.currentPage
             if (!pagerState.isScrollInProgress && page != currentPageIndex) {
-                if (page < builtinCategories.size) {
+                if (page < displayBuiltinCategories.size) {
                     selectedTopTabIndex = 0
                     selectedSubCategoryIndex = page
                 } else {
@@ -282,10 +292,10 @@ fun EmojiKeyboardLayout(
                 .padding(horizontal = if (isLandscape) 50.dp else 4.dp)
                 .padding(bottom = 4.dp)
         ) { pageIndex ->
-            val category = if (pageIndex < builtinCategories.size) {
-                builtinCategories[pageIndex]
+            val category = if (pageIndex < displayBuiltinCategories.size) {
+                displayBuiltinCategories[pageIndex]
             } else {
-                pluginCategories[pageIndex - builtinCategories.size]
+                pluginCategories[pageIndex - displayBuiltinCategories.size]
             }
 
             val emojiColumns = if (isLandscape) 15 else 8
@@ -348,6 +358,18 @@ fun EmojiKeyboardLayout(
                         }
                     }
                 }
+            } else if (category.emojis.isEmpty()) {
+                // 最近使用为空时的占位提示
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "暂无最近使用",
+                        color = textColor.copy(alpha = 0.5f),
+                        fontSize = 14.sp
+                    )
+                }
             } else {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
@@ -361,7 +383,12 @@ fun EmojiKeyboardLayout(
                             rowEmojis.forEach { emoji ->
                                 EmojiButton(
                                     emoji = emoji,
-                                    onClick = { onEmojiSelect(emoji) },
+                                    onClick = {
+                                        recentEmojis = RecentUsageStore.record(
+                                            context, RecentUsageStore.KEY_RECENT_EMOJIS, emoji
+                                        )
+                                        onEmojiSelect(emoji)
+                                    },
                                     modifier = Modifier.weight(1f)
                                 )
                             }

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SymbolKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SymbolKeyboardLayout.kt
@@ -30,16 +30,21 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.kingzcheung.xime.data.RecentUsageStore
+import com.kingzcheung.xime.data.SymbolCategory
 import com.kingzcheung.xime.data.SymbolData
 import kotlinx.coroutines.launch
 
@@ -54,7 +59,15 @@ fun SymbolKeyboardLayout(
     bottomPaddingDp: Int = 0,
     modifier: Modifier = Modifier
 ) {
-    val categories = remember { SymbolData.categories }
+    val context = LocalContext.current
+    // 最近使用（LRU）：作为第一个分类页，点击符号时置顶记录
+    var recentSymbols by remember {
+        mutableStateOf(RecentUsageStore.get(context, RecentUsageStore.KEY_RECENT_SYMBOLS))
+    }
+    val displayCategories = remember(recentSymbols) {
+        listOf(SymbolCategory(name = "最近使用", id = "recentSymbols", symbols = recentSymbols)) +
+            SymbolData.categories
+    }
     // 图标按钮容器色：surface 与 primary 的混合色调（带种子色但不过于强烈）
     val iconButtonContainer = androidx.compose.ui.graphics.lerp(
         MaterialTheme.colorScheme.surface,
@@ -67,7 +80,7 @@ fun SymbolKeyboardLayout(
 
     val pagerState = rememberPagerState(
         initialPage = 0,
-        pageCount = { categories.size }
+        pageCount = { displayCategories.size }
     )
 
     Column(
@@ -112,10 +125,22 @@ fun SymbolKeyboardLayout(
                 state = pagerState,
                 modifier = Modifier.fillMaxSize()
             ) { page ->
-                val category = categories[page]
+                val category = displayCategories[page]
                 val columns = if (isLandscape) 15 else 8
 
-                Column(
+                if (category.symbols.isEmpty()) {
+                    // 最近使用为空时的占位提示
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "暂无最近使用",
+                            color = textColor.copy(alpha = 0.5f),
+                            fontSize = 14.sp
+                        )
+                    }
+                } else Column(
                     modifier = Modifier
                         .fillMaxSize()
                         .verticalScroll(rememberScrollState()),
@@ -129,7 +154,12 @@ fun SymbolKeyboardLayout(
                             rowSymbols.forEach { symbol ->
                                 SymbolButton(
                                     symbol = symbol,
-                                    onClick = { onSelect(symbol) },
+                                    onClick = {
+                                        recentSymbols = RecentUsageStore.record(
+                                            context, RecentUsageStore.KEY_RECENT_SYMBOLS, symbol
+                                        )
+                                        onSelect(symbol)
+                                    },
                                     modifier = Modifier.weight(1f),
                                     textColor = textColor,
                                     backgroundColor = keyBgColor,
@@ -159,7 +189,7 @@ fun SymbolKeyboardLayout(
                     .horizontalScroll(rememberScrollState()),
                 horizontalArrangement = Arrangement.spacedBy(2.dp)
             ) {
-                categories.forEachIndexed { index, category ->
+                displayCategories.forEachIndexed { index, category ->
                     SymbolCategoryTab(
                         name = category.name,
                         isSelected = index == pagerState.currentPage,

--- a/app/src/test/java/com/kingzcheung/xime/data/RecentUsageStoreTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/data/RecentUsageStoreTest.kt
@@ -1,0 +1,42 @@
+package com.kingzcheung.xime.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RecentUsageStoreTest {
+
+    @Test
+    fun `新值置顶`() {
+        val result = RecentUsageStore.record(listOf("a", "b"), "c")
+        assertEquals(listOf("c", "a", "b"), result)
+    }
+
+    @Test
+    fun `已存在的值置顶去重`() {
+        val result = RecentUsageStore.record(listOf("a", "b", "c"), "b")
+        assertEquals(listOf("b", "a", "c"), result)
+    }
+
+    @Test
+    fun `重复点击同一值不产生重复项`() {
+        var list = emptyList<String>()
+        repeat(5) { list = RecentUsageStore.record(list, "x") }
+        assertEquals(listOf("x"), list)
+    }
+
+    @Test
+    fun `超出上限截断末尾`() {
+        var list = emptyList<String>()
+        for (i in 0 until RecentUsageStore.MAX_COUNT + 5) {
+            list = RecentUsageStore.record(list, "k$i")
+        }
+        assertEquals(RecentUsageStore.MAX_COUNT, list.size)
+        assertEquals("k${RecentUsageStore.MAX_COUNT + 4}", list.first())
+        assertEquals("k5", list.last())
+    }
+
+    @Test
+    fun `空列表首次记录`() {
+        assertEquals(listOf("a"), RecentUsageStore.record(emptyList(), "a"))
+    }
+}


### PR DESCRIPTION
- 在表情键盘中引入最近使用（LRU）分类，自动记录和置顶最近使用的emoji
- 在符号键盘中添加最近使用分类，支持符号的使用历史记录
- 实现RecentUsageStore来管理最近使用的emoji和符号数据
- 为最近使用分类添加空状态占位提示界面
- 更分页逻辑以包含最近使用分类页面的正确索引计算

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] 新功能
- [ ] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
