### PR TITLE
fix(speech): 修复录音线程无法正常停止的问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/speech/SpeechRecognitionManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/speech/SpeechRecognitionManager.kt
@@ -147,11 +147,15 @@ class SpeechRecognitionManager(private val context: Context) {
             return
         }
         recordingThread = null
+        thread.stopRequested = true
         val session = synchronized(preloadLock) { sessionId }
         thread.interrupt()
+        thread.forceStopAudio()
         Thread {
             try {
-                thread.join()
+                // join 超时兜底：录音线程若卡在 Lua 调用中（最坏 CALL_TIMEOUT_MS=180s），
+                // 不能让后端释放无限期阻塞（否则 WebSocket 与麦克风一直占着）
+                thread.join(3000)
             } catch (_: InterruptedException) {
                 Thread.currentThread().interrupt()
             }
@@ -190,11 +194,13 @@ class SpeechRecognitionManager(private val context: Context) {
             return
         }
         recordingThread = null
+        thread.stopRequested = true
         val session = synchronized(preloadLock) { sessionId }
         thread.interrupt()
+        thread.forceStopAudio()
         Thread {
             try {
-                thread.join()
+                thread.join(3000)
             } catch (_: InterruptedException) {
                 Thread.currentThread().interrupt()
             }
@@ -378,6 +384,21 @@ class SpeechRecognitionManager(private val context: Context) {
 
         private val spectrumAnalyzer = SpectrumAnalyzer()
 
+        /**
+         * 停止请求标志：不能只依赖线程中断标志停止循环。
+         *
+         * processAudioChunk 会经 LuaScriptRuntime.runGuarded 的 FutureTask.get 执行，
+         * FutureTask.awaitDone 内部用 Thread.interrupted() 检查中断状态并**清除中断标志**，
+         * 随后 LuaScriptRuntime.call 吞掉 InterruptedException 正常返回 NIL——
+         * 于是中断标志被消费后 while (!interrupted()) 永远为真，录音线程无法停止，
+         * stopRecognition 的 join() 永不返回，后端（WebSocket）与麦克风一直后台占用。
+         */
+        @Volatile
+        var stopRequested = false
+
+        @Volatile
+        private var audioRecord: AudioRecord? = null
+
         override fun run() {
             val audioRecord = preStarted ?: (createAudioRecord() ?: run {
                 mainHandler.post {
@@ -386,6 +407,7 @@ class SpeechRecognitionManager(private val context: Context) {
                 }
                 return
             })
+            this.audioRecord = audioRecord
 
             if (!currentBackend.start()) {
                 audioRecord.stop()
@@ -413,7 +435,7 @@ class SpeechRecognitionManager(private val context: Context) {
             val maxPreSpeechChunks = 4  // 0.4s 语音前缓冲
 
             try {
-                while (!interrupted()) {
+                while (!interrupted() && !stopRequested) {
                     val nread = audioRecord.read(buffer, 0, buffer.size)
                     if (nread > 0) {
                         var peak = 0
@@ -457,12 +479,21 @@ class SpeechRecognitionManager(private val context: Context) {
                 }
             } catch (_: Exception) {
             } finally {
-                audioRecord.stop()
-                audioRecord.release()
+                // forceStopAudio 可能已从外部 stop/release，这里需容错（重复释放不抛异常中断后续流程）
+                try { audioRecord.stop() } catch (_: Exception) { }
+                try { audioRecord.release() } catch (_: Exception) { }
             }
 
             currentBackend.stop()
             Log.d(TAG, "Recognition thread ended")
+        }
+
+        /** 从外部强制停止录音：录音线程阻塞在 read() 等不可中断调用时，释放 AudioRecord 使其立即返回错误并退出。 */
+        fun forceStopAudio() {
+            audioRecord?.let { record ->
+                try { record.stop() } catch (_: Exception) { }
+                try { record.release() } catch (_: Exception) { }
+            }
         }
 
         private fun isSpeech(chunk: ByteArray): Boolean {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/VoiceKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/VoiceKeyboardLayout.kt
@@ -74,9 +74,10 @@ fun VoiceKeyboardLayout(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f)
-                .padding(top = 16.dp),
+                .padding(top = 8.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            // 垂直居中：矮屏/大字缩放导致空间不足时内容对称分布，避免贴顶溢出被下方按钮行盖住（"文字只显示上半部分"）
+            verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterVertically)
         ) {
             if (pluginName.isNotEmpty()) {
                 Text(
@@ -124,7 +125,7 @@ fun VoiceKeyboardLayout(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 20.dp),
+                .padding(horizontal = 16.dp, vertical = 12.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -203,7 +204,7 @@ fun VoiceKeyboardLayout(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(80.dp),
+                .height(64.dp),
             contentAlignment = Alignment.Center
         ) {
             Canvas(


### PR DESCRIPTION
- 添加 stopRequested 标志位解决线程中断标志被 Lua 调用清除后无法停止的问题
- 实现 forceStopAudio 方法强制释放 AudioRecord 以立即停止录音
- 修改 join 调用添加 3 秒超时避免无限期阻塞
- 改进音频资源释放逻辑，添加异常处理防止重复释放报错

fix(ui): 调整语音键盘布局适配不同屏幕尺寸

- 减少顶部内边距从 16dp 到 8dp
- 将垂直排列方式改为居中对齐，避免矮屏时内容贴顶溢出
- 调整底部间距从 20dp 到 12dp
- 缩小画布高度从 80dp 到 64dp

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
