### PR TITLE
refactor(ime): 重构IME键盘回调中的insets计算机制 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -256,7 +256,9 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
     testImplementation("org.mockito:mockito-core:5.23.0")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:6.3.0")
+    // JVM 单测使用真实 org.json 实现（android.jar 内为抛异常的 stub）
+    testImplementation("org.json:json:20240303")
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/kingzcheung/xime/handwriting/capture/HandwritingSample.kt
+++ b/app/src/main/java/com/kingzcheung/xime/handwriting/capture/HandwritingSample.kt
@@ -1,0 +1,28 @@
+package com.kingzcheung.xime.handwriting.capture
+
+/**
+ * 单个手写采集样本：一个目标字 + 原始笔迹。
+ *
+ * 坐标语义与键盘手写（HandwritingKeyboardLayout）一致：
+ * - x/y 为作画区局部像素坐标（左上角原点，y 向下），未做任何归一化；
+ * - 时间为相对本次样本首笔起点的毫秒数（首笔起点 = 0）。
+ * 归一化由训练侧复刻推理侧 HandwritingEngine.strokesToSequence 的
+ * bounding-box 算法完成，采集端只存原材料。
+ */
+data class HandwritingSample(
+    val target: String,
+    val canvasWidthPx: Float,
+    val canvasHeightPx: Float,
+    val strokes: List<List<StrokePointMs>>,
+    /** 采集时的识别首选（用于离线对比模型效果），无模型/未识别时为 null */
+    val modelTop: String? = null,
+    /** 识别首选得分，无识别时为 null */
+    val modelTopScore: Float? = null,
+)
+
+/** 带相对时间的采样点（ms 相对本样本首笔起点）。 */
+data class StrokePointMs(
+    val x: Float,
+    val y: Float,
+    val t: Long,
+)

