### PR TITLE
feat(input-service): 实现联想候选上屏功能和空格键优化

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
@@ -384,6 +384,21 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                                 needsUIUpdate = true
                             }
                         }
+                    } else if (!state.isAsciiMode &&
+                        SettingsPreferences.isSpaceCommitAssociationEnabled(service) &&
+                        candState.associationCandidates.isNotEmpty()
+                    ) {
+                        // 空格上屏联想候选（中文模式 + 开关开启 + 联想候选存在）：上屏第一个联想词。
+                        // 仅中文联想——英文模式此分支不生效，空格保持上屏空格字符；
+                        // 连续联想模式：commitText 会自动触发下一轮推理（一直上屏一直推理）；
+                        // 单次联想模式：先置抑制标志，上屏引发的那轮推理被跳过并清空联想候选。
+                        val association = candState.associationCandidates.first()
+                        withContext(Dispatchers.Main) {
+                            if (SettingsPreferences.isSingleAssociationMode(service)) {
+                                service.predictionManager.suppressNextPredictionOnce()
+                            }
+                            service.commitText(association)
+                        }
                     } else {
                         withContext(Dispatchers.Main) {
                             service.commitText(" ")

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
@@ -83,6 +83,14 @@ internal fun rememberImeKeyboardCallbacks(
                             )
                         }
                     } else {
+                        // 单次联想模式（仅中文模式——英文 commitText 不触发推理，
+                        // 否则抑制标志会悬挂并吞掉下次切回中文后的首轮推理）：
+                        // 联想候选上屏前先置抑制标志——commitText 触发的下一轮自动推理
+                        // 被跳过并清空联想候选（只推理一次）。
+                        // 连续联想模式：不抑制，commitText 自动推理新联想（一直上屏一直推理）。
+                        if (!service.uiState.value.isAsciiMode && SettingsPreferences.isSingleAssociationMode(service)) {
+                            service.predictionManager.suppressNextPredictionOnce()
+                        }
                         service.commitText(text)
                         service.updateUI()
                     }

