### PR TITLE
fix(ime): 修复快捷发送表单在Overlay页面下的显示和交互问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
@@ -118,7 +118,10 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                 }
             }
         }
-        if (service.uiState.value.quickSendFormFocused) {
+        // 表单显示期间（无论 EditText 是否持有焦点）都拦截：
+        // 焦点可能因点击表单外区域丢失，此时回车仍应提交并关闭表单、
+        // 退格仍应作用于表单输入框，否则按键落入普通输入语义造成"关闭无效"。
+        if (service.uiState.value.showQuickSendForm) {
             when (key) {
                 "enter" -> {
                     val editText = QuickSendFormEditTextHolder.editText

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
@@ -352,6 +352,11 @@ internal fun rememberImeKeyboardCallbacks(
             },
             onShowQuickSendForm = {
                 service.closeToolPanel()
+                // 从 Overlay 页面（剪贴板面板）打开表单时必须退出 Overlay：
+                // Overlay 渲染为全屏 clickable Box（吞点击），若不退出，表单会被
+                // 盖在其下——可见但关闭按钮等点击全部失效（时灵时不灵的根源：
+                // 从主键盘打开则无叠加）。
+                service.keyboardViewModel.closeOverlay()
                 val current = service.uiState.value
                 service.uiState.value = current.copy(
                     showQuickSendForm = true,
@@ -360,9 +365,13 @@ internal fun rememberImeKeyboardCallbacks(
                     quickSendEditingItemText = "",
                     enterKeyText = "确定",
                 )
-                service.forceInsetsRecompute()
+                // 不在此处 forceInsetsRecompute：此刻 Compose 尚未布局，hack 会用旧高度
+                // 白跑一轮且 pending=true 挡掉撑高后的第一次 y 更新（曾导致表单可见
+                // 却不可触摸）。布局撑高完成后 onGloballyPositioned 会以新 y 触发重算。
             },
             onQuickSendEditItem = { id, text ->
+                // 同 onShowQuickSendForm：编辑入口在剪贴板面板内，先退出 Overlay 防表单被盖
+                service.keyboardViewModel.closeOverlay()
                 service.uiState.value = service.uiState.value.copy(
                     showQuickSendForm = true,
                     quickSendFormFocused = true,
@@ -376,6 +385,7 @@ internal fun rememberImeKeyboardCallbacks(
                 }
             },
             onHideQuickSendForm = {
+                android.util.Log.d("QuickSendForm", "onHideQuickSendForm invoked")
                 service.uiState.value = service.uiState.value.copy(
                     showQuickSendForm = false,
                     quickSendFormFocused = false,
@@ -389,10 +399,15 @@ internal fun rememberImeKeyboardCallbacks(
                 service.forceInsetsRecompute()
             },
             onQuickSendFormFocusChange = { focused: Boolean ->
-                service.uiState.value = service.uiState.value.copy(
-                    quickSendFormFocused = focused,
-                    enterKeyText = if (focused) "确定" else "发送",
-                )
+                // 聚焦时回车键为"确定"；失焦不改文案——表单仍显示，回车保持"确定"
+                // 语义（提交并关闭，由 handleKeyPress 的 showQuickSendForm 分支保证）。
+                // 关闭表单时由 onHideQuickSendForm / onWindowHidden 统一还原"发送"。
+                val s = service.uiState.value
+                service.uiState.value = if (focused) {
+                    s.copy(quickSendFormFocused = true, enterKeyText = "确定")
+                } else {
+                    s.copy(quickSendFormFocused = false)
+                }
             },
         )
     }

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -917,6 +917,26 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
      */
     private var insetsRecomputePending = false
 
+    /**
+     * onGloballyPositioned 无条件记录的键盘内容顶部最新 y。
+     * pending 期间 y 更新被跳过（防 +1dp hack 抖动循环），但跳过的 y 是真实布局
+     * 结果（如快捷发送面板撑高 200dp）——丢掉会让 onComputeInsets 按旧 topPx
+     * 算 touchable region：面板可见却整个区域不可触摸（点关闭无响应）。
+     * pending 清除后由 [applyLatestContentTop] 补应用。
+     */
+    private var latestContentTopY = Int.MIN_VALUE
+
+    private fun applyLatestContentTop() {
+        if (latestContentTopY == Int.MIN_VALUE) return
+        if (latestContentTopY != keyboardContentTopPx) {
+            keyboardContentTopPx = latestContentTopY
+            android.util.Log.d("ImeWindowInsets", "contentBox late-apply y=$latestContentTopY")
+            // 刚才那轮 hack 是按旧 topPx 算的 insets，需再跑一轮让系统按新值重算；
+            // 第二轮的 ±1dp 抖动不会改变真实 y（== topPx）→ applyLatestContentTop 不再触发，收敛
+            forceInsetsRecompute()
+        }
+    }
+
     internal fun forceInsetsRecompute() {
         if (!::keyboardContainer.isInitialized) return
         if (insetsRecomputePending) return
@@ -928,6 +948,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             keyboardContainer.post {
                 keyboardContainer.resetHeight()
                 insetsRecomputePending = false
+                applyLatestContentTop()
             }
         } else {
             keyboardContainer.post { keyboardContainer.requestLayout() }
@@ -1209,11 +1230,15 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 // 快捷发送 / 工具面板为"键盘上方的撑高面板"：显示时键盘总高增加面板高度（面板在键盘上方，
                 // 不遮键盘按键），同时容器物理高度同步变大（updateHeight）→ IME insets 由系统确定性重算，
                 // 关闭后容器还原，彻底避免 insets 残留与白色区域。
-                val quickSendFormExtra = if (state.showQuickSendForm) 200 else 0
+                // Overlay 页面（menubar/剪贴板/emoji 等）全屏覆盖键盘内容区：激活期间撑高面板
+                // 不参与计算，否则 Overlay 页面会带上表单/工具面板的额外高度（容器整体被撑高）。
+                val isOverlayPage = page is com.kingzcheung.xime.keyboard.KeyboardPage.Overlay
+                val quickSendFormExtra = if (state.showQuickSendForm && !isOverlayPage) 200 else 0
                 // 需与 ToolPanel.TOOL_PANEL_HEIGHT(170) 保持一致，否则容器比面板多/少一截，键盘被拉高。
                 // PASSIVE 纯展示面板走 Overlay 全屏覆盖（键盘窗口内容区），不撑高。
                 val toolPanelExtra = if (state.toolPanelVisible &&
-                    state.toolPanelDisplay != "PASSIVE"
+                    state.toolPanelDisplay != "PASSIVE" &&
+                    !isOverlayPage
                 ) 170 else 0
                 val overlayPanelExtra = quickSendFormExtra + toolPanelExtra
 
@@ -1292,10 +1317,14 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                     // insetsRecomputePending 期间的高度摆动是 +1dp hack
                                     // 自身引起的，忽略之：否则 y 在 h/h+1 间交替变化，
                                     // 每次都 != keyboardContentTopPx → 无限循环触发重算。
+                                    // 但真实布局变化（面板撑高）的 y 不能丢——无条件记录到
+                                    // latestContentTopY，pending 清除后由 applyLatestContentTop 补应用。
+                                    val y = it.positionInWindow().y.toInt()
+                                    latestContentTopY = y
                                     if (!state.isFloatingMode && !state.isCompact && !insetsRecomputePending) {
-                                        val y = it.positionInWindow().y.toInt()
                                         if (y != keyboardContentTopPx) {
                                             keyboardContentTopPx = y
+                                            android.util.Log.d("ImeWindowInsets", "contentBox y=$y h=${it.size.height} qsForm=${state.showQuickSendForm}")
                                             // Compose 内容高度/位置变化不会自动触发 IME insets
                                             // 重算（面板关闭后实测残留数秒），这里在布局完成后
                                             // 强制一次真实尺寸变化（+1dp 再还原，视觉不可见），
@@ -1303,6 +1332,8 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                             // 值无变化时不重复触发，避免循环。
                                             mainHandler.post { forceInsetsRecompute() }
                                         }
+                                    } else {
+                                        android.util.Log.d("ImeWindowInsets", "contentBox SKIP y=$y h=${it.size.height} qsForm=${state.showQuickSendForm} pending=$insetsRecomputePending float=${state.isFloatingMode} compact=${state.isCompact}")
                                     }
                                 }
                         ) {
@@ -1933,6 +1964,19 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         super.onWindowHidden()
         clearInputState()
         recentClipboardItemsState.value = emptyList()
+        // 键盘隐藏时重置快捷发送表单临时态：表单开启状态下直接隐藏键盘（未走 onClose）
+        // 会把 showQuickSendForm 残留到下次弹窗，候选栏上方渲染出残留表单背景造成遮挡；
+        // 回车键文案也需一并还原（打开表单时被改为"确定"）。
+        if (uiState.value.showQuickSendForm || uiState.value.quickSendFormFocused) {
+            uiState.value = uiState.value.copy(
+                showQuickSendForm = false,
+                quickSendFormFocused = false,
+                quickSendEditingItemId = null,
+                quickSendEditingItemText = "",
+                enterKeyText = "发送",
+            )
+            QuickSendFormEditTextHolder.editText = null
+        }
     }
 
     override fun onWindowShown() {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidateBarOverlayPanel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidateBarOverlayPanel.kt
@@ -2,6 +2,7 @@ package com.kingzcheung.xime.ui.keyboard
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,6 +19,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -50,20 +52,32 @@ fun CandidateBarOverlayPanel(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
+            // 触摸目标 36dp（视觉圆 28dp 居中）：关闭是高频操作，过小的可点区域
+            // 在键盘高度微调（insets 重算 ±1dp）时容易点空，表现为"点了没反应"
             Box(
                 modifier = Modifier
-                    .size(28.dp)
-                    .clip(RoundedCornerShape(14.dp))
-                    .background(closeButtonBg)
-                    .clickable(onClick = onCloseClick),
+                    .size(36.dp)
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = onCloseClick,
+                    ),
                 contentAlignment = Alignment.Center
             ) {
-                Icon(
-                    imageVector = Icons.Default.Close,
-                    contentDescription = "关闭",
-                    tint = closeButtonColor,
-                    modifier = Modifier.size(18.dp)
-                )
+                Box(
+                    modifier = Modifier
+                        .size(28.dp)
+                        .clip(RoundedCornerShape(14.dp))
+                        .background(closeButtonBg),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "关闭",
+                        tint = closeButtonColor,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
             }
 
             if (title.isNotEmpty()) {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -285,6 +285,7 @@ fun KeyboardView(
                     cardBgColor = keyBgColor,
                     editingItemId = state.quickSendEditingItemId,
                     onClose = { text: String ->
+                        android.util.Log.d("QuickSendForm", "onClose: textLen=${text.length}, editingId=${state.quickSendEditingItemId}, showForm=${state.showQuickSendForm}")
                         if (text.isNotBlank()) {
                             val editingId = state.quickSendEditingItemId
                             if (editingId != null) {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/QuickSendFormArea.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/QuickSendFormArea.kt
@@ -3,10 +3,16 @@ package com.kingzcheung.xime.ui.keyboard
 import android.view.Gravity
 import android.view.View
 import android.view.inputmethod.EditorInfo
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -42,8 +48,18 @@ fun QuickSendFormArea(
         closeButtonColor = accentColor,
         title = title,
         titleColor = textColor,
-        modifier = modifier,
+        modifier = modifier
+            .onGloballyPositioned {
+                android.util.Log.d("QuickSendForm", "formArea bounds=${it.boundsInWindow()} size=${it.size}")
+            }
+            .pointerInput(Unit) {
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+                    android.util.Log.d("QuickSendForm", "formTouch pos=${down.position}")
+                }
+            },
         onCloseClick = {
+            android.util.Log.d("QuickSendForm", "closeClick: holder=${QuickSendFormEditTextHolder.editText != null}")
             val et = QuickSendFormEditTextHolder.editText
             onClose(et?.text?.toString() ?: "")
         },


### PR DESCRIPTION
- 修改ImeKeyRouter中表单焦点判断逻辑，使用showQuickSendForm替代quickSendFormFocused， 确保表单显示期间按键都能正确拦截处理

- 在显示快捷发送表单时添加关闭Overlay页面的逻辑，防止表单被全屏Box覆盖导致点击失效

- 修复表单聚焦状态切换时光标文案未正确更新的问题，保持表单显示时回车键语义一致

- 优化键盘窗口insets计算机制，新增latestContentTopY变量记录最新内容顶部位置， 解决Overlay页面激活时面板撑高导致的触摸区域计算错误

- 添加窗口隐藏时重置快捷发送表单状态的逻辑，防止表单状态残留影响下次显示

- 增加多个关键位置的日志输出用于调试定位问题

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