--- a/app/src/main/java/com/kingzcheung/xime/handwriting/capture/HandwritingSampleCodec.kt
+++ b/app/src/main/java/com/kingzcheung/xime/handwriting/capture/HandwritingSampleCodec.kt
@@ -1,0 +1,137 @@
+package com.kingzcheung.xime.handwriting.capture
+
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.ByteArrayOutputStream
+import java.nio.charset.Charset
+
+/**
+ * HandwritingSample <-> JSON 编解码。
+ *
+ * JSON 结构（训练侧契约）：
+ * ```
+ * {
+ *   "format": "xime-handwriting-capture",
+ *   "version": 1,
+ *   "normalization": "per-stroke-set bounding box: (x-minX)/rangeX, (y-minY)/rangeY",
+ *   "meta": { "app_version", "device", "android", "exported_at_ms", "sample_count" },
+ *   "samples": [
+ *     {
+ *       "target": "中",
+ *       "canvas": { "w": 520.0, "h": 380.0 },
+ *       "strokes": [ { "t0": 0,   "pts": [[x,y,dt], ...] }, { "t0": 430, ... } ],
+ *       "model_top": "中" | 缺省,
+ *       "model_top_score": 0.97 | 缺省
+ *     }
+ *   ]
+ * }
+ * ```
+ * - x/y 为作画区局部像素坐标（原点左上，y 向下），未归一化；
+ * - t0 为笔画起点相对样本首笔起点的毫秒数，pts 内第三列为相对 t0 的毫秒数；
+ * - 归一化在训练侧执行，算法与推理侧 HandwritingEngine.strokesToSequence 一致。
+ */
+object HandwritingSampleCodec {
+
+    const val FORMAT = "xime-handwriting-capture"
+    const val VERSION = 1
+
+    fun samplesToJsonArray(samples: List<HandwritingSample>): JSONArray {
+        val arr = JSONArray()
+        for (sample in samples) arr.put(sampleToJson(sample))
+        return arr
+    }
+
+    fun sampleToJson(sample: HandwritingSample): JSONObject {
+        val obj = JSONObject()
+        obj.put("target", sample.target)
+        obj.put(
+            "canvas",
+            JSONObject().put("w", sample.canvasWidthPx.toDouble()).put("h", sample.canvasHeightPx.toDouble())
+        )
+        val strokes = JSONArray()
+        for (stroke in sample.strokes) {
+            val s = JSONObject()
+            val t0 = stroke.firstOrNull()?.t ?: 0L
+            s.put("t0", t0)
+            val pts = JSONArray()
+            for (p in stroke) {
+                pts.put(JSONArray().put(p.x.toDouble()).put(p.y.toDouble()).put(p.t - t0))
+            }
+            s.put("pts", pts)
+            strokes.put(s)
+        }
+        obj.put("strokes", strokes)
+        sample.modelTop?.let { obj.put("model_top", it) }
+        sample.modelTopScore?.let { obj.put("model_top_score", it.toDouble()) }
+        return obj
+    }
+
+    fun buildExportJson(
+        samples: List<HandwritingSample>,
+        appVersion: String,
+        device: String,
+        androidVersion: String,
+        exportedAtMs: Long,
+    ): String {
+        val root = JSONObject()
+        root.put("format", FORMAT)
+        root.put("version", VERSION)
+        root.put(
+            "normalization",
+            "per-sample bounding box: (x-minX)/max(rangeX,1), (y-minY)/max(rangeY,1); " +
+                "identical to HandwritingEngine.strokesToSequence"
+        )
+        root.put(
+            "meta",
+            JSONObject()
+                .put("app_version", appVersion)
+                .put("device", device)
+                .put("android", androidVersion)
+                .put("exported_at_ms", exportedAtMs)
+                .put("sample_count", samples.size)
+        )
+        root.put("samples", samplesToJsonArray(samples))
+        return root.toString(2)
+    }
+
+    fun parseFromJson(text: String): List<HandwritingSample> {
+        val root = JSONObject(text)
+        if (root.optString("format") != FORMAT) return emptyList()
+        val arr = root.optJSONArray("samples") ?: return emptyList()
+        val out = mutableListOf<HandwritingSample>()
+        for (i in 0 until arr.length()) {
+            val s = arr.optJSONObject(i) ?: continue
+            val target = s.optString("target")
+            if (target.isEmpty()) continue
+            val canvas = s.optJSONObject("canvas")
+            val w = canvas?.optDouble("w")?.toFloat() ?: 0f
+            val h = canvas?.optDouble("h")?.toFloat() ?: 0f
+            val modelTop = s.optString("model_top").ifEmpty { null }
+            val modelTopScore = if (s.has("model_top_score")) s.optDouble("model_top_score").toFloat() else null
+            val strokes = mutableListOf<List<StrokePointMs>>()
+            val sArr = s.optJSONArray("strokes") ?: JSONArray()
+            for (j in 0 until sArr.length()) {
+                val st = sArr.optJSONObject(j) ?: continue
+                val t0 = st.optLong("t0")
+                val ptsArr = st.optJSONArray("pts") ?: JSONArray()
+                val pts = mutableListOf<StrokePointMs>()
+                for (k in 0 until ptsArr.length()) {
+                    val p = ptsArr.optJSONArray(k) ?: continue
+                    if (p.length() < 3) continue
+                    pts.add(
+                        StrokePointMs(
+                            x = p.optDouble(0).toFloat(),
+                            y = p.optDouble(1).toFloat(),
+                            t = t0 + p.optLong(2),
+                        )
+                    )
+                }
+                if (pts.isNotEmpty()) strokes.add(pts)
+            }
+            if (strokes.isNotEmpty()) {
+                out.add(HandwritingSample(target, w, h, strokes, modelTop, modelTopScore))
+            }
+        }
+        return out
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
@@ -365,9 +365,8 @@ internal fun rememberImeKeyboardCallbacks(
                     quickSendEditingItemText = "",
                     enterKeyText = "确定",
                 )
-                // 不在此处 forceInsetsRecompute：此刻 Compose 尚未布局，hack 会用旧高度
-                // 白跑一轮且 pending=true 挡掉撑高后的第一次 y 更新（曾导致表单可见
-                // 却不可触摸）。布局撑高完成后 onGloballyPositioned 会以新 y 触发重算。
+                // 撑高由 SideEffect 驱动：uiState 变化 → Compose 内容高度变化 →
+                // updateHeight 改容器物理高度 → relayout → onComputeInsets 自动重算。
             },
             onQuickSendEditItem = { id, text ->
                 // 同 onShowQuickSendForm：编辑入口在剪贴板面板内，先退出 Overlay 防表单被盖
@@ -395,8 +394,8 @@ internal fun rememberImeKeyboardCallbacks(
                 )
                 QuickSendFormEditTextHolder.editText = null
                 service.keyboardViewModel.showOverlay(OverlayRoute.Clipboard(1))
-                // 兜底：强制容器真实尺寸变化，触发 IME insets 重算恢复为纯键盘高度（防残留）。
-                service.forceInsetsRecompute()
+                // insets 恢复由 SideEffect 驱动：表单收起 → 容器物理高度还原 →
+                // relayout → onComputeInsets 自动重算，无需强制触发。
             },
             onQuickSendFormFocusChange = { focused: Boolean ->
                 // 聚焦时回车键为"确定"；失焦不改文案——表单仍显示，回车保持"确定"

--- a/app/src/main/java/com/kingzcheung/xime/service/VoiceKeyboardContainer.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/VoiceKeyboardContainer.kt
@@ -43,15 +43,6 @@ class VoiceKeyboardContainer(
         }
     }
 
-    fun resetHeight() {
-        val params = layoutParams
-        if (params != null && params.height != FrameLayout.LayoutParams.MATCH_PARENT) {
-            params.height = FrameLayout.LayoutParams.MATCH_PARENT
-            layoutParams = params
-            requestLayout()
-        }
-    }
-
     override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
         ev?.let {
             when (it.action) {

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -100,12 +100,9 @@ import com.kingzcheung.xime.ui.keyboard.KeyboardView
 import com.kingzcheung.xime.ui.keyboard.isT9Schema
 import com.kingzcheung.xime.ui.theme.KeyboardThemes
 import com.kingzcheung.xime.ui.theme.keyboardBackground
-import kotlin.math.abs
 import kotlin.math.roundToInt
 import com.kingzcheung.xime.settings.KeysConfigHelper
 import com.kingzcheung.xime.ui.theme.XimeTheme
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInWindow
 import com.kingzcheung.xime.util.FileLogger
 import com.kingzcheung.xime.util.PreeditMergeHelper
 import com.kingzcheung.xime.BuildConfig
@@ -248,9 +245,6 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     internal var currentEffectiveKeyboardHeight: Int = 0
     internal var currentFloatingCardHeightDp: Int = 0
     internal var previousSchemaId: String = ""
-    /** 键盘内容 Box 顶部在窗口中的 y 坐标（px），由 onGloballyPositioned 实测更新 */
-    private var keyboardContentTopPx: Int = -1
-    private var lastInsetsDebug: String = ""
     
     internal val calculatorEngine = com.kingzcheung.xime.calculator.CalculatorEngine()
 
@@ -849,7 +843,6 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 et.setSelection(prefill.length)
             }
         }
-        forceInsetsRecompute()
     }
 
     /**
@@ -902,57 +895,6 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             enterKeyText = "发送",
         )
         ToolPanelEditTextHolder.editText = null
-        forceInsetsRecompute()
-    }
-
-    /**
-     * Compose 内容高度变化（面板开关）不会自动触发 IME insets 重算，
-     * 实测关闭面板后 insets 残留数秒（仅在下一次输入会话/窗口事件时才恢复）。
-     * 这里通过容器做一次真实尺寸变化（+1dp）再立即还原（同帧内完成，视觉不可见），
-     * 强制系统按 keyboardContentTopPx 重算并下发，消除残留。
-     *
-     * [insetsRecomputePending] 防重入：+1dp 到 resetHeight 还原之间为"飞行中"，
-     * 期间再次调用会读到 +1dp 后的当前高度再叠加 +1——某些 ROM 上 onApplyWindowInsets
-     * 回调时机不同导致 reset 滞后，+1dp 反复叠加/循环 → 键盘底部被持续垫高（2.7.0 用户反馈）。
-     */
-    private var insetsRecomputePending = false
-
-    /**
-     * onGloballyPositioned 无条件记录的键盘内容顶部最新 y。
-     * pending 期间 y 更新被跳过（防 +1dp hack 抖动循环），但跳过的 y 是真实布局
-     * 结果（如快捷发送面板撑高 200dp）——丢掉会让 onComputeInsets 按旧 topPx
-     * 算 touchable region：面板可见却整个区域不可触摸（点关闭无响应）。
-     * pending 清除后由 [applyLatestContentTop] 补应用。
-     */
-    private var latestContentTopY = Int.MIN_VALUE
-
-    private fun applyLatestContentTop() {
-        if (latestContentTopY == Int.MIN_VALUE) return
-        if (latestContentTopY != keyboardContentTopPx) {
-            keyboardContentTopPx = latestContentTopY
-            android.util.Log.d("ImeWindowInsets", "contentBox late-apply y=$latestContentTopY")
-            // 刚才那轮 hack 是按旧 topPx 算的 insets，需再跑一轮让系统按新值重算；
-            // 第二轮的 ±1dp 抖动不会改变真实 y（== topPx）→ applyLatestContentTop 不再触发，收敛
-            forceInsetsRecompute()
-        }
-    }
-
-    internal fun forceInsetsRecompute() {
-        if (!::keyboardContainer.isInitialized) return
-        if (insetsRecomputePending) return
-        val density = resources.displayMetrics.density
-        val h = keyboardContainer.height
-        if (h > 0) {
-            insetsRecomputePending = true
-            keyboardContainer.updateHeight((h / density).toInt() + 1)
-            keyboardContainer.post {
-                keyboardContainer.resetHeight()
-                insetsRecomputePending = false
-                applyLatestContentTop()
-            }
-        } else {
-            keyboardContainer.post { keyboardContainer.requestLayout() }
-        }
     }
 
     /**
@@ -1249,18 +1191,12 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                         val totalDp = if (state.isCompact || state.isFloatingMode) effectiveScreenH
                             else contentHeight + state.keyboardBottomPaddingDp + activeBottomDp
                         SideEffect {
-                            // 容器永远保持 MATCH_PARENT（setInputView 已设置），撑高只发生在
-                            // Compose 内部（键盘内容高度增加），与"键盘调节"完全同一路径：
-                            // 1110 Box 顶部随高度上移 → keyboardContentTopPx 上移 → insets 更新 → 应用被顶起。
-                            // 切勿在此改容器物理高度：容器脱离 MATCH_PARENT 后 IME 窗口内
-                            // 会退化为顶部对齐（FrameLayout child 默认 top-left），键盘整体跑到屏顶。
-                            if (state.isCompact || state.isFloatingMode) {
-                                keyboardContainer.updateHeight(totalDp)
-                            } else {
-                                // 从悬浮/紧凑模式切回时恢复容器为 MATCH_PARENT，
-                                // 否则容器高度残留悬浮时的固定值导致布局异常。
-                                keyboardContainer.resetHeight()
-                            }
+                            // 容器物理高度 = Compose 内容总高（含底部留白），全模式统一。
+                            // 容器高度变化 → View 层 relayout → traversal → onComputeInsets
+                            // 自动以新高度重算并上报（ViewRootImpl 每次 traversal 都 dispatch
+                            // OnComputeInternalInsetsListener，值变化即 setInsets），
+                            // 无需 +1dp hack 强制造型变化。
+                            keyboardContainer.updateHeight(totalDp)
                             currentEffectiveKeyboardHeight = if (state.isFloatingMode) keyboardHeight + floatingDragBarHeight + 50 + state.keyboardBottomPaddingDp
                                 else if (state.isCompact) HARDWARE_CANDIDATE_BAR_HEIGHT
                                 else effectiveKeyboardHeight + overlayPanelExtra
@@ -1313,29 +1249,6 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                 .height(if (state.showKeyboardResize) (state.resizePreviewHeightDp + state.keyboardBottomPaddingDp).dp else (floatingCardContentHeight + state.keyboardBottomPaddingDp + overlayPanelExtra).dp)
                                 .align(androidx.compose.ui.Alignment.BottomCenter)
                                 .then(if (state.isFloatingMode) Modifier else Modifier.offset(y = (-activeBottomDp).dp))
-                                .onGloballyPositioned {
-                                    // insetsRecomputePending 期间的高度摆动是 +1dp hack
-                                    // 自身引起的，忽略之：否则 y 在 h/h+1 间交替变化，
-                                    // 每次都 != keyboardContentTopPx → 无限循环触发重算。
-                                    // 但真实布局变化（面板撑高）的 y 不能丢——无条件记录到
-                                    // latestContentTopY，pending 清除后由 applyLatestContentTop 补应用。
-                                    val y = it.positionInWindow().y.toInt()
-                                    latestContentTopY = y
-                                    if (!state.isFloatingMode && !state.isCompact && !insetsRecomputePending) {
-                                        if (y != keyboardContentTopPx) {
-                                            keyboardContentTopPx = y
-                                            android.util.Log.d("ImeWindowInsets", "contentBox y=$y h=${it.size.height} qsForm=${state.showQuickSendForm}")
-                                            // Compose 内容高度/位置变化不会自动触发 IME insets
-                                            // 重算（面板关闭后实测残留数秒），这里在布局完成后
-                                            // 强制一次真实尺寸变化（+1dp 再还原，视觉不可见），
-                                            // 确保 insets 即时跟随键盘实际高度（防残留/白色区域）。
-                                            // 值无变化时不重复触发，避免循环。
-                                            mainHandler.post { forceInsetsRecompute() }
-                                        }
-                                    } else {
-                                        android.util.Log.d("ImeWindowInsets", "contentBox SKIP y=$y h=${it.size.height} qsForm=${state.showQuickSendForm} pending=$insetsRecomputePending float=${state.isFloatingMode} compact=${state.isCompact}")
-                                    }
-                                }
                         ) {
                         CompositionLocalProvider(LocalStretchFactor provides state.stretchFactor) {
                             // 注意：kbState 只承载键盘按键/布局状态，不承载候选数据。
@@ -1499,8 +1412,12 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 ?.updateLayoutParams<android.view.ViewGroup.LayoutParams> {
                     height = android.view.ViewGroup.LayoutParams.MATCH_PARENT
                 }
-            view.updateLayoutParams<android.view.ViewGroup.LayoutParams> {
+            // 容器在 inputArea 内底部对齐（gravity BOTTOM）：
+            // 容器物理高度 = Compose 内容总高，小于全屏窗口时若默认 top-left
+            // 对齐会让键盘跑到屏顶。高度由 SideEffect 的 updateHeight 动态设置。
+            view.updateLayoutParams<android.widget.FrameLayout.LayoutParams> {
                 height = android.view.ViewGroup.LayoutParams.MATCH_PARENT
+                gravity = android.view.Gravity.BOTTOM
             }
         } catch (_: Exception) {}
     }
@@ -2209,17 +2126,18 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 )
             }
         } else {
-            // 非浮动模式：窗口全屏，键盘内容贴底。
-            // contentTopInsets 直接使用 Compose 实测的键盘内容顶部位置（px），
-            // 避免 window 全屏后 super 误判键盘占满全屏导致布局下沉。
-            if (keyboardContentTopPx > 0) {
-                val dbg = "topPx=$keyboardContentTopPx qsForm=${state.showQuickSendForm} toolPanel=${state.toolPanelVisible} resize=${state.showKeyboardResize} hw=${(keyboardViewModel.page.value as? com.kingzcheung.xime.keyboard.KeyboardPage.Main)?.type == com.kingzcheung.xime.keyboard.MainType.HANDWRITING}"
-                if (dbg != lastInsetsDebug) {
-                    lastInsetsDebug = dbg
-                    Log.d("InsetsDebug", dbg)
-                }
-                outInsets.contentTopInsets = keyboardContentTopPx
-                outInsets.visibleTopInsets = keyboardContentTopPx
+            // 非浮动模式：窗口全屏，容器物理高度 = Compose 内容总高（含底部留白），
+            // 容器在窗口内底部对齐（gravity BOTTOM）。
+            // contentTopInsets 直接用容器顶部在窗口中的 y 同步计算：
+            // 容器高度变化（面板撑高/收起）→ View relayout → traversal → 本方法
+            // 自动以新几何重算并上报，无需 hack；窗口全屏时 super 会误判键盘占满
+            // 全屏导致布局下沉，故必须显式报告容器顶部。
+            if (::keyboardContainer.isInitialized && keyboardContainer.height > 0) {
+                val loc = IntArray(2)
+                keyboardContainer.getLocationInWindow(loc)
+                val topPx = loc[1].coerceAtLeast(0)
+                outInsets.contentTopInsets = topPx
+                outInsets.visibleTopInsets = topPx
                 outInsets.touchableInsets = Insets.TOUCHABLE_INSETS_VISIBLE
             } else {
                 super.onComputeInsets(outInsets)

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/AboutScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/AboutScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PrivacyTip
 import androidx.compose.material.icons.twotone.BugReport
@@ -46,6 +47,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -132,12 +134,28 @@ fun AboutContent(
     onBack: () -> Unit,
     onNavigateToPrivacy: () -> Unit,
     onNavigateToLicenses: () -> Unit,
-    onNavigateToLogViewer: () -> Unit = {}
+    onNavigateToLogViewer: () -> Unit = {},
+    onNavigateToHandwritingCapture: () -> Unit = {},
 ) {
     val uriHandler = LocalUriHandler.current
     val context = LocalContext.current
     var verboseLoggingEnabled by remember {
         mutableStateOf(SettingsPreferences.isVerboseLoggingEnabled(context))
+    }
+    // 彩蛋入口：1.5 秒内连点"设备信息"卡片 7 次解锁"手写数据采集"（平时隐藏）
+    var captureTapCount by remember { mutableStateOf(0) }
+    var lastCaptureTapMs by remember { mutableStateOf(0L) }
+    var captureUnlocked by rememberSaveable { mutableStateOf(false) }
+    fun onDeviceInfoTapped() {
+        val now = System.currentTimeMillis()
+        if (now - lastCaptureTapMs > 1500L) captureTapCount = 0
+        lastCaptureTapMs = now
+        captureTapCount++
+        if (captureTapCount >= 7) {
+            captureTapCount = 0
+            captureUnlocked = true
+            android.widget.Toast.makeText(context, "已解锁手写数据采集入口", android.widget.Toast.LENGTH_SHORT).show()
+        }
     }
     
     Scaffold(
@@ -359,6 +377,18 @@ fun AboutContent(
                             title = "日志查看器",
                             onClick = onNavigateToLogViewer
                         )
+                        if (captureUnlocked) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(start = 72.dp),
+                                thickness = 0.5.dp,
+                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                            )
+                            SettingsItem(
+                                icon = Icons.Default.Edit,
+                                title = "手写数据采集",
+                                onClick = onNavigateToHandwritingCapture
+                            )
+                        }
                         if (BuildConfig.DEBUG) {
                             HorizontalDivider(
                                 modifier = Modifier.padding(start = 72.dp),
@@ -395,6 +425,7 @@ fun AboutContent(
                     Column(
                         modifier = Modifier
                             .fillMaxWidth()
+                            .clickable { onDeviceInfoTapped() }
                             .padding(16.dp)
                     ) {
                         Text(

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/HandwritingCaptureScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/HandwritingCaptureScreen.kt
@@ -1,0 +1,597 @@
+package com.kingzcheung.xime.ui.settings
+
+import android.content.ContentValues
+import android.content.Intent
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import android.util.Log
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.IosShare
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.SaveAlt
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.content.FileProvider
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.kingzcheung.xime.BuildConfig
+import com.kingzcheung.xime.handwriting.HandwritingCandidate
+import com.kingzcheung.xime.handwriting.HandwritingEngine
+import com.kingzcheung.xime.handwriting.StrokePoint
+import com.kingzcheung.xime.handwriting.capture.HandwritingSample
+import com.kingzcheung.xime.handwriting.capture.HandwritingSampleCodec
+import com.kingzcheung.xime.handwriting.capture.StrokePointMs
+import com.kingzcheung.xime.util.FileLogger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+private const val TAG = "HandwritingCapture"
+
+/** 采集导出事件：分享（FileProvider uri）/保存到 Downloads/错误提示。 */
+sealed class CaptureEvent {
+    data class Share(val uri: android.net.Uri, val subject: String) : CaptureEvent()
+    data class Saved(val path: String) : CaptureEvent()
+    data class Error(val message: String) : CaptureEvent()
+}
+
+/**
+ * 手写采集样本仓库（内存）。导出时把当前样本序列化为 JSON（HandwritingSampleCodec）。
+ */
+class HandwritingCaptureViewModel(app: android.app.Application) : AndroidViewModel(app) {
+
+    private val _samples = MutableStateFlow<List<HandwritingSample>>(emptyList())
+    val samples: StateFlow<List<HandwritingSample>> = _samples
+
+    private val _events = MutableSharedFlow<CaptureEvent>(extraBufferCapacity = 8)
+    val events: SharedFlow<CaptureEvent> = _events
+
+    /** 追加样本：同一个字可多次书写提交（多样本提升数据多样性）。 */
+    fun addSample(sample: HandwritingSample) {
+        _samples.update { list -> list + sample }
+    }
+
+    /** 删除该字的全部样本。 */
+    fun removeAllSamples(target: String) {
+        _samples.update { list -> list.filterNot { it.target == target } }
+    }
+
+    fun clearAll() {
+        _samples.value = emptyList()
+    }
+
+    private fun exportFile(): File {
+        val dir = File(getApplication<android.app.Application>().filesDir, "exports").apply { mkdirs() }
+        val stamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+        return File(dir, "xime_handwriting_$stamp.json")
+    }
+
+    private fun writeJson(file: File): String {
+        val app = getApplication<android.app.Application>()
+        val json = HandwritingSampleCodec.buildExportJson(
+            samples = _samples.value,
+            appVersion = BuildConfig.VERSION_NAME,
+            device = AppInfo.deviceModel,
+            androidVersion = AppInfo.androidVersion,
+            exportedAtMs = System.currentTimeMillis(),
+        )
+        file.writeText(json, Charsets.UTF_8)
+        return json
+    }
+
+    fun exportShare() {
+        viewModelScope.launch {
+            if (_samples.value.isEmpty()) {
+                _events.emit(CaptureEvent.Error("暂无采集样本"))
+                return@launch
+            }
+            try {
+                val file = withContext(Dispatchers.IO) { exportFile().also { writeJson(it) } }
+                val uri = FileProvider.getUriForFile(
+                    getApplication(),
+                    "${getApplication<android.app.Application>().packageName}.fileprovider",
+                    file,
+                )
+                _events.emit(CaptureEvent.Share(uri, "Xime 手写采集数据"))
+            } catch (e: Exception) {
+                Log.e(TAG, "exportShare failed", e)
+                FileLogger.e(TAG, "exportShare failed", e)
+                _events.emit(CaptureEvent.Error("导出失败: ${e.message}"))
+            }
+        }
+    }
+
+    fun exportToDownloads() {
+        viewModelScope.launch {
+            if (_samples.value.isEmpty()) {
+                _events.emit(CaptureEvent.Error("暂无采集样本"))
+                return@launch
+            }
+            try {
+                val file = withContext(Dispatchers.IO) { exportFile().also { writeJson(it) } }
+                val savedPath = withContext(Dispatchers.IO) { saveToDownloads(file) }
+                _events.emit(CaptureEvent.Saved(savedPath))
+            } catch (e: Exception) {
+                Log.e(TAG, "exportToDownloads failed", e)
+                FileLogger.e(TAG, "exportToDownloads failed", e)
+                _events.emit(CaptureEvent.Error("保存失败: ${e.message}"))
+            }
+        }
+    }
+
+    private fun saveToDownloads(file: File): String {
+        val context = getApplication<android.app.Application>()
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val values = ContentValues().apply {
+                put(MediaStore.Downloads.DISPLAY_NAME, file.name)
+                put(MediaStore.Downloads.MIME_TYPE, "application/json")
+                put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS)
+            }
+            val uri = context.contentResolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
+                ?: throw IllegalStateException("MediaStore insert failed")
+            context.contentResolver.openOutputStream(uri)?.use { output ->
+                file.inputStream().use { it.copyTo(output) }
+            } ?: throw IllegalStateException("openOutputStream failed")
+            "Download/${file.name}"
+        } else {
+            @Suppress("DEPRECATION")
+            val dest = File(
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+                file.name,
+            )
+            file.copyTo(dest, overwrite = true)
+            "Download/${file.name}"
+        }
+    }
+}
+
+/**
+ * 手写数据采集页（隐藏入口进入，用于采集笔迹样本优化手写模型）：
+ * 粘贴一段文本 → 点击目标字 → 内嵌画布书写 → 识别预览人工确认 → 自动跳下一个未采字 → JSON 导出。
+ *
+ * 坐标语义与键盘手写一致：作画区局部像素坐标（左上原点，y 向下），模型侧按笔迹
+ * bounding box 归一化（HandwritingEngine.strokesToSequence），画布尺寸不影响分布。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HandwritingCaptureScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val viewModel: HandwritingCaptureViewModel = viewModel()
+    val samples by viewModel.samples.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    var sourceText by rememberSaveable { mutableStateOf("") }
+    var currentTarget by rememberSaveable { mutableStateOf<String?>(null) }
+    var menuExpanded by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is CaptureEvent.Share -> {
+                    val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                        type = "application/json"
+                        putExtra(Intent.EXTRA_SUBJECT, event.subject)
+                        putExtra(Intent.EXTRA_STREAM, event.uri)
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        clipData = android.content.ClipData.newRawUri(null, event.uri)
+                    }
+                    context.startActivity(Intent.createChooser(shareIntent, "分享采集数据"))
+                }
+                is CaptureEvent.Saved -> snackbarHostState.showSnackbar("已保存到 ${event.path}")
+                is CaptureEvent.Error -> snackbarHostState.showSnackbar(event.message)
+            }
+        }
+    }
+
+    // 目标字符列表：按文本出现顺序去重，剔除空白
+    val targetChars = remember(sourceText) {
+        sourceText.filterNot { it.isWhitespace() }.let { if (it.isEmpty()) emptyList() else it.toList().distinct() }
+    }
+    // 每字样本数（同字可多次书写）
+    val sampleCounts = remember(samples) { samples.groupingBy { it.target }.eachCount() }
+    val remaining: List<String> = remember(targetChars, sampleCounts) {
+        targetChars.filterNot { ch -> sampleCounts.containsKey(ch.toString()) }.map { it.toString() }
+    }
+
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.surface,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text("手写数据采集") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                ),
+                actions = {
+                    Text(
+                        text = "已采 ${samples.size}",
+                        fontSize = 13.sp,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(end = 4.dp),
+                    )
+                    IconButton(onClick = { menuExpanded = true }) {
+                        Icon(Icons.Filled.MoreVert, contentDescription = "更多")
+                    }
+                    DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+                        DropdownMenuItem(
+                            text = { Text("分享 JSON") },
+                            leadingIcon = { Icon(Icons.Filled.IosShare, contentDescription = null) },
+                            onClick = { menuExpanded = false; viewModel.exportShare() },
+                        )
+                        DropdownMenuItem(
+                            text = { Text("保存到下载") },
+                            leadingIcon = { Icon(Icons.Filled.SaveAlt, contentDescription = null) },
+                            onClick = { menuExpanded = false; viewModel.exportToDownloads() },
+                        )
+                        DropdownMenuItem(
+                            text = { Text("清空样本") },
+                            leadingIcon = { Icon(Icons.Filled.Delete, contentDescription = null) },
+                            onClick = { menuExpanded = false; viewModel.clearAll() },
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp),
+        ) {
+            OutlinedTextField(
+                value = sourceText,
+                onValueChange = { sourceText = it },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("粘贴要采集的文本") },
+                placeholder = { Text("粘贴一段话，逐字采集笔迹") },
+                singleLine = false,
+                maxLines = 2,
+                textStyle = MaterialTheme.typography.bodyMedium,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = if (targetChars.isEmpty()) {
+                    "共 0 个目标字"
+                } else {
+                    "共 ${targetChars.size} 个目标字，剩余 ${remaining.size} 个"
+                },
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(8.dp))
+
+            // 文章式目标字流：36dp 小格紧凑排布，长文本一屏可见大量字
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    for (ch in targetChars) {
+                        val chStr = ch.toString()
+                        val count = sampleCounts[chStr] ?: 0
+                        val selected = chStr == currentTarget
+                        Box(
+                            modifier = Modifier
+                                .size(38.dp)
+                                .clip(RoundedCornerShape(7.dp))
+                                .background(
+                                    if (count > 0) MaterialTheme.colorScheme.tertiaryContainer
+                                    else MaterialTheme.colorScheme.surfaceVariant
+                                )
+                                .then(
+                                    if (selected) {
+                                        Modifier.border(
+                                            2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(7.dp),
+                                        )
+                                    } else Modifier
+                                )
+                                .clickable { currentTarget = chStr },
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = chStr,
+                                fontSize = 19.sp,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                            if (count > 0) {
+                                Text(
+                                    text = "×$count",
+                                    fontSize = 9.sp,
+                                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                                    modifier = Modifier
+                                        .align(Alignment.BottomEnd)
+                                        .padding(end = 2.dp, bottom = 1.dp),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            currentTarget?.let { target ->
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                HandwritingCaptureEditor(
+                    target = target,
+                    existingCount = sampleCounts[target] ?: 0,
+                    onConfirm = { sample ->
+                        viewModel.addSample(sample)
+                        currentTarget = remaining.firstOrNull { it != sample.target }
+                    },
+                    onDelete = {
+                        viewModel.removeAllSamples(target)
+                        currentTarget = null
+                    },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * 单字书写编辑器：米字格画布 + 笔迹录制 + 实时识别预览 + 确认/重写。
+ * 同一字可多次书写提交（追加样本），[existingCount] 为该字已有样本数。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun HandwritingCaptureEditor(
+    target: String,
+    existingCount: Int,
+    onConfirm: (HandwritingSample) -> Unit,
+    onDelete: () -> Unit,
+) {
+    val context = LocalContext.current
+    val strokes = remember(target) { mutableStateListOf<List<StrokePoint>>() }
+    var currentStroke by remember(target) { mutableStateOf<List<StrokePoint>>(emptyList()) }
+    var candidates by remember(target) { mutableStateOf<List<HandwritingCandidate>>(emptyList()) }
+    var canvasSizePx by remember(target) { mutableStateOf(0 to 0) }
+
+    // 与键盘手写共享进程内单例引擎；无模型时 predict 返回空，仅记录笔迹
+    LaunchedEffect(Unit) {
+        val ok = withContext(Dispatchers.IO) { HandwritingEngine.initialize(context) }
+        if (!ok) Log.w(TAG, "Handwriting model not available, capture without preview")
+    }
+
+    // 每笔完成后识别一次（含重写清空时复位）
+    LaunchedEffect(strokes.size, target) {
+        if (strokes.isEmpty()) {
+            candidates = emptyList()
+        } else {
+            candidates = withContext(Dispatchers.Default) {
+                HandwritingEngine.predict(strokes.map { stroke -> stroke.map { it.x to it.y } }, topK = 3)
+            }
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = target,
+                fontSize = 34.sp,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(Modifier.width(12.dp))
+            Column {
+                Text(
+                    text = if (candidates.isEmpty()) "写完显示识别预览" else "识别: " +
+                        candidates.joinToString("  ") { it.char } + "  (确认后按目标字「$target」记样本)",
+                    fontSize = 12.sp,
+                    color = if (candidates.isEmpty()) MaterialTheme.colorScheme.onSurfaceVariant
+                    else MaterialTheme.colorScheme.onSurface,
+                )
+                if (existingCount > 0) {
+                    Text(
+                        text = "已采 ${existingCount} 个样本，确认后新增第 ${existingCount + 1} 个",
+                        fontSize = 11.sp,
+                        color = MaterialTheme.colorScheme.tertiary,
+                    )
+                }
+            }
+            Spacer(Modifier.weight(1f))
+        }
+        Spacer(Modifier.height(8.dp))
+
+        val gridColor = MaterialTheme.colorScheme.outlineVariant
+        val inkColor = MaterialTheme.colorScheme.onSurface
+        Canvas(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .clip(RoundedCornerShape(12.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                .onSizeChanged { canvasSizePx = it.width to it.height }
+                .pointerInput(target) {
+                    awaitEachGesture {
+                        val down = awaitFirstDown()
+                        down.consume()
+                        val stroke = mutableListOf(
+                            StrokePoint(down.position.x, down.position.y),
+                        )
+                        currentStroke = stroke.toList()
+                        do {
+                            val event = awaitPointerEvent()
+                            val change = event.changes.firstOrNull() ?: break
+                            if (change.pressed) {
+                                change.consume()
+                                // 帧内历史点：触屏采样率高于刷新率时一帧含多个采样，
+                                // 全部入轨迹（跟手 + 采集数据保真）
+                                for (h in change.historical) {
+                                    stroke.add(StrokePoint(h.position.x, h.position.y))
+                                }
+                                stroke.add(StrokePoint(change.position.x, change.position.y))
+                                currentStroke = stroke.toList()
+                            } else {
+                                break
+                            }
+                        } while (true)
+                        // 抬笔：笔画结束（单点误触也保留，训练侧可过滤）
+                        strokes.add(stroke.toList())
+                        currentStroke = emptyList()
+                    }
+                },
+        ) {
+            val w = size.width
+            val h = size.height
+            val dash = PathEffect.dashPathEffect(floatArrayOf(12f, 12f))
+            // 田字格：外框 + 十字虚线
+            drawRect(gridColor, style = Stroke(width = 2f))
+            drawLine(gridColor, Offset(w / 2, 0f), Offset(w / 2, h), pathEffect = dash)
+            drawLine(gridColor, Offset(0f, h / 2), Offset(w, h / 2), pathEffect = dash)
+            // 对角虚线（米字格）
+            drawLine(gridColor, Offset(0f, 0f), Offset(w, h), pathEffect = dash)
+            drawLine(gridColor, Offset(w, 0f), Offset(0f, h), pathEffect = dash)
+
+            val strokeWidth = 4.dp.toPx()
+            fun renderStroke(points: List<StrokePoint>) {
+                if (points.isEmpty()) return
+                if (points.size == 1) {
+                    drawCircle(inkColor, radius = strokeWidth / 2, center = Offset(points[0].x, points[0].y))
+                    return
+                }
+                val path = Path().apply {
+                    moveTo(points[0].x, points[0].y)
+                    for (i in 1 until points.size) lineTo(points[i].x, points[i].y)
+                }
+                drawPath(
+                    path, inkColor,
+                    style = Stroke(width = strokeWidth, cap = StrokeCap.Round, join = StrokeJoin.Round),
+                )
+            }
+            for (stroke in strokes) renderStroke(stroke)
+            renderStroke(currentStroke)
+        }
+        Spacer(Modifier.height(8.dp))
+
+        Row {
+            OutlinedButton(
+                onClick = {
+                    strokes.clear()
+                    currentStroke = emptyList()
+                    candidates = emptyList()
+                },
+                enabled = strokes.isNotEmpty(),
+            ) {
+                Text("重写")
+            }
+            Spacer(Modifier.width(12.dp))
+            Button(
+                onClick = {
+                    val w = canvasSizePx.first.toFloat()
+                    val h = canvasSizePx.second.toFloat()
+                    val t0 = strokes.firstOrNull()?.firstOrNull()?.timeMs ?: 0L
+                    val top = candidates.firstOrNull()
+                    onConfirm(
+                        HandwritingSample(
+                            target = target,
+                            canvasWidthPx = w,
+                            canvasHeightPx = h,
+                            strokes = strokes.map { stroke ->
+                                stroke.map { StrokePointMs(it.x, it.y, it.timeMs - t0) }
+                            },
+                            modelTop = top?.char,
+                            modelTopScore = top?.score,
+                        ),
+                    )
+                },
+                enabled = strokes.isNotEmpty(),
+                modifier = Modifier.weight(1f),
+            ) {
+                Text("确认并下一个")
+            }
+            if (existingCount > 0) {
+                Spacer(Modifier.width(12.dp))
+                TextButton(onClick = onDelete) {
+                    Text("删除该字样本", color = MaterialTheme.colorScheme.error)
+                }
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsRoutes.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsRoutes.kt
@@ -22,6 +22,7 @@ object SettingsRoutes {
     const val Privacy = "privacy"
     const val Licenses = "licenses"
     const val LogViewer = "log_viewer"
+    const val HandwritingCapture = "handwriting_capture"
     const val WebDav = "webdav"
     const val ClipboardSync = "clipboard_sync"
     const val SchemaDictBrowser = "schema_dict_browser"

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsScreen.kt
@@ -208,7 +208,8 @@ fun SettingsScreen(
                 onBack = { navController.popBackStack() },
                 onNavigateToPrivacy = { navController.navigate(SettingsRoutes.Privacy) },
                 onNavigateToLicenses = { navController.navigate(SettingsRoutes.Licenses) },
-                onNavigateToLogViewer = { navController.navigate(SettingsRoutes.LogViewer) }
+                onNavigateToLogViewer = { navController.navigate(SettingsRoutes.LogViewer) },
+                onNavigateToHandwritingCapture = { navController.navigate(SettingsRoutes.HandwritingCapture) }
             )
         }
         composable(SettingsRoutes.MarketModel) {
@@ -230,6 +231,11 @@ fun SettingsScreen(
         }
         composable(SettingsRoutes.LogViewer) {
             LogViewerScreen(
+                onBack = { navController.popBackStack() }
+            )
+        }
+        composable(SettingsRoutes.HandwritingCapture) {
+            HandwritingCaptureScreen(
                 onBack = { navController.popBackStack() }
             )
         }

--- a/app/src/test/java/com/kingzcheung/xime/handwriting/HandwritingSampleCodecTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/handwriting/HandwritingSampleCodecTest.kt
@@ -1,0 +1,104 @@
+package com.kingzcheung.xime.handwriting
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import com.kingzcheung.xime.handwriting.capture.HandwritingSample
+import com.kingzcheung.xime.handwriting.capture.HandwritingSampleCodec
+import com.kingzcheung.xime.handwriting.capture.StrokePointMs
+
+class HandwritingSampleCodecTest {
+
+    private fun sample(modelTop: String? = "中") = HandwritingSample(
+        target = "中",
+        canvasWidthPx = 520f,
+        canvasHeightPx = 380f,
+        strokes = listOf(
+            listOf(
+                StrokePointMs(10f, 20f, 0),
+                StrokePointMs(12.5f, 21f, 16),
+                StrokePointMs(15f, 22f, 33),
+            ),
+            listOf(
+                StrokePointMs(100f, 5f, 430),
+                StrokePointMs(100f, 300f, 610),
+            ),
+        ),
+        modelTop = modelTop,
+        modelTopScore = if (modelTop != null) 0.97f else null,
+    )
+
+    @Test
+    fun `导出JSON包含契约字段与归一化说明`() {
+        val json = HandwritingSampleCodec.buildExportJson(
+            samples = listOf(sample()),
+            appVersion = "2.8.0-beta1",
+            device = "Xiaomi 13",
+            androidVersion = "Android 14 (API 34)",
+            exportedAtMs = 1000L,
+        )
+        assertTrue(json.contains("\"format\": \"xime-handwriting-capture\""))
+        assertTrue(json.contains("\"version\": 1"))
+        assertTrue(json.contains("bounding box"))
+        assertTrue(json.contains("\"target\": \"中\""))
+        assertTrue(json.contains("\"model_top\": \"中\""))
+        assertTrue(json.contains("\"sample_count\": 1"))
+    }
+
+    @Test
+    fun `编码解码往返保持数据一致`() {
+        val original = sample()
+        val json = HandwritingSampleCodec.buildExportJson(
+            listOf(original), "v", "d", "a", 0L,
+        )
+        val parsed = HandwritingSampleCodec.parseFromJson(json)
+        assertEquals(1, parsed.size)
+        val s = parsed[0]
+        assertEquals(original.target, s.target)
+        assertEquals(original.canvasWidthPx, s.canvasWidthPx, 0.001f)
+        assertEquals(original.canvasHeightPx, s.canvasHeightPx, 0.001f)
+        assertEquals(original.modelTop, s.modelTop)
+        assertEquals(original.modelTopScore!!, s.modelTopScore!!, 0.0001f)
+        assertEquals(2, s.strokes.size)
+        assertEquals(3, s.strokes[0].size)
+        assertEquals(2, s.strokes[1].size)
+        for ((so, sn) in original.strokes.zip(s.strokes)) {
+            assertEquals(so.size, sn.size)
+            for ((po, pn) in so.zip(sn)) {
+                assertEquals(po.x, pn.x, 0.001f)
+                assertEquals(po.y, pn.y, 0.001f)
+                assertEquals(po.t, pn.t)
+            }
+        }
+    }
+
+    @Test
+    fun `无识别结果的样本不含model字段`() {
+        val json = HandwritingSampleCodec.sampleToJson(sample(modelTop = null))
+        assertTrue(!json.has("model_top"))
+        assertTrue(!json.has("model_top_score"))
+        val parsed = HandwritingSampleCodec.parseFromJson("{\"format\":\"xime-handwriting-capture\",\"samples\":[$json]}")
+        assertNull(parsed[0].modelTop)
+        assertNull(parsed[0].modelTopScore)
+    }
+
+    @Test
+    fun `空笔画与空目标被过滤`() {
+        val root = org.json.JSONObject()
+            .put(
+                "samples",
+                org.json.JSONArray()
+                    .put(org.json.JSONObject().put("target", "").put("strokes", org.json.JSONArray()))
+                    .put(
+                        org.json.JSONObject()
+                            .put("target", "人")
+                            .put("strokes", org.json.JSONArray().put(org.json.JSONObject().put("pts", org.json.JSONArray())))
+                    )
+            )
+        val parsed = HandwritingSampleCodec.parseFromJson(
+            root.put("format", "xime-handwriting-capture").toString()
+        )
+        assertTrue(parsed.isEmpty())
+    }
+}


### PR DESCRIPTION
## 概述

移除不再需要的forceInsetsRecompute强制刷新逻辑，
改为依赖SideEffect驱动的自动重计算机制。

在ImeKeyboardCallbacks.kt中替换注释说明，明确撑高由
SideEffect驱动，UI状态变化会自动触发容器高度变化和
重新布局，从而实现insets的自动重算。

在VoiceKeyboardContainer.kt中删除resetHeight方法，
简化容器高度管理逻辑。

在XimeInputMethodService.kt中进行大量重构：
- 移除keyboardContentTopPx和相关调试变量
- 删除forceInsetsRecompute方法及相关的复杂逻辑
- 移除insetsRecomputePending状态管理
- 使用统一的容器物理高度管理模式
- 简化onComputeInsets方法，直接使用容器位置计算
- 更新布局参数设置，使用Gravity.BOTTOM确保键盘正确定位

这些改动消除了之前用于处理面板开关时insets残留问题的
+1dp hack方案，采用更简洁可靠的自动重计算机制。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