--- a/app/src/main/java/com/kingzcheung/xime/service/PredictionManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/PredictionManager.kt
@@ -37,6 +37,18 @@ class PredictionManager(
     fun invalidatePendingPredictions() {
         requestEpoch++
     }
+
+    /**
+     * 单次联想抑制标志：联想候选上屏（点击/空格）前置位，使 commitText 触发的下一轮
+     * 自动推理被跳过并清空联想候选（候选栏干净），等待用户下一次真实输入。
+     * 连续联想模式不置位——commitText 的自动推理即为"一直上屏一直推理"。
+     */
+    @Volatile
+    private var suppressNextPrediction = false
+
+    fun suppressNextPredictionOnce() {
+        suppressNextPrediction = true
+    }
     
     fun appendCommittedText(text: String) {
         _lastCommittedText = (_lastCommittedText + text).takeLast(MAX_CONTEXT_LENGTH)
@@ -91,6 +103,13 @@ class PredictionManager(
     }
     
     fun getPrediction(contextText: String) {
+        // 单次联想：消费抑制标志——联想上屏引发的本轮推理不执行，回调空结果清空候选栏
+        if (suppressNextPrediction) {
+            suppressNextPrediction = false
+            onPredictionResult(emptyList())
+            return
+        }
+
         if (contextText.isEmpty()) {
             onPredictionResult(emptyList())
             return

--- a/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
@@ -25,6 +25,8 @@ object SettingsPreferences {
     const val KEY_SMART_PREDICTION_ENABLED = "smart_prediction_enabled"
     private const val KEY_PREDICTION_MODEL_REPO = "prediction_model_repo"
     private const val KEY_PREDICTION_SELECTED_MODEL = "prediction_selected_model"
+    private const val KEY_SPACE_COMMIT_ASSOCIATION = "space_commit_association"
+    private const val KEY_ASSOCIATION_SINGLE_MODE = "association_single_mode"
     
     const val KEY_STT_ENABLED = "stt_enabled"
     const val KEY_STT_ONLINE_PLUGIN_ID = "stt_online_plugin_id"
@@ -354,6 +356,27 @@ object SettingsPreferences {
     
     fun setPredictionSelectedModel(context: Context, modelId: String) {
         getPrefs(context).edit().putString(KEY_PREDICTION_SELECTED_MODEL, modelId).apply()
+    }
+
+    /** 空格上屏联想候选：有联想候选时按空格键直接上屏第一个联想词（而非空格字符） */
+    fun isSpaceCommitAssociationEnabled(context: Context): Boolean {
+        return getPrefs(context).getBoolean(KEY_SPACE_COMMIT_ASSOCIATION, false)
+    }
+
+    fun setSpaceCommitAssociationEnabled(context: Context, enabled: Boolean) {
+        getPrefs(context).edit().putBoolean(KEY_SPACE_COMMIT_ASSOCIATION, enabled).apply()
+    }
+
+    /**
+     * 联想模式：false = 连续联想（联想上屏后继续推理，可连续上屏），true = 单次联想（只推理一次）。
+     * 默认连续（保持历史行为）。
+     */
+    fun isSingleAssociationMode(context: Context): Boolean {
+        return getPrefs(context).getBoolean(KEY_ASSOCIATION_SINGLE_MODE, false)
+    }
+
+    fun setAssociationSingleMode(context: Context, single: Boolean) {
+        getPrefs(context).edit().putBoolean(KEY_ASSOCIATION_SINGLE_MODE, single).apply()
     }
     
     fun isSttEnabled(context: Context): Boolean {

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SmartPredictionSettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SmartPredictionSettingsScreen.kt
@@ -1,6 +1,7 @@
 package com.kingzcheung.xime.ui.settings
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -34,6 +35,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
@@ -188,6 +190,57 @@ fun SmartPredictionSettingsContent(
                 })
             }
 
+            if (uiState.isEnabled) {
+                item {
+                    var spaceCommitEnabled by remember {
+                        mutableStateOf(SettingsPreferences.isSpaceCommitAssociationEnabled(context))
+                    }
+                    var singleMode by remember {
+                        mutableStateOf(SettingsPreferences.isSingleAssociationMode(context))
+                    }
+                    SettingsSection(title = "联想行为", content = {
+                        SettingsToggleItem(
+                            icon = Icons.Default.AutoAwesome,
+                            title = "空格上屏联想候选",
+                            subtitle = "有联想候选时，按空格键直接上屏第一个联想词",
+                            checked = spaceCommitEnabled,
+                            onCheckedChange = {
+                                spaceCommitEnabled = it
+                                SettingsPreferences.setSpaceCommitAssociationEnabled(context, it)
+                            }
+                        )
+                        HorizontalDivider(
+                            modifier = Modifier.padding(start = 16.dp),
+                            thickness = 0.5.dp,
+                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                        )
+                        AssociationModeRow(
+                            title = "连续联想",
+                            subtitle = "联想词上屏后继续推理，可连续空格上屏联想词",
+                            isSelected = !singleMode,
+                            onClick = {
+                                singleMode = false
+                                SettingsPreferences.setAssociationSingleMode(context, false)
+                            }
+                        )
+                        HorizontalDivider(
+                            modifier = Modifier.padding(start = 16.dp),
+                            thickness = 0.5.dp,
+                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                        )
+                        AssociationModeRow(
+                            title = "单次联想",
+                            subtitle = "联想词上屏一次后停止推理，待下次输入再联想",
+                            isSelected = singleMode,
+                            onClick = {
+                                singleMode = true
+                                SettingsPreferences.setAssociationSingleMode(context, true)
+                            }
+                        )
+                    })
+                }
+            }
+
             if (predictionModels.isNotEmpty()) {
                 item {
                     SettingsSection(title = "选择模型", content = {
@@ -290,6 +343,38 @@ fun SmartPredictionSettingsContent(
                 })
             }
         }
+    }
+}
+
+@Composable
+private fun AssociationModeRow(
+    title: String,
+    subtitle: String,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                color = if (isSelected) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        RadioButton(selected = isSelected, onClick = onClick)
     }
 }
 


### PR DESCRIPTION
- 新增空格键上屏联想候选功能：在中文模式下，当联想候选存在且开关开启时， 按空格键直接上屏第一个联想词而非空格字符

- 添加单次/连续联想模式切换：支持单次联想（上屏后停止推理）和连续联想 （上屏后继续推理）两种模式

- 在ImeKeyRouter中实现空格键联想上屏逻辑，包括对ASCII模式的判断和候选 验证

- 在ImeKeyboardCallbacks中处理联想候选上屏时的抑制标志设置

- 扩展PredictionManager增加suppressNextPrediction标志，用于控制单次联 想模式下的推理行为

- 在SettingsPreferences中新增space_commit_association和 association_single_mode配置项

- 在SmartPredictionSettingsScreen中添加联想行为设置界面，包含开关选项 和模式选择

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] 新功能
- [ ] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
