### PR TITLE
fix(speech): 修复语音识别状态回调问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/speech/SpeechRecognitionManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/speech/SpeechRecognitionManager.kt
@@ -223,7 +223,7 @@ class SpeechRecognitionManager(private val context: Context) {
 
     private fun setState(state: RecognitionState) {
         currentState = state
-        setState(state)
+        stateCallback?.invoke(state)
     }
 
     fun setCallbacks(


### PR DESCRIPTION
修复了SpeechRecognitionManager中setState方法的无限递归调用问题，
将直接调用setState改为通过stateCallback回调状态变化。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
