### PR TITLE
feat(handwriting): 实现手写叠写功能和版本更新

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,8 +43,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 20260829
-        versionName = "2.8.0"
+        versionCode = 20260830
+        versionName = "2.8.0-beta1"
 
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/kingzcheung/xime/handwriting/HandwritingStrokeFx.kt
+++ b/app/src/main/java/com/kingzcheung/xime/handwriting/HandwritingStrokeFx.kt
@@ -1,0 +1,62 @@
+package com.kingzcheung.xime.handwriting
+
+import com.kingzcheung.xime.handwriting.OverlappedHandwritingRecognizer.Segment
+
+/** 停顿分割阈值（自适应基准）：笔画越多越接近写完，定型越快；起笔阶段保守防误分割。 */
+const val HW_SPLIT_PAUSE_BASE_MS = 700L
+
+/** 每多一笔，停顿阈值递减量（ms）。 */
+const val HW_SPLIT_PAUSE_STEP_MS = 50L
+
+/** 停顿分割阈值下限（ms）。 */
+const val HW_SPLIT_PAUSE_MIN_MS = 500L
+
+/** 识别窗口笔画上限：超过后固化最早段滑窗（正常分割靠停顿，此为不停顿兜底）。 */
+const val HW_RECOGNIZE_WINDOW_LIMIT = 25
+
+/**
+ * 淡出的停顿门槛（ms）：段边界笔间间隔达到此值才视为"换字"，
+ * 前面段笔画才变淡——连笔中途的切分抖动（如"在"=[一][丿][丨]）不触发淡出，
+ * 避免单字没写完部首就消失。
+ */
+const val HW_FADE_GAP_MS = 400L
+
+/**
+ * 手写叠写共享常量与纯函数（主手写键盘与手写查词键盘共用）。
+ */
+object HandwritingStrokeFx {
+
+    /**
+     * 停顿分割阈值（自适应）：笔画越多字越接近写完，定型越快；
+     * 起笔阶段保守（1~2 笔时停顿多半是构思，防慢写者单字中途被误分割）。
+     *
+     * @param windowStrokes 当前识别窗口（未固化）笔画数。
+     */
+    fun splitPauseMs(windowStrokes: Int): Long =
+        (HW_SPLIT_PAUSE_BASE_MS - (windowStrokes - 1) * HW_SPLIT_PAUSE_STEP_MS)
+            .coerceAtLeast(HW_SPLIT_PAUSE_MIN_MS)
+
+    /** 窗口的笔间时间间隔（gaps[j] = 第 j 笔起笔与上一笔收笔的间隔，gaps[0]=0）。 */
+    fun windowGaps(window: List<List<StrokePoint>>): List<Long> =
+        window.mapIndexed { idx, stroke ->
+            if (idx == 0) 0L else stroke.first().timeMs - window[idx - 1].last().timeMs
+        }
+
+    /**
+     * 计算"已完成字"的笔画数（淡出范围）：从最后一段往前找第一个
+     * 换字停顿边界（间隔 ≥ [HW_FADE_GAP_MS]），该边界之前的段全部视为已完成。
+     * 找不到（全程连笔，单字书写中途）返回 0——不淡出。
+     */
+    fun settledStrokesBeforeCurrent(
+        segments: List<Segment>,
+        gaps: List<Long>,
+    ): Int {
+        for (k in segments.size - 1 downTo 1) {
+            val start = segments[k].startStroke
+            if (start < gaps.size && gaps[start] >= HW_FADE_GAP_MS) {
+                return start
+            }
+        }
+        return 0
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/handwriting/OverlappedHandwritingRecognizer.kt
+++ b/app/src/main/java/com/kingzcheung/xime/handwriting/OverlappedHandwritingRecognizer.kt
@@ -1,0 +1,238 @@
+package com.kingzcheung.xime.handwriting
+
+/**
+ * 叠写（连写）识别引擎：在单字识别模型之上实现多字连笔切分。
+ *
+ * 原理：过分割 + 动态规划组合打分。把笔画序列按所有可能的切分点切段，
+ * 每段送单字模型识别，DP 求全局最优切分。段间比较用"段均分 + 切分惩罚"，
+ * 解决部件成字问题（如"张" = 弓 + 长，两者都是独立汉字）：
+ * 未写完时即使被切成 [弓][卜]，写完后合并段"张"的分数更高，均分比较
+ * 会切回单段，上屏内容随之替换纠正。
+ *
+ * 缓存约定：笔画序列只允许尾部追加（前缀不变），段推理结果跨笔画复用；
+ * 笔画缓冲被裁剪/清空时必须调用 [reset] 使缓存失效。
+ *
+ * 推理成本：每追加一笔，仅新增 ≤ [maxStrokesPerSegment] 次单字 ONNX 推理
+ * （其余段全部命中缓存），后台线程调用即可。
+ */
+class OverlappedHandwritingRecognizer(
+    /** 活动笔画最多同时叠写的字数，超过后由调用方固化最早的字。 */
+    private val maxSegments: Int = DEFAULT_MAX_SEGMENTS,
+    /** 单个字允许的最大笔画数（超出视为不可识别为单字）。 */
+    private val maxStrokesPerSegment: Int = DEFAULT_MAX_STROKES_PER_SEGMENT,
+) {
+    /**
+     * 单个切分段（一个字）。
+     *
+     * @param startStroke 段起始笔画索引（0-based，相对本次 recognize 输入）。
+     * @param strokeCount 段内笔画数。
+     * @param candidates 候选字列表（降序，非空）。
+     */
+    data class Segment(
+        val startStroke: Int,
+        val strokeCount: Int,
+        val candidates: List<HandwritingCandidate>,
+    )
+
+    /**
+     * 识别结果。
+     *
+     * @param segments 最优切分（时间序）：最后一段为"当前正在写的字"，
+     *                 前面的段已可固化上屏。段候选非空。
+     * @param totalScore 最优切分的识别分总和。
+     * @param avgScore 段均分（切分比较依据）。
+     */
+    data class Result(
+        val segments: List<Segment>,
+        val totalScore: Float,
+        val avgScore: Float,
+    )
+
+    private val segCache = HashMap<Long, List<HandwritingCandidate>>()
+
+    /**
+     * 对笔画序列做叠写识别。
+     *
+     * @param strokes 笔画序列（时间序，前缀不可变；超长时自动裁剪并清缓存）。
+     * @param gaps 笔间时间间隔（毫秒）：gaps[j] = 第 j 笔起笔与第 j-1 笔收笔的
+     *             间隔（gaps[0] 恒为 0）。分割信号：停顿处倾向切分、连笔处压制切分。
+     *             与 strokes 长度一致或为空（视为无间隔信息）。
+     * @param predictFn 单字识别函数，生产环境用 [HandwritingEngine.predict]；
+     *                  测试注入假模型。
+     */
+    fun recognize(
+        strokes: List<List<Pair<Float, Float>>>,
+        gaps: List<Long> = emptyList(),
+        predictFn: (List<List<Pair<Float, Float>>>, Int) -> List<HandwritingCandidate> =
+            { s, k -> HandwritingEngine.predict(s, k) }
+    ): Result {
+        val bounded = if (strokes.size > maxSegments * maxStrokesPerSegment) {
+            reset()
+            strokes.takeLast(maxSegments * maxStrokesPerSegment)
+        } else {
+            strokes
+        }
+        val n = bounded.size
+        if (n == 0) return Result(emptyList(), 0f, 0f)
+
+        val neg = Float.NEGATIVE_INFINITY
+        // best[k][i]：前 i 笔切成 k 段的最大识别分总和（含时间间隔偏置）
+        val best = Array(maxSegments + 1) { FloatArray(n + 1) { neg } }
+        val back = Array(maxSegments + 1) { IntArray(n + 1) { -1 } }
+        best[0][0] = 0f
+
+        for (k in 1..maxSegments) {
+            for (i in 1..n) {
+                val minJ = (i - maxStrokesPerSegment).coerceAtLeast(0)
+                for (j in minJ until i) {
+                    val prev = best[k - 1][j]
+                    if (prev == neg) continue
+                    val candidates = segmentCandidates(j, i, bounded, predictFn)
+                    if (candidates.isEmpty()) continue
+                    // 时间偏置：j>0 时新段起笔与上一段收笔的间隔影响切分倾向
+                    val gapBias = if (j > 0 && j < gaps.size) gapBias(gaps[j]) else 0f
+                    val score = prev + candidates[0].score + gapBias
+                    if (best[k][i] == neg || score > best[k][i]) {
+                        best[k][i] = score
+                        back[k][i] = j
+                    }
+                }
+            }
+        }
+
+        // 段间比较：段均分 - 每多切一段的惩罚。均分避免"两段低分字之和
+        // 虚高压过单段高分字"；惩罚避免"多一刀白赚分数"。
+        var bestK = 0
+        var bestNorm = neg
+        for (k in 1..maxSegments) {
+            val total = best[k][n]
+            if (total == neg) continue
+            val norm = total / k - SEGMENT_PENALTY * (k - 1)
+            if (norm > bestNorm) {
+                bestNorm = norm
+                bestK = k
+            }
+        }
+        if (bestK == 0) return Result(emptyList(), 0f, 0f)
+
+        // "一个字"先验：DP 选出多段时，必须存在"显著换字停顿"才信任切分。
+        // 显著性用相对阈值判定——边界间隔显著高于窗口内笔间间隔中位数
+        // （慢写者字内间隔本身高，绝对阈值会把匀速书写的复杂字拆开；
+        //   快写者字间间隔虽小但相对突出，仍能正确检出）。
+        // 无显著停顿时按单字处理（合并段识别），输入框始终只显示一个字；
+        // 连笔写多字词时合并段分数必然极低（跨字笔迹不成字），仍尊重 DP 切分。
+        if (bestK >= 2 && !hasPauseBoundary(gaps)) {
+            val merged = segmentCandidates(0, n, bounded, predictFn)
+            val mergedScore = merged.firstOrNull()?.score ?: 0f
+            if (mergedScore >= MERGED_CHAR_MIN_SCORE) {
+                return Result(listOf(Segment(0, n, merged)), mergedScore, mergedScore)
+            }
+        }
+
+        val segments = mutableListOf<Segment>()
+        var i = n
+        for (k in bestK downTo 1) {
+            val j = back[k][i]
+            segments.add(0, Segment(j, i - j, segmentCandidates(j, i, bounded, predictFn)))
+            i = j
+        }
+        val total = best[bestK][n]
+        return Result(segments, total, total / bestK)
+    }
+
+    /** 笔画缓冲被裁剪或清空时调用，使段缓存失效。 */
+    fun reset() {
+        segCache.clear()
+    }
+
+    /**
+     * 窗口滑窗：头部裁剪 k 笔后调用。段缓存 key 平移（(j,i)→(j-k,i-k)），
+     * 被裁笔画之外的段全部复用，无需重新推理。
+     */
+    fun onStrokesTrimmed(k: Int) {
+        if (k <= 0) return
+        val shifted = HashMap<Long, List<HandwritingCandidate>>()
+        for ((key, candidates) in segCache) {
+            val j = (key / 1000L).toInt()
+            val i = (key % 1000L).toInt()
+            if (i > k) shifted[(j - k).toLong() * 1000L + (i - k)] = candidates
+        }
+        segCache.clear()
+        segCache.putAll(shifted)
+    }
+
+    private fun segmentCandidates(
+        j: Int,
+        i: Int,
+        strokes: List<List<Pair<Float, Float>>>,
+        predictFn: (List<List<Pair<Float, Float>>>, Int) -> List<HandwritingCandidate>
+    ): List<HandwritingCandidate> {
+        val key = j.toLong() * 1000L + i
+        segCache[key]?.let { return it }
+        val segment = strokes.subList(j, i).map { stroke ->
+            stroke.map { Pair(it.first, it.second) }
+        }
+        val candidates = predictFn(segment, SEGMENT_TOP_K).take(SEGMENT_TOP_K)
+        segCache[key] = candidates
+        return candidates
+    }
+
+    /**
+     * 切分点时间偏置：笔间停顿是分字的最强信号——
+     * 明显停顿（≥500ms）倾向在此切分（加分）；
+     * 连笔（≤150ms）压制切分（减分），避免单字中途被拆出部件字。
+     */
+    private fun gapBias(gapMs: Long): Float = when {
+        gapMs >= GAP_SPLIT_MS -> GAP_SPLIT_BONUS
+        gapMs <= GAP_JOIN_MS -> GAP_JOIN_MALUS
+        else -> 0f
+    }
+
+    /**
+     * 显著换字停顿检测（相对阈值）：
+     * - 窗口内笔间间隔样本少（<3 个）时用绝对阈值 [GAP_SPLIT_MS]（无中位数参照）；
+     * - 否则边界间隔 ≥ max(中位数×2, [GAP_PAUSE_MIN_MS]) 才算换字。
+     * 匀速慢写的复杂字（字内间隔均匀偏高）无显著边界 → 判定单字；
+     * 快写多字词（字间间隔相对突出）→ 正确检出边界。
+     */
+    private fun hasPauseBoundary(gaps: List<Long>): Boolean {
+        val inner = gaps.drop(1)
+        if (inner.isEmpty()) return false
+        val threshold = if (inner.size < 3) {
+            GAP_SPLIT_MS
+        } else {
+            val median = inner.sorted()[inner.size / 2]
+            maxOf(median * 2, GAP_PAUSE_MIN_MS)
+        }
+        return inner.any { it >= threshold }
+    }
+
+    companion object {
+        /**
+         * 活动笔画最多同时叠写的字数。
+         * 5 段上限保证单字书写中途的临时多段切分（如"在"写到 3 笔时的
+         * [一][丿][丨]）不会被误当作多字而触发固化——写完后合并段分数
+         * 更高会自动切回单段替换。
+         */
+        const val DEFAULT_MAX_SEGMENTS = 5
+        const val DEFAULT_MAX_STROKES_PER_SEGMENT = 20
+        private const val SEGMENT_PENALTY = 0.02f
+        private const val SEGMENT_TOP_K = 8
+
+        /** 笔间停顿达到此值视为"换字"切分点（加分）。 */
+        const val GAP_SPLIT_MS = 500L
+        /** 笔间间隔小于此值视为连笔（压制切分）。 */
+        const val GAP_JOIN_MS = 150L
+        private const val GAP_SPLIT_BONUS = 0.15f
+        private const val GAP_JOIN_MALUS = -0.08f
+
+        /**
+         * 合并段（全窗口单字识别）分数达到此值视为"笔迹整体像一个字"：
+         * 无显著停顿时强制按单字处理（上屏 1 个字），防止单字中途被拆成多字上屏。
+         */
+        private const val MERGED_CHAR_MIN_SCORE = 0.35f
+
+        /** 相对停顿检测的绝对下限（ms）：中位数极低（极快连写）时防止阈值过低。 */
+        private const val GAP_PAUSE_MIN_MS = 250L
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
@@ -105,6 +105,17 @@ internal fun rememberImeKeyboardCallbacks(
             onClipboardPullRemote = { service.clipboardSyncBridge?.pullOnce() },
             onCommitText = { text -> service.textCommit.commitClipboardText(text) },
             onDeleteText = { count -> service.textCommit.deleteClipboardChars(count) },
+            onHandwritingAutoCommit = { newTail, expectedTail ->
+                if (expectedTail.isEmpty()) {
+                    service.commitTextSilently(newTail)
+                    true
+                } else {
+                    // 光标前文本与手写尾部不对应（用户移动过光标/退格过）时不上屏，
+                    // 调用方重置手写尾部状态后以追加模式重建，避免误删/重复上屏
+                    service.replaceBeforeCursor(expectedTail, newTail)
+                }
+            },
+            onHandwritingFinalize = { service.finalizeHandwritingPrediction() },
             onQuickSend = {},
             onKeyboardResize = {
                 val config = service.resources.configuration

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -562,6 +562,32 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                             // 手写方案：不要调 rimeEngine.switchSchema（Rime 没有手写引擎），
                             // 也不要覆盖 savedSchema（由 onStartInput 恢复 UI）
                             Log.d(TAG, "initRimeEngine: savedSchema is handwriting, keeping current Rime schema")
+                            // UI 布局恢复：冷启动时第一次 onStartInput 先于引擎初始化完成，
+                            // RimeEngine.isInitialized()=false 会跳过 handwriting UI 恢复，
+                            // 此处必须补切，否则第一次弹出键盘停留在默认全键盘
+                            val hwDir = com.kingzcheung.xime.model.ModelStorage.getModelDir(
+                                this@XimeInputMethodService, "ochwpro"
+                            )
+                            com.kingzcheung.xime.model.ModelStorage.migrateLegacyForModel(
+                                this@XimeInputMethodService, "ochwpro"
+                            )
+                            val modelOk = java.io.File(hwDir, "ochwpro.onnx").exists() &&
+                                java.io.File(hwDir, "char_index.json").exists()
+                            if (modelOk) {
+                                val page = keyboardViewModel.page.value
+                                val alreadyHandwriting = page is com.kingzcheung.xime.keyboard.KeyboardPage.Main &&
+                                    page.type == com.kingzcheung.xime.keyboard.MainType.HANDWRITING
+                                if (!alreadyHandwriting) {
+                                    keyboardViewModel.switchMain(com.kingzcheung.xime.keyboard.MainType.HANDWRITING)
+                                }
+                            } else {
+                                Log.w(TAG, "initRimeEngine: handwriting model missing, keep full keyboard")
+                                android.widget.Toast.makeText(
+                                    this@XimeInputMethodService,
+                                    "请先下载手写模型",
+                                    android.widget.Toast.LENGTH_LONG
+                                ).show()
+                            }
                         }
                         savedSchema in availableSchemas -> {
                             // 即使 savedSchema == currentSchema 也要调用 switchSchema，
@@ -2161,6 +2187,23 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     internal val pluginEvents = PluginEventDispatcher(this)
 
     override fun commitText(text: String) {
+        commitTextSilently(text)
+        if (isChineseMode) {
+            mainHandler.post {
+                if (!uiState.value.isAsciiMode) {
+                    getPredictionFromPlugin(predictionManager.lastCommittedText)
+                }
+            }
+        }
+    }
+
+    /**
+     * 静默上屏：与 [commitText] 相同的落盘路径（内部编辑器重定向、InputConnection、
+     * text_committed 事件、联想上下文/输入统计），但不触发联想推理。
+     * 手写叠写自动上屏/替换使用——笔画替换频率高，逐次推理既浪费又会闪烁候选栏。
+     * 需在主线程调用。
+     */
+    internal fun commitTextSilently(text: String) {
         if (uiState.value.quickSendFormFocused) {
             mainHandler.post {
                 QuickSendFormEditTextHolder.editText?.let { et ->
@@ -2192,11 +2235,18 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         if (isChineseMode) {
             predictionManager.appendCommittedText(text)
             predictionManager.recordInput(text)
+        }
+    }
 
-            mainHandler.post {
-                if (!uiState.value.isAsciiMode) {
-                    getPredictionFromPlugin(predictionManager.lastCommittedText)
-                }
+    /**
+     * 手写活动区固化后触发一轮联想推理（基于已上屏文本）。
+     * 空格/标点上屏走全量 commitText 自带推理，无需调用此方法。
+     */
+    internal fun finalizeHandwritingPrediction() {
+        if (!isChineseMode) return
+        mainHandler.post {
+            if (!uiState.value.isAsciiMode) {
+                getPredictionFromPlugin(predictionManager.lastCommittedText)
             }
         }
     }

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/HandwritingKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/HandwritingKeyboardLayout.kt
@@ -38,19 +38,35 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.kingzcheung.xime.handwriting.HandwritingCandidate
 import com.kingzcheung.xime.handwriting.HandwritingEngine
+import com.kingzcheung.xime.handwriting.HandwritingStrokeFx
+import com.kingzcheung.xime.handwriting.HW_RECOGNIZE_WINDOW_LIMIT
+import com.kingzcheung.xime.handwriting.OverlappedHandwritingRecognizer
 import com.kingzcheung.xime.handwriting.StrokePoint
 import com.kingzcheung.xime.handwriting.renderStrokes
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+
+/** 超长闲置（ms）：停顿变淡后无新笔画达到此时长才真正清空识别窗口。 */
+private const val HW_CLEAR_IDLE_MS = 3000L
 
 @Composable
 fun HandwritingKeyboardLayout(
     onKeyPress: (String) -> Unit = {},
-    onCandidates: ((List<HandwritingCandidate>) -> Unit)? = null,
+    /**
+     * 叠写识别结果上报（每次笔画更新后）：
+     * segments 为当前笔画窗口的最优切分（最后一段=当前字，前面的段已可固化）。
+     * 接收方负责把段首选字拼接写入屏上（替换式）并刷新候选栏。
+     */
+    onRecognition: ((List<OverlappedHandwritingRecognizer.Segment>) -> Unit)? = null,
+    /** 叠写满上限时最早段被固化（笔画已裁剪出识别窗口），携带该段首选字。 */
+    onSegmentSettled: ((String) -> Unit)? = null,
+    /** 撤销最后一笔至空：屏上活动区字应一并撤销，由接收方处理。 */
+    onUndoActive: (() -> Unit)? = null,
     onButtonFeedback: ((String) -> Unit)? = null,
     keyTextColor: Color = Color(0xFF333333),
     keyBackgroundColor: Color = Color(0xFFE0E0E0),
@@ -61,6 +77,13 @@ fun HandwritingKeyboardLayout(
     specialKeyTextColor: Color = Color.White,
 ) {
     val strokes = remember { mutableStateListOf<List<StrokePoint>>() }
+    // 识别固化前缀（头部）：这些笔画已退出识别窗口（停顿定型/窗口超限滑窗）
+    var settledCount by remember { mutableIntStateOf(0) }
+    // 视觉变淡前缀（头部）：DP 切出新段（前面是已完成字）或固化时推进；
+    // 仅视觉淡出，笔画仍留在识别窗口——"在"中途淡出前几笔，写完仍能合并识别纠正
+    var fadingPrefix by remember { mutableIntStateOf(0) }
+    // 视觉消失前缀（头部）：变淡 450ms 后推进，渲染时跳过
+    var gonePrefix by remember { mutableIntStateOf(0) }
     var currentStrokePoints by remember { mutableStateOf<List<StrokePoint>>(emptyList()) }
     var dragVersion by remember { mutableIntStateOf(0) }
     var lastStrokeEndMs by remember { mutableLongStateOf(0L) }
@@ -70,6 +93,8 @@ fun HandwritingKeyboardLayout(
     val density = androidx.compose.ui.platform.LocalDensity.current
     val sheetWPx = with(density) { 56.dp.toPx() }
     val barHPx = with(density) { 48.dp.toPx() }
+    val recognizer = remember { OverlappedHandwritingRecognizer() }
+    var recognizeJob by remember { mutableStateOf<Job?>(null) }
 
     LaunchedEffect(Unit) {
         withContext(Dispatchers.IO) {
@@ -77,24 +102,115 @@ fun HandwritingKeyboardLayout(
         }
     }
 
-    LaunchedEffect(lastStrokeEndMs) {
-        if (lastStrokeEndMs > 0L) {
-            delay(1000L)
-            strokes.clear()
-            dragVersion++
+    /**
+     * 视觉消失调度：450ms 后 [gonePrefix] 推进到 target（不超 [fadingPrefix]）。
+     * 笔画数据保留在 [strokes]（识别窗口/前缀计数不受影响），渲染层跳过即可。
+     */
+    fun scheduleGone(target: Int) {
+        scope.launch {
+            delay(450L)
+            if (gonePrefix < target) {
+                gonePrefix = target.coerceAtMost(fadingPrefix)
+                dragVersion++
+            }
         }
     }
-    LaunchedEffect(clearSignal) { strokes.clear(); dragVersion++ }
 
-    suspend fun runPrediction() {
-        if (!HandwritingEngine.isInitialized()) return
-        val snapshot = strokes.toList()
-        if (snapshot.isEmpty()) return
-        val pairs = snapshot.map { stroke -> stroke.map { Pair(it.x, it.y) } }
-        val result = withContext(Dispatchers.Default) {
-            HandwritingEngine.predict(pairs, 20)
+    // 停顿处理（自适应阈值）：笔画变淡提示"已识别上屏"，但识别窗口全程保留——
+    // 单字中途的笔序停顿（如"中"写完"口"后停顿）不会清窗，后续笔画落下时
+    // 全窗口重新识别自动纠正（"口"→"中"）。分字完全交给 DP 的时间偏置+
+    // 相对停顿阈值，滑窗（HW_RECOGNIZE_WINDOW_LIMIT）兜底。
+    // 超长闲置（CLEAR_IDLE_MS）无新笔画才真正清窗（下个字从零开始）。
+    LaunchedEffect(lastStrokeEndMs) {
+        if (lastStrokeEndMs > 0L) {
+            delay(HandwritingStrokeFx.splitPauseMs(strokes.size - settledCount))
+            if (strokes.isNotEmpty()) {
+                fadingPrefix = strokes.size
+                dragVersion++
+                scheduleGone(strokes.size)
+            }
+            delay(HW_CLEAR_IDLE_MS)
+            strokes.clear()
+            fadingPrefix = 0
+            gonePrefix = 0
+            settledCount = 0
+            dragVersion++
+            recognizer.reset()
         }
-        onCandidates?.invoke(result)
+    }
+    LaunchedEffect(clearSignal) {
+        strokes.clear()
+        fadingPrefix = 0
+        gonePrefix = 0
+        settledCount = 0
+        dragVersion++
+        recognizer.reset()
+    }
+
+    /** 当前未固化窗口的笔间时间间隔（gaps[j] = 第 j 笔起笔与上一笔收笔的间隔）。 */
+    fun windowGaps(window: List<List<StrokePoint>>): List<Long> =
+        HandwritingStrokeFx.windowGaps(window)
+
+    /**
+     * 叠写识别调度（串行化：新请求取消旧任务，旧结果作废）。
+     * 识别输入只取未固化笔画（[settledCount] 之后的窗口），并携带笔间间隔
+     * 供 DP 做时间偏置（停顿处倾向切分、连笔处压制切分）。
+     * 固化由"窗口笔画超限"驱动（正常分割靠停顿）：
+     * 窗口超过 [RECOGNIZE_WINDOW_LIMIT] 笔时固化最早段（缓存平移无重推理），循环至不超限。
+     */
+    fun scheduleRecognition() {
+        recognizeJob?.cancel()
+        if (settledCount >= strokes.size) return
+        recognizeJob = scope.launch {
+            // 窗口超限：识别一次取最早段固化出窗，循环至不超限
+            while (strokes.size - settledCount > HW_RECOGNIZE_WINDOW_LIMIT && isActive) {
+                val window = strokes.drop(settledCount)
+                val pairs = window.map { stroke -> stroke.map { Pair(it.x, it.y) } }
+                val result = withContext(Dispatchers.Default) {
+                    recognizer.recognize(pairs, windowGaps(window))
+                }
+                if (!isActive) return@launch
+                val first = result.segments.firstOrNull() ?: return@launch
+                val firstChar = first.candidates.firstOrNull()?.char ?: return@launch
+                onSegmentSettled?.invoke(firstChar)
+                withContext(Dispatchers.Main) {
+                    settledCount = (settledCount + first.strokeCount).coerceAtMost(strokes.size)
+                    if (settledCount > fadingPrefix) fadingPrefix = settledCount
+                    dragVersion++
+                    recognizer.onStrokesTrimmed(first.strokeCount)
+                    scheduleGone(fadingPrefix)
+                }
+            }
+            if (settledCount >= strokes.size || !isActive) return@launch
+            // 正常识别上报（固化交给停顿分割）
+            val window = strokes.drop(settledCount)
+            val pairs = window.map { stroke -> stroke.map { Pair(it.x, it.y) } }
+            val result = withContext(Dispatchers.Default) {
+                recognizer.recognize(pairs, windowGaps(window))
+            }
+            if (!isActive) return@launch
+            if (result.segments.isNotEmpty()) {
+                onRecognition?.invoke(result.segments)
+                if (result.segments.size >= 2) {
+                    // DP 切出新段：仅当段边界存在"换字停顿"（gap ≥ HW_FADE_GAP_MS）时，
+                    // 前面段（已完成字，结果已上屏）笔画才变淡（视觉）。
+                    // 连笔中途的切分抖动（如"在"=[一][丿][丨]）不触发淡出。
+                    // 识别窗口保留全部笔画（不固化），后续合并纠正（如"在"写完）仍可进行。
+                    val doneStrokes = HandwritingStrokeFx.settledStrokesBeforeCurrent(
+                        result.segments,
+                        windowGaps(window),
+                    )
+                    if (doneStrokes > 0) {
+                        val target = (settledCount + doneStrokes).coerceAtLeast(fadingPrefix)
+                        if (target > fadingPrefix) {
+                            fadingPrefix = target
+                            dragVersion++
+                            scheduleGone(target)
+                        }
+                    }
+                }
+            }
+        }
     }
 
     fun onStrokeEnd() {
@@ -159,7 +275,21 @@ fun HandwritingKeyboardLayout(
 
         key(dragVersion) {
             Canvas(Modifier.fillMaxSize()) {
-                renderStrokes(strokes, currentStrokePoints, keyTextColor)
+                // 三段渲染：[0,gonePrefix) 已消失不画；[gonePrefix,fadingPrefix) 变淡中；
+                // [fadingPrefix,end) 正常显示。正在书写的笔画（currentStrokePoints）必须
+                // 无条件渲染——它尚未进入 strokes，包进条件会导致笔迹写完才显示
+                if (gonePrefix < fadingPrefix && gonePrefix < strokes.size) {
+                    renderStrokes(
+                        strokes.drop(gonePrefix).take(fadingPrefix - gonePrefix),
+                        emptyList(),
+                        keyTextColor.copy(alpha = 0.3f),
+                    )
+                }
+                renderStrokes(
+                    strokes.drop(fadingPrefix),
+                    currentStrokePoints,
+                    keyTextColor,
+                )
             }
         }
 
@@ -229,14 +359,29 @@ fun HandwritingKeyboardLayout(
                                     currentStrokePoints = emptyList()
                                     onStrokeEnd()
                                     if (strokes.isNotEmpty()) {
-                                        scope.launch { runPrediction() }
+                                        scheduleRecognition()
                                     }
                                 } else {
                                         if (sx >= w - sheetWPx && sy < h - barHPx) {
                                         val cellH = (h - barHPx) / 5f
                                         val idx = (sy / cellH).toInt().coerceIn(0, 4)
-                                        onButtonFeedback?.invoke(listOf("，", "。", "？", "！", "delete")[idx])
-                                        onKeyPress(listOf("，", "。", "？", "！", "delete")[idx])
+                                        val action = listOf("，", "。", "？", "！", "delete")[idx]
+                                        if (action == "delete" && settledCount < strokes.size) {
+                                            // 撤销最后一笔未固化笔画并重新识别（屏上活动字随识别结果替换）
+                                            onButtonFeedback?.invoke("delete")
+                                            strokes.removeAt(strokes.size - 1)
+                                            dragVersion++
+                                            if (settledCount >= strokes.size) {
+                                                // 未固化笔画撤空：屏上活动区字一并撤销
+                                                recognizer.reset()
+                                                onUndoActive?.invoke()
+                                            } else {
+                                                scheduleRecognition()
+                                            }
+                                        } else {
+                                            onButtonFeedback?.invoke(action)
+                                            onKeyPress(action)
+                                        }
                                     } else if (sy >= h - barHPx) {
                                         val seg = w / 5.2f
                                         val idx = when {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/HandwritingLookupKeyboard.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/HandwritingLookupKeyboard.kt
@@ -26,12 +26,16 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kingzcheung.xime.handwriting.HandwritingCandidate
 import com.kingzcheung.xime.handwriting.HandwritingEngine
+import com.kingzcheung.xime.handwriting.HandwritingStrokeFx
+import com.kingzcheung.xime.handwriting.OverlappedHandwritingRecognizer
 import com.kingzcheung.xime.handwriting.StrokePoint
 import com.kingzcheung.xime.handwriting.renderStrokes
 import com.kingzcheung.xime.keyboard.KeyboardDimensions
 import com.kingzcheung.xime.viewmodel.KeyboardUiState
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -52,27 +56,85 @@ fun HandwritingLookupKeyboard(
     modifier: Modifier = Modifier,
 ) {
     val strokes = remember { mutableStateListOf<List<StrokePoint>>() }
+    // 与主手写键盘一致的叠写视觉状态（三段前缀渲染 + 识别窗口），见 HandwritingStrokeFx
+    var settledCount by remember { mutableIntStateOf(0) }
+    var fadingPrefix by remember { mutableIntStateOf(0) }
+    var gonePrefix by remember { mutableIntStateOf(0) }
     var currentStrokePoints by remember { mutableStateOf<List<StrokePoint>>(emptyList()) }
     var dragVersion by remember { mutableIntStateOf(0) }
     var lastStrokeEndMs by remember { mutableLongStateOf(0L) }
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    val recognizer = remember { OverlappedHandwritingRecognizer() }
+    var recognizeJob by remember { mutableStateOf<Job?>(null) }
 
     LaunchedEffect(Unit) { withContext(Dispatchers.IO) { HandwritingEngine.initialize(context) } }
-    LaunchedEffect(lastStrokeEndMs) {
-        if (lastStrokeEndMs > 0L) {
-            delay(1000L); strokes.clear(); dragVersion++
+
+    /** 视觉消失调度：450ms 后 gonePrefix 推进到 target（笔画数据保留，渲染层跳过）。 */
+    fun scheduleGone(target: Int) {
+        scope.launch {
+            delay(450L)
+            if (gonePrefix < target) {
+                gonePrefix = target.coerceAtMost(fadingPrefix)
+                dragVersion++
+            }
         }
     }
-    LaunchedEffect(clearSignal) { strokes.clear(); dragVersion++ }
 
-    suspend fun runPrediction() {
-        if (!HandwritingEngine.isInitialized()) return
-        val snapshot = strokes.toList()
-        if (snapshot.isEmpty()) return
-        val pairs = snapshot.map { stroke -> stroke.map { Pair(it.x, it.y) } }
-        val result = withContext(Dispatchers.Default) { HandwritingEngine.predict(pairs, 20) }
-        onCandidates?.invoke(result)
+    // 停顿分割（自适应阈值，同主手写键盘）：定型=笔画变淡后消失、识别窗口清空。
+    // 查词无自动上屏，候选栏保留供点选，直到下一次书写
+    LaunchedEffect(lastStrokeEndMs) {
+        if (lastStrokeEndMs > 0L) {
+            delay(HandwritingStrokeFx.splitPauseMs(strokes.size - settledCount))
+            if (strokes.isNotEmpty()) {
+                fadingPrefix = strokes.size
+                settledCount = strokes.size
+                dragVersion++
+                recognizer.reset()
+                scheduleGone(strokes.size)
+            }
+        }
+    }
+    LaunchedEffect(clearSignal) {
+        strokes.clear()
+        fadingPrefix = 0
+        gonePrefix = 0
+        settledCount = 0
+        dragVersion++
+        recognizer.reset()
+    }
+
+    /**
+     * 叠写识别调度（与主手写键盘同源）：DP 切分 + 笔间间隔时间偏置。
+     * 查词上报最后一段候选（正在写的字）；前面段（已完成字，需存在换字停顿）
+     * 笔画变淡——连笔中途切分抖动不淡出。
+     */
+    fun scheduleRecognition() {
+        recognizeJob?.cancel()
+        if (settledCount >= strokes.size) return
+        recognizeJob = scope.launch {
+            val window = strokes.drop(settledCount)
+            val pairs = window.map { stroke -> stroke.map { Pair(it.x, it.y) } }
+            val gaps = HandwritingStrokeFx.windowGaps(window)
+            val result = withContext(Dispatchers.Default) {
+                recognizer.recognize(pairs, gaps)
+            }
+            if (!isActive) return@launch
+            if (result.segments.isNotEmpty()) {
+                onCandidates?.invoke(result.segments.last().candidates)
+                if (result.segments.size >= 2) {
+                    val doneStrokes = HandwritingStrokeFx.settledStrokesBeforeCurrent(result.segments, gaps)
+                    if (doneStrokes > 0) {
+                        val target = (settledCount + doneStrokes).coerceAtLeast(fadingPrefix)
+                        if (target > fadingPrefix) {
+                            fadingPrefix = target
+                            dragVersion++
+                            scheduleGone(target)
+                        }
+                    }
+                }
+            }
+        }
     }
 
     Box(
@@ -122,7 +184,7 @@ fun HandwritingLookupKeyboard(
                                 }
                                 currentStrokePoints = emptyList()
                                 lastStrokeEndMs = System.currentTimeMillis()
-                                if (strokes.isNotEmpty()) scope.launch { runPrediction() }
+                                if (strokes.isNotEmpty()) scheduleRecognition()
                             }
                             break
                         }
@@ -132,7 +194,16 @@ fun HandwritingLookupKeyboard(
 
         key(dragVersion) {
             Canvas(Modifier.fillMaxSize()) {
-                renderStrokes(strokes, currentStrokePoints, keyTextColor)
+                // 三段渲染（同主手写键盘）：消失段不画、变淡段 0.3 透明度。
+                // 正在书写的笔画必须无条件渲染（尚未进入 strokes）
+                if (gonePrefix < fadingPrefix && gonePrefix < strokes.size) {
+                    renderStrokes(
+                        strokes.drop(gonePrefix).take(fadingPrefix - gonePrefix),
+                        emptyList(),
+                        keyTextColor.copy(alpha = 0.3f),
+                    )
+                }
+                renderStrokes(strokes.drop(fadingPrefix), currentStrokePoints, keyTextColor)
             }
         }
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
@@ -110,4 +110,15 @@ data class KeyboardCallbacks(
      * 服务层负责上屏首位候选词或待确认英文，再由键盘层切换布局。
      */
     val onCommitCandidateBeforeModeChange: (() -> Unit)? = null,
+    /**
+     * 手写叠写自动上屏：把屏上手写尾部 [expectedTail] 替换为 [newTail]
+     * （静默上屏——不触发联想推理）。返回是否成功：
+     * 期望校验失败（用户移动过光标/退格过）返回 false 且不上屏，
+     * 调用方应重置手写尾部状态（后续识别以追加模式重建）。需在主线程调用。
+     */
+    val onHandwritingAutoCommit: ((newTail: String, expectedTail: String) -> Boolean)? = null,
+    /**
+     * 手写活动区固化（停顿/点选确认）后触发联想推理（基于已上屏文本）。
+     */
+    val onHandwritingFinalize: (() -> Unit)? = null,
 )

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -233,6 +233,13 @@ fun KeyboardView(
             var handwritingComments by remember { mutableStateOf<List<String>>(emptyList()) }
             var handwritingClearSignal by remember { mutableIntStateOf(0) }
             var isHandwritingLookup by remember { mutableStateOf(false) }
+            // 手写叠写状态真源：tailText=屏上手写会话尾部文本（含固化+活动字）；
+            // activeLen=其中活动部分长度（可被识别结果替换/固化/撤销）；
+            // lastSegLen=最后一次识别的段长（停顿定型不清零）——点选替换据此定位
+            // "最后上屏的字"（停顿后再点候选仍可替换，而非追加）
+            var handwritingTail by remember { mutableStateOf("") }
+            var handwritingActiveLen by remember { mutableStateOf(0) }
+            var handwritingLastSegLen by remember { mutableStateOf(0) }
 
             val isHandwritingPage = page is KeyboardPage.Main && (page as KeyboardPage.Main).type == MainType.HANDWRITING
             val showHandwritingCandidates = (isHandwritingPage || isHandwritingLookup) && handwritingCandidates.isNotEmpty()
@@ -369,11 +376,27 @@ fun KeyboardView(
                 callbacks = CandidateBarCallbacks(
                     onCandidateSelect = { index ->
                         if (showHandwritingCandidates && index in handwritingCandidates.indices) {
-                            val ch = handwritingCandidates[index]
-                            callbacks.onCommitText?.invoke(ch)
-                            handwritingCandidates = emptyList()
-                            handwritingComments = emptyList()
-                            handwritingClearSignal++
+                            if (isHandwritingLookup) {
+                                // 手写查词：直接上屏（原有行为）
+                                val ch = handwritingCandidates[index]
+                                callbacks.onCommitText?.invoke(ch)
+                                handwritingCandidates = emptyList()
+                                handwritingComments = emptyList()
+                                handwritingClearSignal++
+                            } else {
+                                // 兜底路径（AssociationOnly 正常走 onAssociationSelect）：
+                                // 与点选替换同语义；候选栏保留供继续改选
+                                val ch = handwritingCandidates[index]
+                                if (index > 0 && handwritingLastSegLen > 0) {
+                                    val newTail = handwritingTail.dropLast(handwritingLastSegLen) + ch
+                                    val ok = callbacks.onHandwritingAutoCommit?.invoke(newTail, handwritingTail) ?: false
+                                    if (ok || handwritingTail.isEmpty()) handwritingTail = newTail
+                                    handwritingLastSegLen = ch.length
+                                }
+                                handwritingActiveLen = 0
+                                callbacks.onHandwritingFinalize?.invoke()
+                                handwritingClearSignal++
+                            }
                         } else {
                             callbacks.onCandidateSelect(index)
                         }
@@ -417,11 +440,31 @@ fun KeyboardView(
                     },
                     onAssociationSelect = { index ->
                         if (showHandwritingCandidates && index in handwritingCandidates.indices) {
-                            val ch = handwritingCandidates[index]
-                            callbacks.onCommitText?.invoke(ch)
-                            handwritingCandidates = emptyList()
-                            handwritingComments = emptyList()
-                            handwritingClearSignal++
+                            if (isHandwritingLookup) {
+                                // 手写查词：查词结果直接上屏（原有行为，与叠写状态无关）
+                                val ch = handwritingCandidates[index]
+                                callbacks.onCommitText?.invoke(ch)
+                                handwritingCandidates = emptyList()
+                                handwritingComments = emptyList()
+                                handwritingClearSignal++
+                            } else if (index == 0) {
+                                // 首选已自动上屏：点选仅固化当前字并触发联想。
+                                // 候选栏保留——用户可继续改点其他候选，直到下一次书写
+                                handwritingActiveLen = 0
+                                callbacks.onHandwritingFinalize?.invoke()
+                                handwritingClearSignal++
+                            } else {
+                                // 替换最后上屏的字为点选候选（停顿定型后仍可替换）。
+                                // 候选栏保留供继续改选，笔画清空
+                                val ch = handwritingCandidates[index]
+                                val newTail = handwritingTail.dropLast(handwritingLastSegLen) + ch
+                                val ok = callbacks.onHandwritingAutoCommit?.invoke(newTail, handwritingTail) ?: false
+                                if (ok || handwritingTail.isEmpty()) handwritingTail = newTail
+                                handwritingActiveLen = 0
+                                handwritingLastSegLen = ch.length
+                                callbacks.onHandwritingFinalize?.invoke()
+                                handwritingClearSignal++
+                            }
                         } else {
                             callbacks.onAssociationSelect?.invoke(index)
                         }
@@ -684,12 +727,27 @@ fun KeyboardView(
                             onKeyPress = { key ->
                                 when (key) {
                                     "delete" -> {
-                                        if (handwritingCandidates.isNotEmpty()) {
-                                            handwritingCandidates = emptyList()
-                                            handwritingComments = emptyList()
-                                            handwritingClearSignal++
-                                        } else {
-                                            callbacks.onKeyPress("delete", false)
+                                        when {
+                                            handwritingActiveLen > 0 -> {
+                                                // 撤销当前字：删屏上活动区文本，清笔画重写
+                                                callbacks.onDeleteText?.invoke(handwritingActiveLen)
+                                                handwritingTail = handwritingTail.dropLast(handwritingActiveLen)
+                                                handwritingActiveLen = 0
+                                                handwritingLastSegLen = 0
+                                                handwritingCandidates = emptyList()
+                                                handwritingComments = emptyList()
+                                                handwritingClearSignal++
+                                            }
+                                            handwritingTail.isNotEmpty() -> {
+                                                // 无活动字：退格删固化尾字，tail 乐观修剪（下次替换校验兜底）。
+                                                // 候选栏同步失效（tail 已变，点选替换无意义）
+                                                callbacks.onDeleteText?.invoke(1)
+                                                handwritingTail = handwritingTail.dropLast(1)
+                                                handwritingLastSegLen = 0
+                                                handwritingCandidates = emptyList()
+                                                handwritingComments = emptyList()
+                                            }
+                                            else -> callbacks.onKeyPress("delete", false)
                                         }
                                     }
                                     "symbol" -> viewModel.enterPanel(PanelType.COMMON_SYMBOL)
@@ -699,23 +757,61 @@ fun KeyboardView(
                                         callbacks.onKeyPress("ime_switch", false)
                                     }
                                     "space" -> {
-                                        if (handwritingCandidates.isNotEmpty()) {
-                                            val ch = handwritingCandidates[0]
-                                            callbacks.onCommitText?.invoke(ch)
-                                            handwritingCandidates = emptyList()
-                                            handwritingComments = emptyList()
-                                            handwritingClearSignal++
-                                        } else {
-                                            callbacks.onKeyPress("space", false)
-                                        }
+                                        // 当前字已自动上屏：空格=固化 + 上屏空格（全量 commitText 触发联想）。
+                                        // 选择期结束：清候选栏
+                                        handwritingActiveLen = 0
+                                        handwritingLastSegLen = 0
+                                        handwritingCandidates = emptyList()
+                                        handwritingComments = emptyList()
+                                        callbacks.onCommitText?.invoke(" ")
                                     }
-                                    "enter" -> callbacks.onKeyPress("enter", false)
-                                    else -> callbacks.onCommitText?.invoke(key)
+                                    "enter" -> {
+                                        // 换行定稿：选择期结束
+                                        handwritingActiveLen = 0
+                                        handwritingLastSegLen = 0
+                                        handwritingCandidates = emptyList()
+                                        handwritingComments = emptyList()
+                                        callbacks.onKeyPress("enter", false)
+                                    }
+                                    else -> {
+                                        // 标点等直接上屏：固化活动字 + 选择期结束
+                                        handwritingActiveLen = 0
+                                        handwritingLastSegLen = 0
+                                        handwritingCandidates = emptyList()
+                                        handwritingComments = emptyList()
+                                        callbacks.onCommitText?.invoke(key)
+                                    }
                                 }
                             },
-                            onCandidates = { candidates ->
-                                handwritingCandidates = candidates.map { it.char }
-                                handwritingComments = emptyList()
+                            onRecognition = { segments ->
+                                val segText = segments.mapNotNull { seg ->
+                                    seg.candidates.firstOrNull()?.char
+                                }.joinToString("")
+                                if (segText.isNotEmpty()) {
+                                    // 替换式上屏：活动区整体重写为最新识别结果（微信式边写边上屏）。
+                                    // 校验失败（光标漂移）时重置尾部状态，后续识别以追加模式重建
+                                    val newTail = handwritingTail.dropLast(handwritingActiveLen) + segText
+                                    val ok = callbacks.onHandwritingAutoCommit?.invoke(newTail, handwritingTail) ?: false
+                                    handwritingTail = if (ok || handwritingTail.isEmpty()) newTail else ""
+                                    handwritingActiveLen = segText.length
+                                    handwritingLastSegLen = segText.length
+                                    handwritingCandidates = segments.last().candidates.map { it.char }
+                                    handwritingComments = emptyList()
+                                }
+                            },
+                            onSegmentSettled = { ch ->
+                                // 叠写满上限：最早段固化（屏上不动，退出活动区）
+                                handwritingActiveLen = (handwritingActiveLen - ch.length).coerceAtLeast(0)
+                            },
+                            onUndoActive = {
+                                if (handwritingActiveLen > 0) {
+                                    callbacks.onDeleteText?.invoke(handwritingActiveLen)
+                                    handwritingTail = handwritingTail.dropLast(handwritingActiveLen)
+                                    handwritingActiveLen = 0
+                                    handwritingCandidates = emptyList()
+                                    handwritingComments = emptyList()
+                                    handwritingClearSignal++
+                                }
                             },
                             onButtonFeedback = { key ->
                                 callbacks.onKeyPressDown?.invoke(key)

--- a/app/src/test/java/com/kingzcheung/xime/handwriting/OverlappedHandwritingRecognizerTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/handwriting/OverlappedHandwritingRecognizerTest.kt
@@ -1,0 +1,267 @@
+package com.kingzcheung.xime.handwriting
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 叠写识别器单测：注入假单字模型（按段内笔画编号/段长返回可控结果），
+ * 验证 DP 切分逻辑、部件成字纠正、缓存复用与超限防御。
+ *
+ * 笔画编码约定：第 idx 笔的两个点 y 坐标均为 idx（假模型据此识别"笔画起点"）。
+ */
+class OverlappedHandwritingRecognizerTest {
+
+    private fun strokesOf(count: Int): List<List<Pair<Float, Float>>> =
+        (0 until count).map { idx ->
+            listOf(Pair(0f, idx.toFloat()), Pair(1f, idx.toFloat()))
+        }
+
+    private fun cand(ch: String, score: Float) = listOf(HandwritingCandidate(ch, score))
+
+    @Test
+    fun `单字未分裂时切为一段`() {
+        // 假模型：任意段都识别为"张"（单段分数最高，无更优切分）
+        val recognizer = OverlappedHandwritingRecognizer()
+        val result = recognizer.recognize(strokesOf(5), predictFn = { _, _ -> cand("张", 0.95f) })
+        assertEquals(1, result.segments.size)
+        assertEquals("张", result.segments[0].candidates[0].char)
+    }
+
+    @Test
+    fun `两字连写切成两段`() {
+        // 前 5 笔识别"你"，后 5 笔识别"好"，其余段（含 10 笔合并段）识别不出
+        val recognizer = OverlappedHandwritingRecognizer()
+        val fake: (List<List<Pair<Float, Float>>>, Int) -> List<HandwritingCandidate> = { seg, _ ->
+            val start = seg[0][0].second.toInt()
+            val size = seg.size
+            when {
+                start == 0 && size == 5 -> cand("你", 0.9f)
+                start == 5 && size == 5 -> cand("好", 0.85f)
+                else -> emptyList()
+            }
+        }
+        val result = recognizer.recognize(strokesOf(10), predictFn = fake)
+        assertEquals(2, result.segments.size)
+        assertEquals("你", result.segments[0].candidates[0].char)
+        assertEquals("好", result.segments[1].candidates[0].char)
+    }
+
+    @Test
+    fun `部件成字写完后切回单段`() {
+        // 模拟"张" = 弓(3笔) + 长(4笔)：写到 3 笔时[弓]成段；
+        // 7 笔写完时合并段"张"分数更高，均分比较应切回单段
+        val recognizer = OverlappedHandwritingRecognizer()
+        val fake: (List<List<Pair<Float, Float>>>, Int) -> List<HandwritingCandidate> = { seg, _ ->
+            when (seg.size) {
+                3 -> cand("弓", 0.9f)
+                4 -> cand("卜", 0.6f)
+                7 -> cand("张", 0.95f)
+                else -> emptyList()
+            }
+        }
+        // 3 笔：单段"弓"
+        val partial = recognizer.recognize(strokesOf(3), predictFn = fake)
+        assertEquals(1, partial.segments.size)
+        assertEquals("弓", partial.segments[0].candidates[0].char)
+        // 7 笔：写完，合并段"张"（0.95/1）应胜过 [弓][卜]（(0.9+0.6)/2-0.02）
+        val done = recognizer.recognize(strokesOf(7), predictFn = fake)
+        assertEquals(1, done.segments.size)
+        assertEquals("张", done.segments[0].candidates[0].char)
+    }
+
+    @Test
+    fun `候选栏取当前字多候选`() {
+        // 最后一段返回多候选（按分数降序）
+        val recognizer = OverlappedHandwritingRecognizer()
+        val fake: (List<List<Pair<Float, Float>>>, Int) -> List<HandwritingCandidate> = { seg, _ ->
+            if (seg.size == 4) listOf(
+                HandwritingCandidate("张", 0.95f),
+                HandwritingCandidate("账", 0.8f),
+            ) else emptyList()
+        }
+        val result = recognizer.recognize(strokesOf(4), predictFn = fake)
+        assertEquals(1, result.segments.size)
+        assertEquals(2, result.segments[0].candidates.size)
+        assertEquals("张", result.segments[0].candidates[0].char)
+        assertEquals("账", result.segments[0].candidates[1].char)
+    }
+
+    @Test
+    fun `段缓存跨笔画复用`() {
+        // 尾部追加 3 笔后重新识别：新增推理只发生在含新笔画的段
+        // （i=8,9,10 的 k=1 轮 27 段 + 可行前缀段的少量 k=2 尾段），
+        // 远小于全量重算的段数；且相同输入再次识别时零新增推理。
+        var calls = 0
+        val fake: (List<List<Pair<Float, Float>>>, Int) -> List<HandwritingCandidate> = { seg, _ ->
+            calls++
+            if (seg.size == 5 && seg[0][0].second.toInt() == 0) cand("你", 0.9f) else emptyList()
+        }
+        val recognizer = OverlappedHandwritingRecognizer()
+        recognizer.recognize(strokesOf(7), predictFn = fake)
+        val afterFirst = calls
+        recognizer.recognize(strokesOf(10), predictFn = fake)
+        // 全量重算 10 笔约 60 段（k=1 轮 55 段 + k=2 尾段），带缓存增量应远小于它
+        assertTrue("缓存未生效：新增推理 ${calls - afterFirst} 段", calls - afterFirst <= 30)
+        val afterSecond = calls
+        recognizer.recognize(strokesOf(10), predictFn = fake)
+        assertEquals("相同输入不应产生新推理", afterSecond, calls)
+    }
+
+    @Test
+    fun `笔画超限自动裁剪尾部`() {
+        val recognizer = OverlappedHandwritingRecognizer()
+        val result = recognizer.recognize(strokesOf(101), predictFn = { _, _ -> cand("字", 0.9f) })
+        assertTrue(result.segments.isNotEmpty())
+        assertTrue(result.segments.size <= OverlappedHandwritingRecognizer.DEFAULT_MAX_SEGMENTS)
+    }
+
+    @Test
+    fun `停顿间隔强化切分`() {
+        // 两段均分 0.9-0.02=0.88 与单段 0.9 打平偏弱：
+        // 大停顿(+0.15) → 两段胜出；连笔(-0.08) → 单段胜出
+        val recognizer = OverlappedHandwritingRecognizer()
+        val fake: (List<List<Pair<Float, Float>>>, Int) -> List<HandwritingCandidate> = { seg, _ ->
+            cand(if (seg.size == 1) "一" else "双", 0.9f)
+        }
+        val strokes = strokesOf(2)
+        val split = recognizer.recognize(strokes, listOf(0L, 600L), fake)
+        assertEquals(2, split.segments.size)
+        val joined = recognizer.recognize(strokes, listOf(0L, 80L), fake)
+        assertEquals(1, joined.segments.size)
+    }
+
+    @Test
+    fun `慢写复杂字匀速笔迹不拆分`() {
+        // 模拟 17 笔复杂字匀速慢写（每笔间隔 450ms，无显著停顿边界）：
+        // 部件都是高分简单字（DP 多段均分高），但相对阈值检测无显著停顿
+        // → 强制单字（合并段"赢"分数尚可），输入框只显示 1 个字
+        val recognizer = OverlappedHandwritingRecognizer()
+        val fake: (List<List<Pair<Float, Float>>>, Int) -> List<HandwritingCandidate> = { seg, _ ->
+            when (seg.size) {
+                17 -> cand("赢", 0.6f)
+                else -> cand("部", 0.85f)
+            }
+        }
+        val gaps = List(17) { if (it == 0) 0L else 450L }
+        val result = recognizer.recognize(strokesOf(17), gaps, fake)
+        assertEquals(1, result.segments.size)
+        assertEquals("赢", result.segments[0].candidates[0].char)
+    }
+
+    @Test
+    fun `慢写多字词的长停顿边界仍被检出`() {
+        // 慢写者（字内 400ms）写完"你"后停 1.2s 再写"好"：
+        // 1.2s 显著高于中位数（×2=800ms）→ 边界有效 → 多段
+        val recognizer = OverlappedHandwritingRecognizer()
+        val fake: (List<List<Pair<Float, Float>>>, Int) -> List<HandwritingCandidate> = { seg, _ ->
+            when {
+                seg.size == 5 && seg[0][0].second.toInt() == 0 -> cand("你", 0.9f)
+                seg.size == 5 && seg[0][0].second.toInt() == 5 -> cand("好", 0.85f)
+                else -> emptyList()
+            }
+        }
+        val gaps = List(10) { idx ->
+            when {
+                idx == 0 -> 0L
+                idx == 5 -> 1200L
+                else -> 400L
+            }
+        }
+        val result = recognizer.recognize(strokesOf(10), gaps, fake)
+        assertEquals(2, result.segments.size)
+    }
+
+    @Test
+    fun `连笔单字中途不被拆分`() {
+        // 模拟"在"6 笔连写（笔间 80ms）：中途多段（每笔都是高分简单字）
+        // 被连笔减分压制，写完 6 笔后合并段"在"应胜出
+        val recognizer = OverlappedHandwritingRecognizer()
+        val fake: (List<List<Pair<Float, Float>>>, Int) -> List<HandwritingCandidate> = { seg, _ ->
+            when (seg.size) {
+                1 -> cand("一", 0.9f)
+                6 -> cand("在", 0.95f)
+                else -> cand("部", 0.7f)
+            }
+        }
+        val gaps = List(6) { if (it == 0) 0L else 80L }
+        val result = recognizer.recognize(strokesOf(6), gaps, fake)
+        assertEquals(1, result.segments.size)
+        assertEquals("在", result.segments[0].candidates[0].char)
+    }
+
+    @Test
+    fun `连笔无停顿时单字中途强制按单字处理`() {
+        // 模拟"在"写到 2 笔：DP 多段 [一][一]（0.88）胜过合并段"彐"（0.5），
+        // 但无停顿 + 合并段分数尚可（0.5 ≥ 0.35）→ 强制单字，输入框只显示 1 个字
+        val recognizer = OverlappedHandwritingRecognizer()
+        val fake: (List<List<Pair<Float, Float>>>, Int) -> List<HandwritingCandidate> = { seg, _ ->
+            when (seg.size) {
+                1 -> cand("一", 0.9f)
+                2 -> cand("彐", 0.5f)
+                else -> emptyList()
+            }
+        }
+        val result = recognizer.recognize(strokesOf(2), listOf(0L, 80L), fake)
+        assertEquals(1, result.segments.size)
+        assertEquals("彐", result.segments[0].candidates[0].char)
+    }
+
+    @Test
+    fun `有换字停顿时尊重多段切分`() {
+        // 同上假模型，但段边界有 600ms 停顿（真换字）→ 不强制单字，多段上屏
+        val recognizer = OverlappedHandwritingRecognizer()
+        val fake: (List<List<Pair<Float, Float>>>, Int) -> List<HandwritingCandidate> = { seg, _ ->
+            when (seg.size) {
+                1 -> cand("一", 0.9f)
+                2 -> cand("彐", 0.5f)
+                else -> emptyList()
+            }
+        }
+        val result = recognizer.recognize(strokesOf(2), listOf(0L, 600L), fake)
+        assertEquals(2, result.segments.size)
+    }
+
+    @Test
+    fun `连笔写多字词时合并分数极低仍切多段`() {
+        // 连笔写"你好"：合并段（跨字笔迹）分数极低（0.2 < 0.35）→ 尊重 DP 多段
+        val recognizer = OverlappedHandwritingRecognizer()
+        val fake: (List<List<Pair<Float, Float>>>, Int) -> List<HandwritingCandidate> = { seg, _ ->
+            when {
+                seg.size == 5 && seg[0][0].second.toInt() == 0 -> cand("你", 0.9f)
+                seg.size == 5 && seg[0][0].second.toInt() == 5 -> cand("好", 0.85f)
+                seg.size == 10 -> cand("伪", 0.2f)
+                else -> emptyList()
+            }
+        }
+        val gaps = List(10) { if (it == 0) 0L else 80L }
+        val result = recognizer.recognize(strokesOf(10), gaps, fake)
+        assertEquals(2, result.segments.size)
+        assertEquals("你", result.segments[0].candidates[0].char)
+        assertEquals("好", result.segments[1].candidates[0].char)
+    }
+
+    @Test
+    fun `空输入返回空结果`() {
+        val recognizer = OverlappedHandwritingRecognizer()
+        val result = recognizer.recognize(emptyList()) { _, _ -> cand("字", 0.9f) }
+        assertTrue(result.segments.isEmpty())
+    }
+
+    @Test
+    fun `reset后缓存失效重新推理`() {
+        var calls = 0
+        val fake: (List<List<Pair<Float, Float>>>, Int) -> List<HandwritingCandidate> = { _, _ ->
+            calls++
+            cand("字", 0.9f)
+        }
+        val recognizer = OverlappedHandwritingRecognizer()
+        recognizer.recognize(strokesOf(3), predictFn = fake)
+        val before = calls
+        recognizer.recognize(strokesOf(3), predictFn = fake)
+        assertEquals(before, calls)
+        recognizer.reset()
+        recognizer.recognize(strokesOf(3), predictFn = fake)
+        assertTrue(calls > before)
+    }
+}


### PR DESCRIPTION
- 更新应用版本号从 2.8.0 到 2.8.0-beta1，versionCode 递增到 20260830
- 新增手写叠写自动提交回调 onHandwritingAutoCommit，支持屏上文本替换验证
- 新增手写固化回调 onHandwritingFinalize，用于触发联想推理
- 重构手写键盘布局实现叠写识别：
  - 引入 OverlappedHandwritingRecognizer 支持动态规划切分
  - 实现三段式笔画渲染（正常/变淡/消失）提升用户体验
 - 添加超长闲置清理机制防止内存泄漏
- 完善手写查找键盘的叠写视觉状态同步
- 增强键盘视图的手写状态管理：
  - 跟踪手写尾部文本、活动长度和最后段长度
  - 实现点选替换和撤销功能的精确定位
  - 优化删除键行为区分活动字和固化字处理
- 修复冷启动时手写UI恢复问题，确保模型存在性检查
- 新增静默提交方法 commitTextSilently 避免频繁推理闪烁

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] 新功能
- [ ] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
