### PR TITLE
fix(XimeInputMethodService): 解决编码气泡被裁剪问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1087,7 +1087,12 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 )
             }
         )
-        
+        // 编码气泡绘制在候选栏上方（栏外，drawBehind 负坐标）：insets 重构后容器
+        // 物理高度 = Compose 内容总高（gravity BOTTOM），候选栏紧贴容器顶边，
+        // 气泡落在容器顶边之外——关闭容器裁剪，气泡才能画进 inputArea 的空白区。
+        // 仅影响越界绘制裁剪，不触碰容器高度/insets 计算路径。
+        keyboardContainer.clipChildren = false
+
         bottomInsetPxState.value = getActiveBottomInsetPx(window.window)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             keyboardContainer.setOnApplyWindowInsetsListener { v, insets ->
@@ -1409,8 +1414,13 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         try {
             window.window?.decorView
                 ?.findViewById<FrameLayout>(android.R.id.inputArea)
-                ?.updateLayoutParams<android.view.ViewGroup.LayoutParams> {
-                    height = android.view.ViewGroup.LayoutParams.MATCH_PARENT
+                ?.let { area ->
+                    area.updateLayoutParams<android.view.ViewGroup.LayoutParams> {
+                        height = android.view.ViewGroup.LayoutParams.MATCH_PARENT
+                    }
+                    // 栏外编码气泡越出容器顶边后进入 inputArea 空白区，
+                    // inputArea 默认 clipChildren=true 会把越界部分裁掉。
+                    area.clipChildren = false
                 }
             // 容器在 inputArea 内底部对齐（gravity BOTTOM）：
             // 容器物理高度 = Compose 内容总高，小于全屏窗口时若默认 top-left

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidateBar.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidateBar.kt
@@ -248,7 +248,7 @@ fun CandidateBar(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .height(50.dp)
+            .height(44.dp)
             .drawPreeditBubble(
                 text = preeditBubbleText,
                 enabled = showPreeditBubble,


### PR DESCRIPTION
为解决编码气泡绘制在候选栏上方时被容器裁剪的问题，
设置 keyboardContainer.clipChildren = false 和
inputArea.clipChildren = false，允许气泡绘制到容器边界之外
的区域。添加详细注释说明裁剪机制和解决方案原理。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
