### PR TITLE
feat(clipboard): 添加快捷发送触发编码功能支持

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,8 +43,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 20260830
-        versionName = "2.8.0-beta1"
+        versionCode = 20260901
+        versionName = "2.8.0-beta2"
 
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/kingzcheung/xime/XimeApplication.kt
+++ b/app/src/main/java/com/kingzcheung/xime/XimeApplication.kt
@@ -77,6 +77,12 @@ class XimeApplication : Application(), ImageLoaderFactory {
         PluginManager.cryptoHostApiFactory = {
             com.kingzcheung.xime.plugin.crypto.CryptoHostApiImpl()
         }
+        PluginManager.quickSendHostApiFactory = { _ ->
+            com.kingzcheung.xime.plugin.QuickSendHostApiImpl(this)
+        }
+        PluginManager.clipboardHostApiFactory = { _ ->
+            com.kingzcheung.xime.plugin.ClipboardHostApiImpl(this)
+        }
         PluginManager.initialize(this) {
             if (isDebug) {
                 PluginManager.installPluginsFromAssetsForDebug("plugins")

--- a/app/src/main/java/com/kingzcheung/xime/clipboard/ClipboardManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/ClipboardManager.kt
@@ -27,6 +27,8 @@ import android.content.ClipboardManager as AndroidClipboardManager
 data class ClipboardItem(
     val id: Long = 0,
     val text: String,
+    /** 快捷发送触发编码（如 dh），空 = 仅内容命中不参与编码匹配。 */
+    val code: String = "",
     val timestamp: Long = System.currentTimeMillis(),
     val isPinned: Boolean = false,
     val isQuickSend: Boolean = false,
@@ -214,6 +216,7 @@ class ClipboardManager private constructor(private val context: Context) {
         return ClipboardItem(
             id = id,
             text = text,
+            code = code,
             timestamp = timestamp,
             isPinned = isPinned,
             isQuickSend = isQuickSend,
@@ -303,20 +306,20 @@ class ClipboardManager private constructor(private val context: Context) {
         }
     }
 
-    fun updateQuickSendItem(id: Long, newText: String): Boolean {
+    fun updateQuickSendItem(id: Long, newText: String, newCode: String = ""): Boolean {
         if (newText.isBlank()) return false
         val index = _quickSendItems.value.indexOfFirst { it.id == id }
         if (index < 0) return false
         scope.launch {
-            dao.updateText(id, newText, System.currentTimeMillis())
+            dao.updateQuickSendItem(id, newText, newCode.trim(), System.currentTimeMillis())
         }
         return true
     }
 
-    fun addQuickSendItem(text: String) {
+    fun addQuickSendItem(text: String, code: String = "") {
         if (text.isBlank()) return
         scope.launch {
-            dao.insertQuickSend(text, System.currentTimeMillis(), MAX_QUICK_SEND_ITEMS)
+            dao.insertQuickSend(text, code.trim(), System.currentTimeMillis(), MAX_QUICK_SEND_ITEMS)
         }
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/clipboard/db/ClipboardDao.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/db/ClipboardDao.kt
@@ -61,6 +61,9 @@ interface ClipboardDao {
     @Query("UPDATE clipboard_entries SET text = :text, timestamp = :now WHERE id = :id")
     suspend fun updateText(id: Long, text: String, now: Long)
 
+    @Query("UPDATE clipboard_entries SET text = :text, code = :code, timestamp = :now WHERE id = :id")
+    suspend fun updateQuickSendItem(id: Long, text: String, code: String, now: Long)
+
     @Query("UPDATE clipboard_entries SET consumed = 1 WHERE id = :id")
     suspend fun markConsumed(id: Long)
 
@@ -107,14 +110,15 @@ interface ClipboardDao {
     suspend fun countQuickSend(): Int
 
     @Transaction
-    suspend fun insertQuickSend(text: String, now: Long, maxQuickSend: Int) {
+    suspend fun insertQuickSend(text: String, code: String, now: Long, maxQuickSend: Int) {
         val existing = findQuickSendByText(text)
         if (existing != null) {
-            updateTimestamp(existing.id, now)
+            updateQuickSendItem(existing.id, text, code, now)
         } else {
             insert(
                 ClipboardEntry(
                     text = text,
+                    code = code,
                     timestamp = now,
                     isPinned = true,
                     isQuickSend = true

--- a/app/src/main/java/com/kingzcheung/xime/clipboard/db/ClipboardDatabase.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/db/ClipboardDatabase.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.SupervisorJob
 
 @Database(
     entities = [ClipboardEntry::class],
-    version = 2,
+    version = 3,
     exportSchema = false
 )
 abstract class ClipboardDatabase : RoomDatabase() {
@@ -31,6 +31,15 @@ abstract class ClipboardDatabase : RoomDatabase() {
             }
         }
 
+        /** v2 → v3：新增 code 列（快捷发送触发编码）。 */
+        private val MIGRATION_2_3 = object : Migration(2, 3) {
+            override suspend fun migrate(connection: SQLiteConnection) {
+                connection.prepare(
+                    "ALTER TABLE clipboard_entries ADD COLUMN code TEXT NOT NULL DEFAULT ''"
+                ).step()
+            }
+        }
+
         @Volatile
         private var instance: ClipboardDatabase? = null
 
@@ -42,7 +51,7 @@ abstract class ClipboardDatabase : RoomDatabase() {
                 )
                     .setDriver(AndroidSQLiteDriver())
                     .setQueryCoroutineContext(Dispatchers.IO)
-                    .addMigrations(MIGRATION_1_2)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
                     .build()
                     .also { instance = it }
             }

--- a/app/src/main/java/com/kingzcheung/xime/clipboard/db/ClipboardEntry.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/db/ClipboardEntry.kt
@@ -12,6 +12,8 @@ import androidx.room3.PrimaryKey
 data class ClipboardEntry(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val text: String,
+    /** 快捷发送触发编码（如 dh）：用户输入编码前缀命中后，对应快捷条目进入候选栏。 */
+    @ColumnInfo(defaultValue = "") val code: String = "",
     @ColumnInfo(defaultValue = "0") val timestamp: Long = System.currentTimeMillis(),
     @ColumnInfo(defaultValue = "0") val isPinned: Boolean = false,
     @ColumnInfo(defaultValue = "0") val isQuickSend: Boolean = false,

--- a/app/src/main/java/com/kingzcheung/xime/plugin/ClipboardHostApiImpl.kt
+++ b/app/src/main/java/com/kingzcheung/xime/plugin/ClipboardHostApiImpl.kt
@@ -1,0 +1,22 @@
+package com.kingzcheung.xime.plugin
+
+import android.content.Context
+import com.kingzcheung.xime.clipboard.ClipboardManager
+import com.kingzcheung.xime.plugin.core.lua.ClipboardHostApi
+
+/**
+ * 剪贴板只读 API 实现：读系统剪贴板当前文本。
+ * 仅对 manifest 声明 `clipboard_read` 的插件由生命周期管理器注入。
+ */
+class ClipboardHostApiImpl(context: Context) : ClipboardHostApi {
+
+    private val clipboardManager = ClipboardManager.getInstance(context)
+
+    override fun getText(): String? {
+        return try {
+            clipboardManager.getCurrentClipboardText()?.takeIf { it.isNotEmpty() }
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/plugin/QuickSendHostApiImpl.kt
+++ b/app/src/main/java/com/kingzcheung/xime/plugin/QuickSendHostApiImpl.kt
@@ -1,0 +1,28 @@
+package com.kingzcheung.xime.plugin
+
+import android.content.Context
+import com.kingzcheung.xime.clipboard.ClipboardManager
+import com.kingzcheung.xime.plugin.core.lua.QuickSendHostApi
+import com.kingzcheung.xime.plugin.core.lua.QuickSendItem
+
+/**
+ * 快捷发送只读 API 实现：同步读 [ClipboardManager] 进程单例的内存缓存
+ * （Room `clipboard_entries` 表 isQuickSend 子集的 StateFlow），零 IO。
+ * 仅对 manifest 声明 `quick_send_read` 的插件由生命周期管理器注入。
+ */
+class QuickSendHostApiImpl(context: Context) : QuickSendHostApi {
+
+    private val clipboardManager = ClipboardManager.getInstance(context)
+
+    override fun list(): List<QuickSendItem> {
+        return clipboardManager.quickSendItems.value.map {
+            QuickSendItem(
+                id = it.id,
+                text = it.text,
+                code = it.code,
+                timestamp = it.timestamp,
+                isPinned = it.isPinned,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/service/CandidateAction.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/CandidateAction.kt
@@ -1,0 +1,21 @@
+package com.kingzcheung.xime.service
+
+/**
+ * 候选词变换后单个显示候选的上屏动作（与 CandidateState.candidates 平行）。
+ *
+ * - [engineIndex] >= 0：引擎候选引用（插件可能仅覆盖了显示注释），点击走引擎选词
+ * - [engineIndex] < 0：插件自有候选，点击直接上屏 [commitText]（绕过引擎，所见即所得）
+ *
+ * 空列表 = 纯引擎语义（显示 index 即引擎 index），所有既有路径零影响。
+ */
+data class CandidateAction(
+    val engineIndex: Int,
+    val commitText: String,
+) {
+    val isPluginCandidate: Boolean get() = engineIndex < 0
+
+    companion object {
+        fun engine(index: Int) = CandidateAction(engineIndex = index, commitText = "")
+        fun plugin(text: String) = CandidateAction(engineIndex = -1, commitText = text)
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/service/CandidateState.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/CandidateState.kt
@@ -12,5 +12,8 @@ data class CandidateState(
     val pendingEnglishText: String = "",
     val isShowingRecentClipboard: Boolean = false,
     /** 当前宿主是否支持英文候选的"回删替换"（终端等受限宿主为 false，不展示英文候选）。 */
-    val englishReplaceSupported: Boolean = true
+    val englishReplaceSupported: Boolean = true,
+    /** 候选词变换映射（插件 candidate_transform 能力）：与 [candidates] 平行；
+     *  空列表 = 纯引擎语义（显示 index 即引擎 index）。见 CandidateAction。 */
+    val candidateActions: List<CandidateAction> = emptyList()
 )

--- a/app/src/main/java/com/kingzcheung/xime/service/CandidateTransformCoordinator.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/CandidateTransformCoordinator.kt
@@ -1,0 +1,141 @@
+package com.kingzcheung.xime.service
+
+import com.kingzcheung.xime.plugin.core.lua.CandidateTransformCandidate
+import com.kingzcheung.xime.plugin.core.lua.CandidateTransformItem
+import com.kingzcheung.xime.plugin.core.lua.CandidateTransformOutcome
+import com.kingzcheung.xime.plugin.core.lua.CandidateTransformRequest
+import com.kingzcheung.xime.plugin.core.lua.LuaScriptRuntime
+import com.kingzcheung.xime.plugin.core.runtime.PluginManager
+import com.kingzcheung.xime.rime.RimeCandidate
+import com.kingzcheung.xime.rime.RimeProcessResult
+import com.kingzcheung.xime.ui.keyboard.isT9Schema
+import com.kingzcheung.xime.util.FileLogger
+
+/** 变换结果：显示候选（引擎引用 + 插件候选混合）+ 平行的上屏动作映射。 */
+internal data class CandidateTransformResult(
+    val candidates: List<RimeCandidate>,
+    val actions: List<CandidateAction>,
+)
+
+/**
+ * 候选词变换协调器（插件 candidate_transform 能力，首个 hotPath 能力）。
+ *
+ * 在 rime 返回候选之后、候选栏渲染之前同步调用插件 transformCandidates 修改候选；
+ * 插件候选（text）点击后直接上屏插件文本，引擎引用（engine_index）走原引擎选词。
+ *
+ * 设计契约（docs/plugin-capability-registry.md §4.1/§5）：
+ * - 线程：仅在 key-processing 线程调用（阻塞至多 15ms），主线程永不等待插件
+ * - 短路：敏感输入框 / T9 / ascii 模式 / 空编码 / 无声明插件 → 不产生请求
+ * - 熔断：连续 3 次失败（超时/报错/格式错）本会话禁用，插件重载或进程重启恢复
+ * - 降级：任何失败回退原始候选，actions 为空 = 纯引擎语义
+ */
+internal class CandidateTransformCoordinator(private val service: XimeInputMethodService) {
+
+    companion object {
+        private const val MAX_CONSECUTIVE_FAILURES = 3
+
+        /**
+         * 插件响应 → 显示候选 + 上屏动作（纯函数，便于单测）。
+         * 语义校验：engine_index 越界/重复丢弃；text 空丢弃；总数上限截断。
+         * 引用项 comment 覆盖显示注释；无可显示内容返回 null（不干预）。
+         */
+        internal fun buildDisplay(
+            items: List<CandidateTransformItem>,
+            engineCandidates: List<RimeCandidate>,
+            maxCandidates: Int = LuaScriptRuntime.TRANSFORM_MAX_CANDIDATES,
+        ): CandidateTransformResult? {
+            val display = ArrayList<RimeCandidate>(items.size)
+            val actions = ArrayList<CandidateAction>(items.size)
+            val seenEngineIdx = HashSet<Int>()
+            for (item in items) {
+                if (display.size >= maxCandidates) break
+                val engineIdx = item.engineIndex
+                if (engineIdx != null) {
+                    if (engineIdx < 0 || engineIdx >= engineCandidates.size || !seenEngineIdx.add(engineIdx)) continue
+                    val engine = engineCandidates[engineIdx]
+                    display.add(RimeCandidate(engine.text, item.comment ?: engine.comment))
+                    actions.add(CandidateAction.engine(engineIdx))
+                } else {
+                    val text = item.text?.takeIf { it.isNotEmpty() } ?: continue
+                    display.add(RimeCandidate(text, item.comment ?: ""))
+                    actions.add(CandidateAction.plugin(text))
+                }
+            }
+            if (display.isEmpty()) return null
+            // 纯引擎引用（重排/去注释覆盖）也保留 actions：显示 index 与引擎 index 可能不同
+            return CandidateTransformResult(display, actions)
+        }
+    }
+
+    /** 连续失败熔断标记（本会话禁用；插件重载/进程重启恢复）。 */
+    @Volatile
+    private var disabledThisSession = false
+    private var consecutiveFailures = 0
+
+    /** 对一次引擎按键结果做变换。返回 null = 不干预，调用方原样渲染。 */
+    fun transformFor(result: RimeProcessResult): CandidateTransformResult? {
+        if (result.isAsciiMode) return null
+        if (result.inputText.isEmpty() && result.candidates.isEmpty()) return null
+        return transform(
+            inputText = result.inputText,
+            preedit = result.preeditText,
+            engineCandidates = result.candidates.toList(),
+            asciiMode = result.isAsciiMode,
+        )
+    }
+
+    /**
+     * 变换入口（key-processing 线程，阻塞至多 15ms）。
+     * T9 路径不接入变换（v1 边界），此处防御再判。
+     */
+    fun transform(
+        inputText: String,
+        preedit: String,
+        engineCandidates: List<RimeCandidate>,
+        asciiMode: Boolean,
+    ): CandidateTransformResult? {
+        if (disabledThisSession) return null
+        if (asciiMode) return null
+        if (isT9Schema(service.uiState.value.currentSchemaId)) return null
+        if (service.pluginEvents.isCurrentEditorSensitive) return null
+        val runtime = findRuntime() ?: return null
+        val outcome = runtime.transformCandidates(
+            CandidateTransformRequest(
+                inputText = inputText,
+                preedit = preedit,
+                candidates = engineCandidates.map { CandidateTransformCandidate(it.text, it.comment) },
+                asciiMode = asciiMode,
+            )
+        )
+        return when (outcome) {
+            is CandidateTransformOutcome.NoResponse -> {
+                consecutiveFailures = 0
+                null
+            }
+            is CandidateTransformOutcome.Failed -> {
+                consecutiveFailures++
+                if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+                    disabledThisSession = true
+                    FileLogger.w(
+                        XimeInputMethodService.TAG,
+                        "candidate_transform 连续失败 $consecutiveFailures 次，本会话禁用该插件变换"
+                    )
+                }
+                null
+            }
+            is CandidateTransformOutcome.Success -> {
+                consecutiveFailures = 0
+                buildDisplay(outcome.items, engineCandidates)
+            }
+        }
+    }
+
+    /** 第一个声明 candidate_transform 且已加载的插件运行时（v1 单插件；链式变换为后续增强）。 */
+    private fun findRuntime(): LuaScriptRuntime? {
+        for ((_, loaded) in PluginManager.loadedPluginsFlow.value) {
+            if (loaded.pluginInfo.capabilities?.candidateTransform != true) continue
+            return loaded.script ?: continue
+        }
+        return null
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
@@ -23,6 +23,26 @@ import kotlinx.coroutines.withContext
  * 所有共享状态通过 service 引用访问（同模块 internal 成员）。
  */
 internal class ImeKeyRouter(private val service: XimeInputMethodService) {
+
+    /**
+     * 候选词变换（hotPath 插件能力）+ 发送 UI 更新。
+     * 必须在 key-processing 线程调用：同步等插件至多 15ms；
+     * 超时/失败/插件不干预（null）均回退原始候选（actions 为空 = 纯引擎语义）。
+     */
+    private fun sendTransformedResult(
+        result: com.kingzcheung.xime.rime.RimeProcessResult,
+        afterUpdate: (suspend () -> Unit)? = null,
+    ) {
+        val transformed = service.candidateTransform.transformFor(result)
+        service.uiEventChannel.trySend {
+            service.sessionController.updateUIWithResult(
+                transformed?.let { result.copy(candidates = it.candidates.toTypedArray()) } ?: result,
+                transformed?.actions ?: emptyList()
+            )
+            if (afterUpdate != null) afterUpdate()
+        }
+    }
+
     internal fun handleKeyPress(key: String, isShifted: Boolean) {
         if (service.uiState.value.toolPanelInputFocused) {
             val candState = service.candidateState.value
@@ -46,7 +66,8 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                                 candidates = emptyList(),
                                 candidateComments = emptyList(),
                                 associationCandidates = emptyList(),
-                                isComposing = false
+                                isComposing = false,
+                                candidateActions = emptyList()
                             )
                         }
                     }
@@ -61,9 +82,7 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                         if (result.inputText.isEmpty()) {
                             service.rimeEngine.clearComposition()
                         }
-                        service.uiEventChannel.trySend {
-                            service.sessionController.updateUIWithResult(result)
-                        }
+                        sendTransformedResult(result)
                     } else {
                         ToolPanelEditTextHolder.editText?.let { et ->
                             val start = et.selectionStart.coerceAtLeast(0)
@@ -101,9 +120,7 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                             val keyCode = key.lowercase()[0].code
                             val result = service.rimeEngine.processKeyAndGetResult(keyCode, 0)
                             if (result.processed) {
-                                service.uiEventChannel.trySend {
-                                    service.sessionController.updateUIWithResult(result)
-                                }
+                                sendTransformedResult(result)
                             }
                             return
                         }
@@ -125,18 +142,27 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
             when (key) {
                 "enter" -> {
                     val editText = QuickSendFormEditTextHolder.editText
+                    val codeEditText = QuickSendFormCodeEditTextHolder.editText
                     val text = editText?.text?.toString() ?: ""
+                    val code = codeEditText?.text?.toString()?.trim() ?: ""
                     val s = service.uiState.value
                     val editingId = s.quickSendEditingItemId
                     if (text.isNotBlank()) {
                         if (editingId != null) {
-                            service.keyboardViewModel.updateQuickSendItem(editingId, text)
+                            service.keyboardViewModel.updateQuickSendItem(editingId, text, code)
                         } else {
-                            service.keyboardViewModel.addQuickSendText(text)
+                            service.keyboardViewModel.addQuickSendText(text, code)
                         }
                     }
-                    service.uiState.value = s.copy(showQuickSendForm = false, quickSendFormFocused = false, quickSendEditingItemId = null, quickSendEditingItemText = "")
+                    service.uiState.value = s.copy(
+                        showQuickSendForm = false,
+                        quickSendFormFocused = false,
+                        quickSendEditingItemId = null,
+                        quickSendEditingItemText = "",
+                        quickSendEditingItemCode = ""
+                    )
                     QuickSendFormEditTextHolder.editText = null
+                    QuickSendFormCodeEditTextHolder.editText = null
                     service.keyboardViewModel.showOverlay(OverlayRoute.Clipboard(1))
                     return
                 }
@@ -150,9 +176,7 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                         if (result.inputText.isEmpty()) {
                             service.rimeEngine.clearComposition()
                         }
-                        service.uiEventChannel.trySend {
-                            service.sessionController.updateUIWithResult(result)
-                        }
+                        sendTransformedResult(result)
                     } else {
                         // 无组合态 → 直接操作 EditText 删除已上屏文字
                         QuickSendFormEditTextHolder.editText?.let { et ->
@@ -246,7 +270,8 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                             pendingEnglishText = "",
                             inputText = "",
                             isComposing = false,
-                            isShowingRecentClipboard = false
+                            isShowingRecentClipboard = false,
+                            candidateActions = emptyList()
                         )
                         withContext(Dispatchers.Main) {
                             service.currentInputConnection?.let {
@@ -368,7 +393,8 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                                         pendingEnglishText = "",
                                         candidates = emptyList(),
                                         candidateComments = emptyList(),
-                                        associationCandidates = emptyList()
+                                        associationCandidates = emptyList(),
+                                        candidateActions = emptyList()
                                     )
                                 }
                                 service.rimeEngine.clearComposition()
@@ -412,9 +438,7 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                     if (candState.isComposing || candState.inputText.isNotEmpty()) {
                         val result = service.rimeEngine.processKeyAndGetResult(0x27, 0)
                         if (result.processed) {
-                            service.uiEventChannel.trySend {
-                                service.sessionController.updateUIWithResult(result)
-                            }
+                            sendTransformedResult(result)
                         } else {
                             needsUIUpdate = true
                         }
@@ -502,6 +526,21 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                         updateCalculatorCandidates()
                     }
                     
+                    // 数字选词拦截（插件候选变换存在时）：数字键不进入引擎——rime 会自行选
+                    // 引擎候选并返回 committedText，绕过插件候选；映射为对应位置显示候选的
+                    // 点击（selectCandidateAsync 按 candidateActions 分流上屏）。
+                    // actions 为空（无变换）时保持原生数字选词行为不变。
+                    if (!state.isAsciiMode && candState.isComposing &&
+                        key.length == 1 && key[0] in '1'..'9'
+                    ) {
+                        val actions = service.candidateState.value.candidateActions
+                        val digitIndex = key[0] - '1'
+                        if (actions.isNotEmpty() && digitIndex < service.candidateState.value.candidates.size) {
+                            selectCandidateAsync(digitIndex)
+                            return@launch
+                        }
+                    }
+
                     // 所有按键统一经过 Rime 引擎
                     // 字母键不进入此分支（即使 pendingEnglish 非空），需要继续积累编码
                     // 英文模式（isAsciiMode）下非字母键（QWERTY 上滑的数字/符号、数字/符号面板）
@@ -541,10 +580,7 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                                     if (result.committedText.isNotEmpty()) {
                                         withContext(Dispatchers.Main) { service.commitText(result.committedText) }
                                     }
-                                    service.uiEventChannel.trySend {
-                                        service.sessionController.updateUIWithResult(result)
-                                        if (service.calculatorEngine.isActive()) updateCalculatorCandidates()
-                                    }
+                                    sendTransformedResult(result) { if (service.calculatorEngine.isActive()) updateCalculatorCandidates() }
                                 } else {
                                     committedText = char
                                     needsUIUpdate = true
@@ -573,18 +609,12 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                                         withContext(Dispatchers.Main) {
                                             service.commitText(committed)
                                         }
-                                        service.uiEventChannel.trySend {
-                                            service.sessionController.updateUIWithResult(result)
-                                            if (service.calculatorEngine.isActive()) updateCalculatorCandidates()
-                                        }
+                                        sendTransformedResult(result) { if (service.calculatorEngine.isActive()) updateCalculatorCandidates() }
                                     } else {
                                         if (committed.isNotEmpty()) {
                                             withContext(Dispatchers.Main) { service.commitText(committed) }
                                         }
-                                        service.uiEventChannel.trySend {
-                                            service.sessionController.updateUIWithResult(result)
-                                            if (service.calculatorEngine.isActive()) updateCalculatorCandidates()
-                                        }
+                                        sendTransformedResult(result) { if (service.calculatorEngine.isActive()) updateCalculatorCandidates() }
                                     }
                                 }
                             } else {
@@ -631,8 +661,7 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                     if (textToCommit != null) {
                         withContext(Dispatchers.Main) { service.commitText(textToCommit) }
                     }
-                    service.uiEventChannel.trySend {
-                        service.sessionController.updateUIWithResult(result)
+                    sendTransformedResult(result) {
                         if (service.calculatorEngine.isActive()) {
                             updateCalculatorCandidates()
                         }
@@ -643,6 +672,17 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                     val capturedIsAscii = service.rimeEngine.isAsciiMode()
                     val capturedHasNext = service.rimeEngine.hasNextPage()
                     val capturedHasPrev = service.rimeEngine.hasPrevPage()
+                    // 候选词变换（hotPath 插件能力）：内联刷新路径（无 RimeProcessResult），
+                    // key-processing 线程同步调用；ascii 场景不变换（调用点语义与 transformFor 一致）
+                    val transformed = if (capturedInputText.isNotEmpty() && !capturedIsAscii) {
+                        service.candidateTransform.transform(
+                            capturedInputText, "", capturedCandidates.toList(), capturedIsAscii
+                        )
+                    } else {
+                        null
+                    }
+                    val displayCandidates: List<com.kingzcheung.xime.rime.RimeCandidate> =
+                        transformed?.candidates ?: capturedCandidates.toList()
                     if (textToCommit != null) {
                         withContext(Dispatchers.Main) { service.commitText(textToCommit) }
                     }
@@ -654,7 +694,7 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                             }
                             filtered.map { it.text } to filtered.map { it.comment }
                         } else {
-                            capturedCandidates.map { it.text } to capturedCandidates.map { it.comment }
+                            displayCandidates.map { it.text } to displayCandidates.map { it.comment }
                         }
                         service.candidateState.value = service.candidateState.value.copy(
                             inputText = capturedInputText,
@@ -664,7 +704,8 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                             associationCandidates = if ((capturedIsAscii || !service.isChineseMode) && pendingEnglish.isEmpty()) emptyList() else service.candidateState.value.associationCandidates,
                             isShowingRecentClipboard = false,
                             hasNextPage = capturedHasNext,
-                            hasPrevPage = capturedHasPrev
+                            hasPrevPage = capturedHasPrev,
+                            candidateActions = transformed?.actions ?: emptyList()
                         )
                         if (capturedIsAscii != service.uiState.value.isAsciiMode) {
                             FileLogger.i(XimeInputMethodService.TAG, "keyRouter UI refresh: ascii ${service.uiState.value.isAsciiMode}->$capturedIsAscii")
@@ -773,7 +814,8 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                             pendingEnglishText = newPending,
                             candidates = emptyList(),
                             candidateComments = emptyList(),
-                            associationCandidates = emptyList()
+                            associationCandidates = emptyList(),
+                            candidateActions = emptyList()
                         )
                     }
                     if (service.supportsEnglishCandidateReplace()) {
@@ -792,7 +834,8 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                             candidates = emptyList(),
                             candidateComments = emptyList(),
                             associationCandidates = emptyList(),
-                            isShowingRecentClipboard = false
+                            isShowingRecentClipboard = false,
+                            candidateActions = emptyList()
                         )
                     }
                 }
@@ -824,10 +867,7 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                         }
                     }
                 }
-                service.uiEventChannel.trySend {
-                    service.sessionController.updateUIWithResult(result)
-                    if (service.calculatorEngine.isActive()) updateCalculatorCandidates()
-                }
+                sendTransformedResult(result) { if (service.calculatorEngine.isActive()) updateCalculatorCandidates() }
             }
 
             // 3. 联想词或剪贴板：仅清空候选栏，不回删已上屏字符
@@ -870,6 +910,21 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
     }
 
     suspend fun selectCandidateAsync(index: Int) {
+        // 插件候选（candidate_transform 变换）：直接上屏插件文本（所见即所得），不走引擎选词。
+        // 引擎引用项继续走下方引擎路径，用映射记录的引擎索引（显示 index 因插件候选插入而错位）。
+        val pendingAction = service.candidateState.value.candidateActions.getOrNull(index)
+        if (pendingAction != null && pendingAction.isPluginCandidate) {
+            // 防御：中英/方案切换后引擎组合已清空但 candidateState 残留旧候选+actions，
+            // 此时点选必须回落原生路径（引擎侧 selectCandidate 失败自动防呆，与旧行为一致），
+            // 否则残留插件候选会绕过引擎校验直接上屏。
+            val engineHasComposition = service.rimeEngine.getInput().isNotEmpty() ||
+                service.rimeEngine.getCandidates().isNotEmpty()
+            if (engineHasComposition) {
+                commitPluginCandidate(pendingAction.commitText)
+                return
+            }
+        }
+
         val selectedCandidate = if (index < service.candidateState.value.candidates.size) {
             service.candidateState.value.candidates[index]
         } else null
@@ -897,7 +952,10 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
         val selectRimeOk = if (isT9) {
             true
         } else {
-            val rimeIndex = if (selectedCandidate != null) {
+            val rimeIndex = if (pendingAction != null && pendingAction.engineIndex >= 0) {
+                // 变换映射记录的引擎候选索引（比按显示文本回查更准）
+                pendingAction.engineIndex
+            } else if (selectedCandidate != null) {
                 resolveRimeCandidateIndex(index, selectedCandidate, service.rimeEngine.getCandidates().toList())
             } else {
                 index
@@ -1006,6 +1064,30 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                 }
             }
         }
+    }
+
+    /**
+     * 插件候选直接上屏（所见即所得）：不经引擎 select/commit。
+     * 先上屏并清空候选状态（与 enter 提交分支同序），再清引擎组合态。
+     */
+    private suspend fun commitPluginCandidate(text: String) {
+        withContext(Dispatchers.Main) {
+            service.commitText(text)
+            service.candidateState.value = service.candidateState.value.copy(
+                inputText = "",
+                preeditText = "",
+                candidates = emptyList(),
+                candidateComments = emptyList(),
+                associationCandidates = emptyList(),
+                pendingEnglishText = "",
+                isComposing = false,
+                isShowingRecentClipboard = false,
+                hasNextPage = false,
+                hasPrevPage = false,
+                candidateActions = emptyList()
+            )
+        }
+        service.rimeEngine.clearComposition()
     }
     
     /**

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
@@ -363,12 +363,13 @@ internal fun rememberImeKeyboardCallbacks(
                     quickSendFormFocused = true,
                     quickSendEditingItemId = null,
                     quickSendEditingItemText = "",
+                    quickSendEditingItemCode = "",
                     enterKeyText = "确定",
                 )
                 // 撑高由 SideEffect 驱动：uiState 变化 → Compose 内容高度变化 →
                 // updateHeight 改容器物理高度 → relayout → onComputeInsets 自动重算。
             },
-            onQuickSendEditItem = { id, text ->
+            onQuickSendEditItem = { id, text, code ->
                 // 同 onShowQuickSendForm：编辑入口在剪贴板面板内，先退出 Overlay 防表单被盖
                 service.keyboardViewModel.closeOverlay()
                 service.uiState.value = service.uiState.value.copy(
@@ -376,6 +377,7 @@ internal fun rememberImeKeyboardCallbacks(
                     quickSendFormFocused = true,
                     quickSendEditingItemId = id,
                     quickSendEditingItemText = text,
+                    quickSendEditingItemCode = code,
                     enterKeyText = "确定",
                 )
                 QuickSendFormEditTextHolder.editText?.let { et ->
@@ -390,9 +392,11 @@ internal fun rememberImeKeyboardCallbacks(
                     quickSendFormFocused = false,
                     quickSendEditingItemId = null,
                     quickSendEditingItemText = "",
+                    quickSendEditingItemCode = "",
                     enterKeyText = "发送",
                 )
                 QuickSendFormEditTextHolder.editText = null
+                QuickSendFormCodeEditTextHolder.editText = null
                 service.keyboardViewModel.showOverlay(OverlayRoute.Clipboard(1))
                 // insets 恢复由 SideEffect 驱动：表单收起 → 容器物理高度还原 →
                 // relayout → onComputeInsets 自动重算，无需强制触发。

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeSessionController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeSessionController.kt
@@ -19,7 +19,10 @@ import kotlinx.coroutines.withContext
  * 方案名称/开关刷新与切换、T9 切离提交等逻辑。共享状态通过 service 引用访问。
  */
 internal class ImeSessionController(private val service: XimeInputMethodService) {
-    internal fun applyComposition(composition: com.kingzcheung.xime.rime.RimeComposition) {
+    internal fun applyComposition(
+        composition: com.kingzcheung.xime.rime.RimeComposition,
+        pluginActions: List<CandidateAction> = emptyList(),
+    ) {
         val inputText = composition.input
         val codeInInputBox = SettingsPreferences.getInputTextLocation(service) == SettingsPreferences.INPUT_TEXT_INPUT_BOX
         val preeditText = composition.preedit
@@ -87,7 +90,9 @@ internal class ImeSessionController(private val service: XimeInputMethodService)
             associationCandidates = if ((isAsciiMode || !service.isChineseMode) && pendingEnglish.isEmpty()) emptyList() else service.candidateState.value.associationCandidates,
             isShowingRecentClipboard = false,
             hasNextPage = hasNextPage,
-            hasPrevPage = hasPrevPage
+            hasPrevPage = hasPrevPage,
+            // 候选词变换映射（T9 不接入变换，防御清空）
+            candidateActions = if (isT9Schema) emptyList() else pluginActions
         )
         if (isAsciiMode != service.uiState.value.isAsciiMode) {
             FileLogger.i(XimeInputMethodService.TAG, "applyComposition: ascii ${service.uiState.value.isAsciiMode}->$isAsciiMode")
@@ -129,7 +134,10 @@ internal class ImeSessionController(private val service: XimeInputMethodService)
         }
     }
 
-    internal fun updateUIWithResult(result: com.kingzcheung.xime.rime.RimeProcessResult) {
+    internal fun updateUIWithResult(
+        result: com.kingzcheung.xime.rime.RimeProcessResult,
+        pluginActions: List<CandidateAction> = emptyList(),
+    ) {
         val isAsciiMode = result.isAsciiMode
         val candidatesWithComments = result.candidates
 
@@ -191,7 +199,9 @@ internal class ImeSessionController(private val service: XimeInputMethodService)
             associationCandidates = if ((isAsciiMode || !service.isChineseMode) && pendingEnglish.isEmpty()) emptyList() else service.candidateState.value.associationCandidates,
             isShowingRecentClipboard = false,
             hasNextPage = result.hasNextPage,
-            hasPrevPage = result.hasPrevPage
+            hasPrevPage = result.hasPrevPage,
+            // 候选词变换映射（T9 不接入变换，防御清空；ascii 时调用方不产生 actions）
+            candidateActions = if (isT9Schema) emptyList() else pluginActions
         )
         service.uiState.value = service.uiState.value.copy(isAsciiMode = isAsciiMode)
         // composing 快照 → 插件（input_changed 事件；空编码表示本轮输入结束）
@@ -386,7 +396,8 @@ internal class ImeSessionController(private val service: XimeInputMethodService)
                 isComposing = false,
                 associationCandidates = emptyList(),
                 hasNextPage = false,
-                hasPrevPage = false
+                hasPrevPage = false,
+                candidateActions = emptyList()
             )
         }
     }

--- a/app/src/main/java/com/kingzcheung/xime/service/InputUIState.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/InputUIState.kt
@@ -52,6 +52,7 @@ data class InputUIState(
     val quickSendFormFocused: Boolean = false,
     val quickSendEditingItemId: Long? = null,
     val quickSendEditingItemText: String = "",
+    val quickSendEditingItemCode: String = "",
     /** 通用工具面板是否显示（候选栏上方，与快捷发送同位置）。 */
     val toolPanelVisible: Boolean = false,
     /** 面板输入框是否聚焦（聚焦时按键路由注入面板 EditText）。 */
@@ -70,7 +71,7 @@ data class InputUIState(
     val toolPanelRequestEpoch: Long = 0,
     /** 面板展示模式（manifest display.name）：PASSIVE 时以 Overlay 全屏渲染纯展示 InfoPanel（与表情/符号同级）。 */
     val toolPanelDisplay: String? = null,
-    /** passive 纯展示节点树（getPanelState.ui，白名单节点声明式 UI）。 */
-    val toolPanelUiNodes: List<Map<*, *>>? = null,
+    /** passive 纯展示节点树（getPanelState.ui，统一 UiNode 声明式模型）。 */
+    val toolPanelUiNodes: List<com.kingzcheung.xime.plugin.core.config.UiNode>? = null,
     val clipboardSyncEnabled: Boolean = false,
 )

--- a/app/src/main/java/com/kingzcheung/xime/service/PluginEventDispatcher.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/PluginEventDispatcher.kt
@@ -25,7 +25,14 @@ internal class PluginEventDispatcher(private val service: XimeInputMethodService
     /** 进程生命周期累计上屏提交次数。 */
     private var sessionCommits: Long = 0L
 
+    /** 当前输入会话是否敏感输入框（密码类 / 不学习标记）。
+     *  主线程写（onStartInput）、key-processing 线程读（候选词变换短路），volatile 保证可见性。 */
+    @Volatile
     private var sensitiveInput: Boolean = false
+
+    /** 当前输入会话是否敏感输入框（密码类 / 不学习标记）。
+     *  供 hotPath 插件能力（候选词变换）在发起请求前短路。 */
+    val isCurrentEditorSensitive: Boolean get() = sensitiveInput
 
     /** 新输入会话：刷新敏感标记并重置 composing 去重。 */
     fun onStartInput(attribute: EditorInfo?) {

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -137,6 +137,11 @@ object QuickSendFormEditTextHolder {
     var editText: android.widget.EditText? = null
 }
 
+/** 快捷发送表单的触发编码输入框 holder（与内容输入框独立）。 */
+object QuickSendFormCodeEditTextHolder {
+    var editText: android.widget.EditText? = null
+}
+
 /** 通用工具面板输入框 holder（与快捷发送独立，避免互相覆盖）。 */
 object ToolPanelEditTextHolder {
     var editText: android.widget.EditText? = null
@@ -660,6 +665,14 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             serviceScope.launch {
                 clipboardManager.quickSendItems.collect { items ->
                     quickSendItemsState.value = items
+                    // 快捷发送列表变更 → 插件事件（仅投递给 manifest 声明
+                    // capabilities.events 含 quick_send_changed 的插件）
+                    PluginManager.dispatchEvent(
+                        com.kingzcheung.xime.plugin.core.lua.PluginEvent(
+                            com.kingzcheung.xime.plugin.core.lua.PluginEvent.TYPE_QUICK_SEND_CHANGED,
+                            mapOf(com.kingzcheung.xime.plugin.core.lua.PluginEvent.FIELD_COUNT to items.size)
+                        )
+                    )
                 }
             }
             startClipboardSyncIfEnabled()
@@ -791,8 +804,10 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 quickSendFormFocused = false,
                 quickSendEditingItemId = null,
                 quickSendEditingItemText = "",
+                quickSendEditingItemCode = "",
             )
             QuickSendFormEditTextHolder.editText = null
+            QuickSendFormCodeEditTextHolder.editText = null
         }
         // 打开面板前清理宿主输入框残留输入态（未上屏的拼音/英文），
         // 避免旧组合混入面板输入、或面板关闭后覆盖宿主输入框中段文字。
@@ -806,6 +821,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 associationCandidates = emptyList(),
                 pendingEnglishText = "",
                 inputText = "",
+                candidateActions = emptyList(),
                 preeditText = "",
                 isComposing = false,
                 isShowingRecentClipboard = false,
@@ -1313,6 +1329,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                     quickSendFormFocused = state.quickSendFormFocused,
                                     quickSendEditingItemId = state.quickSendEditingItemId,
                                     quickSendEditingItemText = state.quickSendEditingItemText,
+                                    quickSendEditingItemCode = state.quickSendEditingItemCode,
                                     toolPanelVisible = state.toolPanelVisible,
                                     toolPanelInputFocused = state.toolPanelInputFocused,
                                     toolPanelPluginId = state.toolPanelPluginId,
@@ -1697,7 +1714,8 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                     candidateState.value = candidateState.value.copy(
                         candidates = emptyList(),
                         candidateComments = emptyList(),
-                        isShowingRecentClipboard = false
+                        isShowingRecentClipboard = false,
+                        candidateActions = emptyList()
                     )
                 }
             }
@@ -1900,9 +1918,11 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 quickSendFormFocused = false,
                 quickSendEditingItemId = null,
                 quickSendEditingItemText = "",
+                quickSendEditingItemCode = "",
                 enterKeyText = "发送",
             )
             QuickSendFormEditTextHolder.editText = null
+            QuickSendFormCodeEditTextHolder.editText = null
         }
     }
 
@@ -1959,7 +1979,8 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             pendingEnglishText = "",
             hasNextPage = false,
             hasPrevPage = false,
-            englishReplaceSupported = true
+            englishReplaceSupported = true,
+            candidateActions = emptyList()
         )
         endComposingInputBox()
     }
@@ -2038,7 +2059,30 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     }
     
     internal fun updateUI() {
-        sessionController.applyComposition(rimeEngine.getComposition())
+        val composition = rimeEngine.getComposition()
+        // 候选词变换（hotPath 插件能力）：仅 key-processing 线程同步等插件（至多 15ms），
+        // 主线程调用点（联想上屏/光标移动/剪贴板点选后的刷新）一律跳过——主线程永不等待插件；
+        // 这些调用点组合态已清空（input 为空），正常不触发，Looper 判定仅为防御
+        val transformed = if (composition.input.isNotEmpty() &&
+            android.os.Looper.myLooper() != android.os.Looper.getMainLooper()
+        ) {
+            candidateTransform.transform(
+                inputText = composition.input,
+                preedit = composition.preedit,
+                engineCandidates = composition.candidates.toList(),
+                asciiMode = composition.isAsciiMode,
+            )
+        } else {
+            null
+        }
+        if (transformed != null) {
+            sessionController.applyComposition(
+                composition.copy(candidates = transformed.candidates.toTypedArray()),
+                transformed.actions
+            )
+        } else {
+            sessionController.applyComposition(composition)
+        }
     }
 
     /**
@@ -2157,6 +2201,9 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
 
     /** 插件下行事件投递器（input_changed / text_committed，敏感输入豁免）。 */
     internal val pluginEvents = PluginEventDispatcher(this)
+
+    /** 候选词变换协调器（插件 candidate_transform 能力，hotPath：key-processing 线程同步调用）。 */
+    internal val candidateTransform = CandidateTransformCoordinator(this)
 
     override fun commitText(text: String) {
         commitTextSilently(text)

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/InfoPanel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/InfoPanel.kt
@@ -34,22 +34,24 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kingzcheung.xime.plugin.core.api.PluginResultItem
+import com.kingzcheung.xime.plugin.core.config.UiNode
+import com.kingzcheung.xime.plugin.core.config.UiNodeType
 
 private const val MAX_UI_NODES = 64
 
 /**
  * passive 纯展示面板（全屏 Overlay 页面，与表情/符号同级，覆盖键盘）。
  *
- * 渲染插件通过 getPanelState.ui 声明的白名单节点树（声明式 UI）：
- *   section(title) / text(content, style) / metric(label, value, unit?) /
- *   divider / action(label, actionId)
+ * 渲染插件通过 getPanelState.ui 声明的白名单节点树（统一 [UiNode] 声明模型）：
+ *   SECTION / TEXT / METRIC / DIVIDER / BUTTON
  * 以及 items 候选条目（点击 → onItemClick → 宿主上屏，替代原 SELECT 全屏结果页）。
- * 未知 type 降级为文本渲染；节点数截断 [MAX_UI_NODES]；不做嵌套渲染。
+ * 表单型节点（TEXTAREA/SECRET/SELECT 等）在面板降级为只读文本；
+ * 节点数截断 [MAX_UI_NODES]；不做嵌套渲染。
  */
 @Composable
 fun InfoPanel(
     title: String,
-    nodes: List<Map<*, *>>,
+    nodes: List<UiNode>,
     items: List<PluginResultItem> = emptyList(),
     isLoading: Boolean = false,
     backgroundColor: Color,
@@ -126,23 +128,23 @@ fun InfoPanel(
                 )
             }
             nodes.take(MAX_UI_NODES).forEach { node ->
-                val type = node["type"]?.toString() ?: ""
-                when (type) {
-                    "section" -> InfoSection(node["title"]?.toString() ?: "", accentColor)
-                    "text" -> InfoText(node, textColor)
-                    "metric" -> InfoMetric(node, textColor, accentColor)
-                    "divider" -> HorizontalDivider(
+                when (node.type) {
+                    UiNodeType.SECTION -> InfoSection(node.label ?: "", accentColor)
+                    UiNodeType.TEXT,
+                    UiNodeType.TEXTAREA -> InfoText(node, textColor)
+                    UiNodeType.METRIC -> InfoMetric(node, textColor, accentColor)
+                    UiNodeType.DIVIDER -> HorizontalDivider(
                         modifier = Modifier.padding(vertical = 6.dp),
                         color = textColor.copy(alpha = 0.15f),
                     )
-                    "action" -> InfoAction(node, onAction)
-                    else -> Text(
-                        // 未知节点类型降级：前向兼容，插件新节点跑旧宿主不崩溃
-                        text = node["content"]?.toString() ?: node["title"]?.toString() ?: "",
-                        color = textColor.copy(alpha = 0.7f),
-                        fontSize = 13.sp,
-                        modifier = Modifier.padding(vertical = 2.dp),
-                    )
+                    UiNodeType.BUTTON -> InfoAction(node, onAction)
+                    else -> // 表单型字段降级为只读文本（前向兼容，插件新节点跑旧宿主不崩溃）
+                        Text(
+                            text = node.value ?: node.label ?: "",
+                            color = textColor.copy(alpha = 0.7f),
+                            fontSize = 13.sp,
+                            modifier = Modifier.padding(vertical = 2.dp),
+                        )
                 }
             }
             // 候选条目（插件 getPanelState.items，点击上屏；替代原 SELECT 全屏结果页）
@@ -184,11 +186,11 @@ private fun InfoSection(title: String, accentColor: Color) {
 }
 
 @Composable
-private fun InfoText(node: Map<*, *>, textColor: Color) {
-    val style = node["style"]?.toString()
+private fun InfoText(node: UiNode, textColor: Color) {
+    val style = node.style
     val isCaption = style == "caption"
     Text(
-        text = node["content"]?.toString() ?: "",
+        text = node.value ?: "",
         color = textColor.copy(alpha = if (isCaption) 0.6f else 0.9f),
         fontSize = if (isCaption) 11.sp else 14.sp,
         modifier = Modifier.padding(vertical = 2.dp),
@@ -196,10 +198,10 @@ private fun InfoText(node: Map<*, *>, textColor: Color) {
 }
 
 @Composable
-private fun InfoMetric(node: Map<*, *>, textColor: Color, accentColor: Color) {
-    val value = node["value"]?.toString() ?: ""
-    val label = node["label"]?.toString() ?: ""
-    val unit = node["unit"]?.toString() ?: ""
+private fun InfoMetric(node: UiNode, textColor: Color, accentColor: Color) {
+    val value = node.value ?: ""
+    val label = node.label ?: ""
+    val unit = node.unit ?: ""
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -228,9 +230,9 @@ private fun InfoMetric(node: Map<*, *>, textColor: Color, accentColor: Color) {
 }
 
 @Composable
-private fun InfoAction(node: Map<*, *>, onAction: (String) -> Unit) {
-    val actionId = node["actionId"]?.toString() ?: return
-    val label = node["label"]?.toString() ?: return
+private fun InfoAction(node: UiNode, onAction: (String) -> Unit) {
+    val actionId = node.key ?: return
+    val label = node.label ?: return
     FilledTonalButton(
         onClick = { onAction(actionId) },
         modifier = Modifier

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
@@ -103,7 +103,7 @@ data class KeyboardCallbacks(
      */
     val onClipboardPullRemote: (() -> Unit)? = null,
     val onHideQuickSendForm: (() -> Unit)? = null,
-    val onQuickSendEditItem: ((Long, String) -> Unit)? = null,
+    val onQuickSendEditItem: ((Long, String, String) -> Unit)? = null,
     val onQuickSendFormFocusChange: ((Boolean) -> Unit)? = null,
     /**
      * 全键盘（中文/英文）切离至其他键盘（数字/符号）时调用。

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -282,16 +282,17 @@ fun KeyboardView(
                     accentColor = accentColor,
                     isFocused = state.quickSendFormFocused,
                     initialText = state.quickSendEditingItemText,
+                    initialCode = state.quickSendEditingItemCode,
                     cardBgColor = keyBgColor,
                     editingItemId = state.quickSendEditingItemId,
-                    onClose = { text: String ->
+                    onClose = { text: String, code: String ->
                         android.util.Log.d("QuickSendForm", "onClose: textLen=${text.length}, editingId=${state.quickSendEditingItemId}, showForm=${state.showQuickSendForm}")
                         if (text.isNotBlank()) {
                             val editingId = state.quickSendEditingItemId
                             if (editingId != null) {
-                                viewModel.updateQuickSendItem(editingId, text)
+                                viewModel.updateQuickSendItem(editingId, text, code)
                             } else {
-                                viewModel.addQuickSendText(text)
+                                viewModel.addQuickSendText(text, code)
                             }
                         }
                         callbacks.onHideQuickSendForm?.invoke()
@@ -1044,9 +1045,9 @@ fun KeyboardView(
                             viewModel.closeOverlay()
                             callbacks.onShowQuickSendForm?.invoke()
                         },
-                        onQuickSendEditItem = { id, text ->
+                        onQuickSendEditItem = { id, text, code ->
                             viewModel.closeOverlay()
-                            callbacks.onQuickSendEditItem?.invoke(id, text)
+                            callbacks.onQuickSendEditItem?.invoke(id, text, code)
                         },
                         onPullRemote = callbacks.onClipboardPullRemote,
                         pullRemoteAvailable = state.clipboardSyncEnabled,

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/QuickSendFormArea.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/QuickSendFormArea.kt
@@ -6,6 +6,7 @@ import android.view.inputmethod.EditorInfo
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -16,6 +17,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.kingzcheung.xime.service.QuickSendFormCodeEditTextHolder
 import com.kingzcheung.xime.service.QuickSendFormEditTextHolder
 
 private val QUICK_SEND_FORM_HEIGHT = 200
@@ -27,9 +29,10 @@ fun QuickSendFormArea(
     accentColor: Color,
     isFocused: Boolean,
     initialText: String = "",
+    initialCode: String = "",
     cardBgColor: Color,
     editingItemId: Long? = null,
-    onClose: (text: String) -> Unit,
+    onClose: (text: String, code: String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -61,44 +64,79 @@ fun QuickSendFormArea(
         onCloseClick = {
             android.util.Log.d("QuickSendForm", "closeClick: holder=${QuickSendFormEditTextHolder.editText != null}")
             val et = QuickSendFormEditTextHolder.editText
-            onClose(et?.text?.toString() ?: "")
+            val codeEt = QuickSendFormCodeEditTextHolder.editText
+            onClose(et?.text?.toString() ?: "", codeEt?.text?.toString() ?: "")
         },
     ) {
-        AndroidView(
-            factory = { context ->
-                android.widget.EditText(context).apply {
-                    setBackgroundColor(android.graphics.Color.TRANSPARENT)
-                    setTextColor(textColor.hashCode())
-                    setHintTextColor((textColor.copy(alpha = 0.4f)).hashCode())
-                    hint = "输入快捷发送内容"
-                    textSize = 16f
-                    isSingleLine = false
-                    gravity = Gravity.TOP or Gravity.START
-                    setPadding(12, 8, 12, 8)
+        androidx.compose.foundation.layout.Column(modifier = Modifier.fillMaxSize()) {
+            AndroidView(
+                factory = { context ->
+                    android.widget.EditText(context).apply {
+                        setBackgroundColor(android.graphics.Color.TRANSPARENT)
+                        setTextColor(textColor.hashCode())
+                        setHintTextColor((textColor.copy(alpha = 0.4f)).hashCode())
+                        hint = "输入快捷发送内容"
+                        textSize = 16f
+                        isSingleLine = false
+                        gravity = Gravity.TOP or Gravity.START
+                        setPadding(12, 8, 12, 8)
 
-                    setImeActionLabel("确定", EditorInfo.IME_ACTION_DONE)
-                    imeOptions = EditorInfo.IME_FLAG_NO_ENTER_ACTION or
-                        EditorInfo.IME_ACTION_DONE
+                        setImeActionLabel("确定", EditorInfo.IME_ACTION_DONE)
+                        imeOptions = EditorInfo.IME_FLAG_NO_ENTER_ACTION or
+                            EditorInfo.IME_ACTION_DONE
 
-                    onFocusChangeListener = View.OnFocusChangeListener { _, hasFocus ->
-                        onFocusChange(hasFocus)
+                        onFocusChangeListener = View.OnFocusChangeListener { _, hasFocus ->
+                            onFocusChange(hasFocus)
+                        }
+                        setOnClickListener {
+                            onFocusChange(true)
+                        }
+                        QuickSendFormEditTextHolder.editText = this
+                        if (isFocused) {
+                            post { requestFocus() }
+                        }
                     }
-                    setOnClickListener {
-                        onFocusChange(true)
+                },
+                update = { editText ->
+                    if (initialText.isNotEmpty() && !editText.text.toString().equals(initialText)) {
+                        editText.setText(initialText)
+                        editText.setSelection(initialText.length)
                     }
-                    QuickSendFormEditTextHolder.editText = this
-                    if (isFocused) {
-                        post { requestFocus() }
+                },
+                modifier = Modifier
+                    .fillMaxSize()
+                    .weight(1f),
+            )
+            AndroidView(
+                factory = { context ->
+                    android.widget.EditText(context).apply {
+                        setBackgroundColor(android.graphics.Color.TRANSPARENT)
+                        setTextColor(textColor.hashCode())
+                        setHintTextColor((textColor.copy(alpha = 0.4f)).hashCode())
+                        hint = "触发编码（选填，如 dh）"
+                        textSize = 14f
+                        isSingleLine = true
+                        gravity = Gravity.START or Gravity.CENTER_VERTICAL
+                        setPadding(12, 4, 12, 4)
+
+                        setImeActionLabel("确定", EditorInfo.IME_ACTION_DONE)
+                        imeOptions = EditorInfo.IME_FLAG_NO_ENTER_ACTION or
+                            EditorInfo.IME_ACTION_DONE
+
+                        setOnClickListener {
+                            onFocusChange(true)
+                        }
+                        QuickSendFormCodeEditTextHolder.editText = this
                     }
-                }
-            },
-            update = { editText ->
-                if (initialText.isNotEmpty() && !editText.text.toString().equals(initialText)) {
-                    editText.setText(initialText)
-                    editText.setSelection(initialText.length)
-                }
-            },
-            modifier = Modifier.fillMaxSize(),
-        )
+                },
+                update = { editText ->
+                    if (initialCode.isNotEmpty() && !editText.text.toString().equals(initialCode)) {
+                        editText.setText(initialCode)
+                        editText.setSelection(initialCode.length)
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/menubar/ClipboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/menubar/ClipboardView.kt
@@ -78,7 +78,7 @@ fun ClipboardView(
     bottomPaddingDp: Int = 0,
     modifier: Modifier = Modifier,
     onQuickSendAddClick: (() -> Unit)? = null,
-    onQuickSendEditItem: ((Long, String) -> Unit)? = null,
+    onQuickSendEditItem: ((Long, String, String) -> Unit)? = null,
     onPullRemote: (() -> Unit)? = null,
     pullRemoteAvailable: Boolean = false,
 ) {
@@ -419,7 +419,7 @@ fun ClipboardView(
                             icon = Icons.Default.Create,
                             label = "编辑",
                             onClick = {
-                                edit(anchor.item.id, anchor.item.text)
+                                edit(anchor.item.id, anchor.item.text, anchor.item.code)
                             }
                         )
                     },

--- a/app/src/main/java/com/kingzcheung/xime/ui/menubar/QuickSendView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/menubar/QuickSendView.kt
@@ -30,7 +30,7 @@ fun QuickSendTabContent(
     viewModel: KeyboardViewModel,
     onSelect: (String) -> Unit,
     onQuickSendAddClick: (() -> Unit)? = null,
-    onQuickSendEditItem: ((Long, String) -> Unit)? = null,
+    onQuickSendEditItem: ((Long, String, String) -> Unit)? = null,
     onLongPressItem: (ClipboardItem, Boolean) -> Unit,
 ) {
     if (items.isEmpty()) {

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/PluginConfigFormScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/PluginConfigFormScreen.kt
@@ -56,8 +56,8 @@ import androidx.compose.ui.unit.dp
 import com.kingzcheung.xime.plugin.PluginConfigStoreImpl
 import com.kingzcheung.xime.plugin.core.config.IPluginConfigurable
 import com.kingzcheung.xime.plugin.core.config.PluginConfigStore
-import com.kingzcheung.xime.plugin.core.config.PluginFieldType
-import com.kingzcheung.xime.plugin.core.config.PluginSettingField
+import com.kingzcheung.xime.plugin.core.config.UiNode
+import com.kingzcheung.xime.plugin.core.config.UiNodeType
 import com.kingzcheung.xime.plugin.core.lua.ws.NetworkPolicy
 import com.kingzcheung.xime.plugin.core.runtime.PluginManager
 import com.kingzcheung.xime.settings.SettingsPreferences
@@ -71,7 +71,7 @@ fun PluginConfigFormScreen(
     pluginId: String,
     plugin: IPluginConfigurable,
     pluginName: String,
-    schema: List<PluginSettingField> = emptyList(),
+    schema: List<UiNode> = emptyList(),
     onBack: () -> Unit,
     embedded: Boolean = false
 ) {
@@ -88,17 +88,18 @@ fun PluginConfigFormScreen(
 
     val dynamicOptions = remember(plugin) { mutableStateMapOf<String, List<String>>() }
     LaunchedEffect(plugin, fields) {
-        fields.filter { it.type == PluginFieldType.SELECT || it.type == PluginFieldType.MULTI_SELECT }
+        fields.filter { it.type == UiNodeType.SELECT || it.type == UiNodeType.MULTI_SELECT }
+            .filter { it.key != null }
             .forEach { field ->
                 val opts = withContext(Dispatchers.IO) {
-                    runCatching { plugin.getOptions(field.key) }.getOrNull()
+                    runCatching { plugin.getOptions(field.key!!) }.getOrNull()
                 }
-                if (opts != null) dynamicOptions[field.key] = opts
+                if (opts != null) dynamicOptions[field.key!!] = opts
             }
     }
 
     @Composable
-    fun sectionContent(section: String, sectionFields: List<PluginSettingField>) {
+    fun sectionContent(section: String, sectionFields: List<UiNode>) {
         SettingsSection(
             title = section.ifBlank { "插件配置" },
             content = {
@@ -107,11 +108,11 @@ fun PluginConfigFormScreen(
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     sectionFields.forEach { field ->
-                        PluginSettingFieldEditor(
+                        UiNodeEditor(
                             field = field,
                             configStore = configStore,
                             options = field.options.ifEmpty {
-                                dynamicOptions[field.key].orEmpty()
+                                field.key?.let { dynamicOptions[it].orEmpty() } ?: emptyList()
                             },
                             plugin = plugin
                         )
@@ -143,8 +144,8 @@ fun PluginConfigFormScreen(
             onClick = {
                 var allValid = true
                 fields.forEach { field ->
-                    if (field.type == PluginFieldType.SECRET && field.required) {
-                        val current = configStore.get(field.key)
+                    if (field.type == UiNodeType.SECRET && field.required && field.key != null) {
+                        val current = configStore.get(field.key!!)
                         if (current.isNullOrBlank()) allValid = false
                     }
                 }
@@ -223,34 +224,38 @@ fun PluginConfigFormScreen(
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
-private fun PluginSettingFieldEditor(
-    field: PluginSettingField,
+private fun UiNodeEditor(
+    field: UiNode,
     configStore: PluginConfigStore,
     options: List<String>,
     plugin: IPluginConfigurable
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    var buttonBusy by remember(field.key) { mutableStateOf(false) }
-    var value by rememberSaveable(field.key) {
-        mutableStateOf(configStore.get(field.key) ?: field.defaultValue ?: "")
+    // 表单字段必须绑定 configStore key；无 key 的节点（展示型误入表单）不渲染
+    val key = field.key ?: return
+    var buttonBusy by remember(key) { mutableStateOf(false) }
+    var value by rememberSaveable(key) {
+        mutableStateOf(configStore.get(key) ?: field.defaultValue ?: "")
     }
-    var showSecret by rememberSaveable(field.key) { mutableStateOf(false) }
-    var expanded by rememberSaveable(field.key) { mutableStateOf(false) }
+    var showSecret by rememberSaveable(key) { mutableStateOf(false) }
+    var expanded by rememberSaveable(key) { mutableStateOf(false) }
 
     fun persist() {
-        configStore.set(field.key, value)
+        configStore.set(key, value)
     }
 
     when (field.type) {
-        PluginFieldType.TEXTAREA -> {
+        // 展示型节点（SECTION/METRIC/DIVIDER）在设置表单中忽略
+        UiNodeType.SECTION, UiNodeType.METRIC, UiNodeType.DIVIDER -> Unit
+        UiNodeType.TEXTAREA -> {
             OutlinedTextField(
                 value = value,
                 onValueChange = {
                     value = it
                     persist()
                 },
-                label = { Text(field.label) },
+                label = { Text(field.label ?: "") },
                 placeholder = field.placeholder?.let { { Text(it) } },
                 minLines = 4,
                 maxLines = 8,
@@ -264,18 +269,18 @@ private fun PluginSettingFieldEditor(
             )
         }
 
-        PluginFieldType.TEXT,
-        PluginFieldType.NUMBER -> {
+        UiNodeType.TEXT,
+        UiNodeType.NUMBER -> {
             OutlinedTextField(
                 value = value,
                 onValueChange = {
                     value = it
                     persist()
                 },
-                label = { Text(field.label) },
+                label = { Text(field.label ?: "") },
                 placeholder = field.placeholder?.let { { Text(it) } },
                 singleLine = true,
-                keyboardOptions = if (field.type == PluginFieldType.NUMBER) {
+                keyboardOptions = if (field.type == UiNodeType.NUMBER) {
                     KeyboardOptions(keyboardType = KeyboardType.Number)
                 } else {
                     KeyboardOptions.Default
@@ -290,14 +295,14 @@ private fun PluginSettingFieldEditor(
             )
         }
 
-        PluginFieldType.SECRET -> {
+        UiNodeType.SECRET -> {
             OutlinedTextField(
                 value = value,
                 onValueChange = {
                     value = it
                     persist()
                 },
-                label = { Text(field.label) },
+                label = { Text(field.label ?: "") },
                 placeholder = field.placeholder?.let { { Text(it) } },
                 singleLine = true,
                 visualTransformation = if (showSecret) {
@@ -324,14 +329,14 @@ private fun PluginSettingFieldEditor(
             )
         }
 
-        PluginFieldType.SWITCH -> {
+        UiNodeType.SWITCH -> {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text = field.label,
+                        text = field.label ?: "",
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.Medium
                     )
@@ -357,7 +362,7 @@ private fun PluginSettingFieldEditor(
             }
         }
 
-        PluginFieldType.SELECT -> {
+        UiNodeType.SELECT -> {
             ExposedDropdownMenuBox(
                 expanded = expanded,
                 onExpandedChange = { expanded = it }
@@ -366,7 +371,7 @@ private fun PluginSettingFieldEditor(
                     value = value,
                     onValueChange = {},
                     readOnly = true,
-                    label = { Text(field.label) },
+                    label = { Text(field.label ?: "") },
                     trailingIcon = {
                         ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
                     },
@@ -401,11 +406,11 @@ private fun PluginSettingFieldEditor(
             }
         }
 
-        PluginFieldType.MULTI_SELECT -> {
+        UiNodeType.MULTI_SELECT -> {
             val selected = value.split(",").map { it.trim() }.filter { it.isNotEmpty() }.toSet()
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(
-                    text = field.label,
+                    text = field.label ?: "",
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.Medium
                 )
@@ -446,10 +451,10 @@ private fun PluginSettingFieldEditor(
             }
         }
 
-        PluginFieldType.BUTTON -> {
+        UiNodeType.BUTTON -> {
             Button(
                 onClick = {
-                    val action = field.action
+                    val action = key
                     if (action.isNullOrBlank()) {
                         Toast.makeText(context, "未配置动作", Toast.LENGTH_SHORT).show()
                         return@Button
@@ -457,7 +462,7 @@ private fun PluginSettingFieldEditor(
                     buttonBusy = true
                     scope.launch {
                         val error = withContext(Dispatchers.IO) {
-                            runCatching { plugin.onAction(action) }.getOrNull()
+                            runCatching { plugin.onAction(action.toString()) }.getOrNull()
                         }
                         buttonBusy = false
                         if (error.isNullOrBlank()) {
@@ -474,7 +479,7 @@ private fun PluginSettingFieldEditor(
                     contentColor = MaterialTheme.colorScheme.onPrimary
                 )
             ) {
-                Text(if (buttonBusy) "处理中…" else field.label)
+                Text(if (buttonBusy) "处理中…" else field.label ?: "")
             }
         }
     }

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
@@ -84,6 +84,7 @@ data class KeyboardUiState(
     val quickSendFormFocused: Boolean = false,
     val quickSendEditingItemId: Long? = null,
     val quickSendEditingItemText: String = "",
+    val quickSendEditingItemCode: String = "",
     val toolPanelVisible: Boolean = false,
     val toolPanelInputFocused: Boolean = false,
     val toolPanelPluginId: String = "",
@@ -93,7 +94,7 @@ data class KeyboardUiState(
     val toolPanelLoading: Boolean = false,
     val toolPanelRequestEpoch: Long = 0,
     val toolPanelDisplay: String? = null,
-    val toolPanelUiNodes: List<Map<*, *>>? = null,
+    val toolPanelUiNodes: List<com.kingzcheung.xime.plugin.core.config.UiNode>? = null,
     val clipboardSyncEnabled: Boolean = false,
 )
 
@@ -532,12 +533,12 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
         clipboardManager.addToQuickSend(id)
     }
 
-    fun addQuickSendText(text: String) {
-        clipboardManager.addQuickSendItem(text)
+    fun addQuickSendText(text: String, code: String = "") {
+        clipboardManager.addQuickSendItem(text, code)
     }
 
-    fun updateQuickSendItem(id: Long, text: String) {
-        clipboardManager.updateQuickSendItem(id, text)
+    fun updateQuickSendItem(id: Long, text: String, code: String = "") {
+        clipboardManager.updateQuickSendItem(id, text, code)
     }
 
     fun removeQuickSendItem(id: Long) {

--- a/app/src/test/java/com/kingzcheung/xime/service/CandidateTransformCoordinatorTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/service/CandidateTransformCoordinatorTest.kt
@@ -1,0 +1,124 @@
+package com.kingzcheung.xime.service
+
+import com.kingzcheung.xime.plugin.core.lua.CandidateTransformItem
+import com.kingzcheung.xime.rime.RimeCandidate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 候选词变换映射（CandidateTransformCoordinator.buildDisplay 纯函数）：
+ * - 引用项（engine_index）→ 平行 CandidateAction.engine + comment 覆盖
+ * - 插件项（text）→ CandidateAction.plugin，点击直接上屏
+ * - 语义校验：越界/重复 engine_index 丢弃、空 text 丢弃、总数上限截断
+ * - 空结果 → null（不干预）
+ */
+class CandidateTransformCoordinatorTest {
+
+    private val engine = listOf(
+        RimeCandidate("你好", "nǐ hǎo"),
+        RimeCandidate("你好吗", ""),
+        RimeCandidate("拟好", "nǐ hǎo"),
+    )
+
+    @Test
+    fun `引用项映射引擎候选并保留平行动作`() {
+        val result = CandidateTransformCoordinator.buildDisplay(
+            items = listOf(
+                CandidateTransformItem(engineIndex = 2, text = null, comment = null),
+                CandidateTransformItem(engineIndex = 0, text = null, comment = null),
+            ),
+            engineCandidates = engine,
+        )!!
+        assertEquals(listOf("拟好", "你好"), result.candidates.map { it.text })
+        assertEquals(listOf(2, 0), result.actions.map { it.engineIndex })
+        // 引用项仍显示引擎注释
+        assertEquals("nǐ hǎo", result.candidates[0].comment)
+        assertFalse(result.actions[0].isPluginCandidate)
+    }
+
+    @Test
+    fun `引用项 comment 覆盖仅影响显示`() {
+        val result = CandidateTransformCoordinator.buildDisplay(
+            items = listOf(CandidateTransformItem(engineIndex = 0, text = null, comment = "覆盖注释")),
+            engineCandidates = engine,
+        )!!
+        assertEquals("覆盖注释", result.candidates[0].comment)
+        // commitText 不用于引擎引用
+        assertEquals("", result.actions[0].commitText)
+    }
+
+    @Test
+    fun `插件候选映射为直接上屏动作`() {
+        val result = CandidateTransformCoordinator.buildDisplay(
+            items = listOf(CandidateTransformItem(engineIndex = null, text = "18500000000", comment = "手机号")),
+            engineCandidates = engine,
+        )!!
+        assertEquals("18500000000", result.candidates[0].text)
+        assertEquals("手机号", result.candidates[0].comment)
+        val action = result.actions[0]
+        assertTrue(action.isPluginCandidate)
+        assertEquals(-1, action.engineIndex)
+        assertEquals("18500000000", action.commitText)
+    }
+
+    @Test
+    fun `混合列表保持插件给定的顺序`() {
+        val result = CandidateTransformCoordinator.buildDisplay(
+            items = listOf(
+                CandidateTransformItem(engineIndex = 0, text = null, comment = null),
+                CandidateTransformItem(engineIndex = null, text = "快捷短语", comment = null),
+                CandidateTransformItem(engineIndex = 1, text = null, comment = null),
+            ),
+            engineCandidates = engine,
+        )!!
+        assertEquals(listOf("你好", "快捷短语", "你好吗"), result.candidates.map { it.text })
+        assertEquals(listOf(0, -1, 1), result.actions.map { it.engineIndex })
+    }
+
+    @Test
+    fun `越界与重复 engine_index 丢弃`() {
+        val result = CandidateTransformCoordinator.buildDisplay(
+            items = listOf(
+                CandidateTransformItem(engineIndex = 3, text = null, comment = null),
+                CandidateTransformItem(engineIndex = -1, text = null, comment = null),
+                CandidateTransformItem(engineIndex = 0, text = null, comment = null),
+                CandidateTransformItem(engineIndex = 0, text = null, comment = null),
+            ),
+            engineCandidates = engine,
+        )!!
+        assertEquals(1, result.candidates.size)
+        assertEquals(0, result.actions[0].engineIndex)
+    }
+
+    @Test
+    fun `空 text 与全部非法项`() {
+        val result = CandidateTransformCoordinator.buildDisplay(
+            items = listOf(
+                CandidateTransformItem(engineIndex = null, text = "", comment = null),
+                CandidateTransformItem(engineIndex = null, text = null, comment = "x"),
+                CandidateTransformItem(engineIndex = 99, text = null, comment = null),
+            ),
+            engineCandidates = engine,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `总数上限截断`() {
+        val items = (0 until 30).map { CandidateTransformItem(engineIndex = null, text = "c$it", comment = null) }
+        val result = CandidateTransformCoordinator.buildDisplay(items = items, engineCandidates = engine, maxCandidates = 20)!!
+        assertEquals(20, result.candidates.size)
+        assertEquals(20, result.actions.size)
+        assertEquals("c19", result.candidates[19].text)
+    }
+
+    @Test
+    fun `空响应返回 null 不干预`() {
+        assertNull(
+            CandidateTransformCoordinator.buildDisplay(items = emptyList(), engineCandidates = engine)
+        )
+    }
+}

--- a/docs/plugin-capability-registry.md
+++ b/docs/plugin-capability-registry.md
@@ -1,0 +1,269 @@
+# 插件能力注册表（Capability Registry）设计
+
+> 日期：2026-09-01
+> 背景：为「候选词变换」（插件可修改候选栏内容）设计插件 API 时，审查发现插件系统能力协议层存在结构性混乱。本文档定义收敛方案，并给出首个接入输入主流程的能力 `candidate_transform` 的完整规范与分阶段迁移计划。
+> 关系：本文档是 `plugin-system-audit.md`（2026-08-28 架构盘点）的延续——审计文档第 8 节「设计原则」的修订与第 6 条结论「能力声明消费端需要统一框架」的落地设计。
+
+## 1. 现状诊断：能力协议的乱象
+
+骨架层（生命周期、崩溃隔离、签名、网络三重门、配置隔离）是健康的。乱的是**新增一个能力的成本与身份表达**：
+
+### 1.1 新增一个能力要动 6 处
+
+1. `PluginCategory` 加枚举（分类驱动消费入口 + 激活模式）
+2. `PluginCapabilities` 加字段和参数类（注释自称"宿主消费能力的唯一来源"）
+3. Kotlin 接口（EmojiPlugin / ToolPlugin / AsrPlugin / ClipboardSyncPlugin 各一套）
+4. `LuaPluginContract` 注册 Lua 契约函数名
+5. 新写一个 Lua Adapter（已有 5 个：Lua / LuaEmoji / LuaTool / LuaAsr / LuaClipboardSync）
+6. 宿主消费点接线（ExtensionManager per-category 查询 + 各消费页面）
+
+### 1.2 `type` 与 `capabilities` 双轨重叠
+
+`PluginCategory`（manifest `type` 字段）与 `PluginCapabilities`（manifest `capabilities` 节点）表达的是**同一个插件身份的两半**，且语义重叠：
+
+| PluginCategory | PluginCapabilities 字段 | 重叠内容 |
+|---|---|---|
+| EMOJI | `emoji` | 同一能力 |
+| ASR | `speech` | 同一能力 |
+| TOOL | `tool` | 同一能力 |
+| CLIPBOARD_SYNC | `clipboardSync` | 同一能力 |
+| PREDICTION | （无） | 预留未实现 |
+
+实例证据（`plugins/typing-stats/manifest.yaml`）：同一文件里 `type: tool` 与 `capabilities.tool.display: passive` 写的是同一个身份的两半。
+
+### 1.3 交互模型的执行底座其实只有两种
+
+盘点全部现有能力（见 audit 文档 §2），底层执行模型只有两种：
+
+- **同步调用**（宿主等待插件返回值）：getEmojis / getPanelState / pull() / getSettingsSchema
+- **异步投递**（宿主不等）：input_changed / text_committed 事件、clipboard push、ASR PCM 推流（+ 异步回调回传结果）
+
+混乱的表象（每能力一套说辞）掩盖了统一的底座，这为收敛提供了条件。
+
+## 2. 设计原则
+
+1. **单一事实来源**：manifest `capabilities` 是插件身份与能力的唯一来源；`type` 退役（过渡期降级为纯 UI 分组展示）。
+2. **注册表驱动**：能力 = 注册表一行；新能力不再新造机制，六处接线从注册表派生。
+3. **执行模型两分**：SYNC（宿主等结果，必须有硬超时预算）/ FIRE_AND_FORGET（宿主不等）。任何能力必须显式声明归属。
+4. **hotPath 显式化**：是否接入输入主流程（按键路径）是能力的显式属性，主流程豁免条款只对 `hotPath=true` 的能力生效。
+5. **双形态收敛在解析层**：APK 插件（XML meta-data）与 Lua 插件（manifest.yaml）解析产物统一进 `PluginInfo.capabilities`，上层不感知载体差异。
+6. **数据出入门沿用审计原则 1**：任何用户数据离开 IME 进插件，必须 capability 声明 + 启动前校验 + 设置页可见开关（模板 = clipboardSync）。
+
+## 3. 能力注册表
+
+### 3.1 模型定义（plugin-core）
+
+```kotlin
+/** 交互语义（给人看的分类，对齐 audit 文档三类 + 面板） */
+enum class PluginInteraction { PULL, EVENT, STREAM, PANEL }
+
+/** 执行模型（机器判定的底座） */
+enum class PluginExecution { SYNC, FIRE_AND_FORGET }
+
+enum class PluginCapabilityDef(
+    val manifestKey: String,        // capabilities 下的 key
+    val label: String,              // 管理页展示名
+    val interaction: PluginInteraction,
+    val execution: PluginExecution,
+    val luaFunctions: List<String>, // Lua 契约函数（声明了能力才允许宿主分发调用）
+    val hotPath: Boolean,           // 是否接入输入主流程（按键路径）
+    val timeoutMs: Long?,           // SYNC 必填硬超时；FIRE_AND_FORGET 为 null
+) { ... }
+```
+
+### 3.2 现有能力映射（存量收编，行为不变）
+
+| manifestKey | interaction | execution | luaFunctions | hotPath | timeout | 备注 |
+|---|---|---|---|---|---|---|
+| `emoji` | PULL | SYNC | getCategories / getEmojis | false | 沿用现状（180s） | 搜索通路待接线（audit §7.4） |
+| `speech` | STREAM | FIRE_AND_FORGET（回调） | onLoad 等 + host.asr.emit* | false | 回调 5s | 宿主推 PCM，插件异步回推结果 |
+| `tool` | PANEL | SYNC（getPanelState）+ FIRE_AND_FORGET（onPanel*） | getPanelState / onPanelInput / onPanelAction / onPanelItemClick | false | 沿用现状（180s） | 200ms 轮询待改 `panelStateChanged`（audit §7.2） |
+| `clipboard_sync` | EVENT + PULL | FIRE_AND_FORGET（push）+ SYNC（pull） | push / pull | false | 沿用现状 | 出入门管控模板 |
+| `events` | EVENT | FIRE_AND_FORGET | onPluginEvent | false | conflated 投递 | 事件订阅（input_changed / text_committed） |
+| `prediction` | PULL | SYNC | （预留） | false | 待定 | PREDICTION 消费页未实现（audit §7.3） |
+| `candidate_transform` | PULL | SYNC | transformCandidates | **true** | **15ms** | 首个 hotPath 能力，规范见 §5 |
+| `quick_send_read` | PULL | SYNC | host.quickSend.list() | false | 沿用现状（180s） | 快捷发送只读（ClipboardManager 内存缓存，零 IO）；配 `quick_send_changed` 事件做缓存刷新 |
+| `clipboard_read` | PULL | SYNC | host.clipboard.get() | false | 沿用现状（180s） | 剪贴板当前文本只读；外发仍受网络三重门约束 |
+
+### 3.3 manifest 规范（统一后）
+
+```yaml
+id: com.example.plugin
+name: ...
+version: ...
+entry: main.lua
+
+capabilities:            # 插件身份与能力的唯一来源
+  emoji:                 # 静态参数节点（现有，不变）
+    supportsSearch: true
+  events:                # 事件订阅（现有，不变）
+    - input_changed
+  candidate_transform: true   # 布尔型能力（新增）
+
+type: tool               # 过渡期保留：仅作插件管理页分组展示；阶段 3 退役
+```
+
+规则：
+- `capabilities` 未声明的能力，宿主**不建立通道、不分发调用**（未声明零开销，沿用事件系统模式）。
+- 布尔型能力（无参数）用 `true`；带静态参数的能力用节点（现有 emoji/speech/tool/clipboard_sync 模式不变）。
+- 未知能力字段：解析期忽略（沿用现有 sanitize），注册表校验时对"已注册但未声明"的能力静默跳过。
+
+## 4. 交互模型与安全策略矩阵
+
+| interaction | execution | 数据流出管控 | 线程与超时 | 敏感输入豁免 |
+|---|---|---|---|---|
+| PULL | SYNC | 请求体含用户数据（编码/候选/上下文）→ 必须声明 | 调用方线程 + 硬超时（hotPath=15ms，非 hotPath 沿用 180s）+ hotPath 熔断 | hotPath 必须 |
+| EVENT | FIRE_AND_FORGET | payload 含用户数据 → 必须声明 events | conflated channel + 插件执行器 | 敏感输入不投递（已实现） |
+| STREAM | FIRE_AND_FORGET（回调回推） | 音频等 → 必须声明 | 专用执行器 + 回调 5s | 录音由用户主动触发 |
+| PANEL | 混合 | 上下文文本 → 待补声明（audit §3 管控缺口） | 200ms 轮询（待改事件通知） | 待补 |
+
+### 4.1 审计原则 4「主流程零等待」的豁免条款（修订）
+
+原文：插件调用一律异步投递，主流程只 trySend。
+
+修订为：**主线程 / 主调度器永不阻塞插件调用；但 `hotPath=true` 的 PULL 能力允许在 key-processing 线程同步等待插件结果**，条件（全部满足才豁免）：
+
+1. 硬超时 ≤ 15ms，超时回退原始数据（不重试、不阻塞后续）；
+2. 连续超时熔断（连续 3 次超时 → 本会话禁用该插件此能力）；
+3. 敏感输入框（复用 `PluginEventDispatcher.isSensitiveEditor` 判定）短路，不产生请求；
+4. 不持有 `rimeLock` 等引擎锁等待（变换发生在引擎结果返回之后，锁已释放）。
+
+## 5. 首个 hotPath 能力：candidate_transform
+
+### 5.1 需求语义
+
+用户场景（快捷发送）：rime 返回候选后、候选栏渲染前，插件根据当前编码串查询快捷内容，**替换部分候选或追加新候选**；用户点击插件候选时**上屏插件文本**（所见即所得）。
+
+### 5.2 manifest 声明
+
+```yaml
+capabilities:
+  candidate_transform: true
+```
+
+### 5.3 Lua 契约（LuaPluginContract 新增 FN_TRANSFORM_CANDIDATES）
+
+```lua
+function plugin.transformCandidates(request)
+  -- request = {
+  --   input_text = "nh",        -- 原始键入串（无分隔符）
+  --   preedit     = "ni'hao",   -- 引擎回显（带分隔符）
+  --   candidates  = { {text="你好", comment=""}, ... },  -- ascii 过滤后的当前引擎候选
+  --   ascii_mode  = false,
+  -- }
+  -- 返回 nil = 不干预（渲染原始候选）
+  return {
+    candidates = {
+      { engine_index = 0 },                      -- 引用引擎候选：点击走引擎选词；comment 可选覆盖显示
+      { text = "快捷短语A", comment = "快捷" },   -- 插件候选：点击直接上屏 text
+    }
+  }
+end
+```
+
+校验规则（宿主侧，违规即丢弃）：
+- `engine_index` 越界或重复 → 丢弃该项；
+- `text` 为空 → 丢弃该项；
+- 响应候选总数上限 20；
+- 响应格式错误 / 超时 / Lua 报错 → 整体回退原始候选。
+
+### 5.4 宿主实现要点
+
+**数据模型**：
+
+```kotlin
+data class CandidateAction(
+    val engineIndex: Int,      // >= 0 引用引擎候选；-1 为插件候选
+    val commitText: String,    // 插件候选的上屏文本（engineIndex < 0 时有效）
+)
+// CandidateState 新增：candidateActions: List<CandidateAction> = emptyList()
+// 默认空 = 纯引擎语义（displayIndex == engineIndex），所有现有路径零影响
+```
+
+**挂钩点**（全部在 key-processing 线程，主线程零等待）：
+
+1. `ImeKeyRouter` 主字母路径（:559 附近）拿到 `RimeProcessResult` 并完成 ascii 过滤后调用变换；
+2. delete 路径（:804 附近，退格后候选仍需匹配快捷短语）；
+3. 内联刷新路径（:649 附近，getInput + getCandidatesWithComments 分支）；
+4. 翻页路径（`pageUp`/`pageDown` → `service.updateUI()`）：实现时确认 `updateUI()` 取数点所在线程——若在 key-processing 线程则翻页后重新变换（推荐，保证插件候选跨页存在）；否则翻页后回退纯引擎候选（actions 清空）。
+
+**变换协调器**（新建 `CandidateTransformCoordinator`，service 组件，模式仿 PluginEventDispatcher）：
+- 前置条件（全部满足才调用）：存在声明 `candidate_transform` 的已启用插件 + 非敏感输入 + 中文模式 + 编码非空；
+- 每能力一插件：v1 仅取第一个匹配插件，多插件链式变换列为后续增强；
+- 连续 3 次超时 → 本会话熔断（FileLogger 记录）。
+
+**选词分流**（`ImeKeyRouter.selectCandidateAsync` :872 入口）：
+
+```kotlin
+val action = service.candidateState.value.candidateActions.getOrNull(index)
+if (action != null && action.engineIndex < 0) {
+    // 插件候选：直接上屏 + clearComposition + 清空候选状态（复用 enter 分支 :294-306 的直接提交模式）
+    return
+}
+// 引擎候选：现有逻辑；engineIndex 已知时跳过 resolveRimeCandidateIndex（仅作兜底）
+```
+
+T9 分支不受影响（见 5.5 边界）。
+
+**数字选词拦截**（关键，否则引擎绕过插件候选）：
+中文组合态 + `candidateActions` 非空时，数字键 `'1'..'9'` 不再进入 `processKeyAndGetResult`（rime 会自行选词返回 committedText，绕过映射），改为映射到 `selectCandidateAsync(n-1)`。物理键盘 KEYCODE_1-9 已收口在 `keyRouter.selectCandidate`（XimeInputMethodService.kt:1479-1488），天然走分流，无需改动。
+
+### 5.5 失败降级
+
+| 场景 | 行为 |
+|---|---|
+| 插件超时（15ms）/ Lua 报错 / 返回 nil / 格式错误 | 原始候选原样渲染，actions 为空 |
+| 敏感输入框 | 不产生请求，直接跳过 |
+| 无插件声明该能力 | 零开销（不建通道、不调用） |
+| 连续 3 次超时 | 本会话熔断该插件，恢复原始候选直至插件重载 |
+
+### 5.6 边界与后续
+
+- **v1 不覆盖 T9**：T9 路径（applyComposition 在主线程）恒不启用变换，candidateActions 恒空，T9 逻辑零影响；T9 接入列为后续独立功能点。
+- **ascii 模式跳过**：英文模式不调用变换。
+- **插件候选是整段直接上屏**：不走引擎的段落续接语义（如 `nihaoshijie` 选前半）；文档向插件作者明示。
+- **快捷发送数据源**：v1 示例插件使用插件自有数据（Lua 内存表）；宿主快捷发送数据的只读桥接 API（如 `xime.getQuickSends()`）列为后续增强。
+- **多插件链式变换**、**候选列表插件可全量重排**（当前 engine_index 引用 + 插件文本两分，不支持中间任意插入保持引擎语义）列为后续增强。
+
+## 6. 迁移计划（分阶段 → 已合并一次性实现）
+
+> 2026-09-01 更新：应项目决策，阶段 1（candidate_transform 全链路）已一次性实现完成；
+> 阶段 2 的注册表核心（能力声明 + Lua 契约 + 宿主协调器）随阶段 1 一并落地。
+> 阶段 3（type 退役）与阶段 4（Adapter 收敛）为纯重构，与功能无关，仍按独立 PR 排期。
+
+| 阶段 | 内容 | 状态 |
+|---|---|---|
+| **0（本文档）** | 规范基线：注册表模型 + 能力映射表 + 安全策略矩阵 + 豁免条款 | ✅ 完成 |
+| **1** | 实现 `candidate_transform`：PluginCapabilities 加布尔字段 + LuaPluginContract 注册函数 + LuaScriptRuntime 桥接（15ms 超时/解析/校验）+ 宿主挂钩（§5.4）+ 单元测试 | ✅ 完成（2026-09-01） |
+| **2** | 注册表代码化：`PluginCapabilityDef` 枚举落进 plugin-core（纯数据），InstallerManager 校验统一走注册表；ExtensionManager 新增 `getEnabledWithCapability(key)`，消费点渐进切换 | 部分落地（能力声明/契约/协调器已按规范实现；`PluginCapabilityDef` 枚举待抽为纯数据） |
+| **3** | `type` 退役：PluginCategory 降级为"由 capabilities 派生的展示分组"；manifest schema 文档更新；PREDICTION 消费页落地时同步 | 未开始 |
+| **4（低优）** | Lua Adapter 收敛：5 个 Adapter → 1 个通用 binder + 每能力转换器；manifest 解析层统一 | 未开始 |
+
+### 阶段 1 落地清单（2026-09-01）
+
+**plugin-core**：
+- `model/PluginCapabilities.kt`：`candidateTransform: Boolean`（`@SerialName("candidate_transform")`）
+- `runtime/installer/InstallerManager.kt`：`CapabilitiesConfig.candidateTransform`（kaml 解析）+ `toModel` 透传
+- `runtime/installer/XmlManager.kt`：capabilities JSON 编解码补 `candidateTransform`
+- `lua/CandidateTransform.kt`：Request / Candidate / Item / Outcome（sealed）数据模型
+- `lua/sdk/LuaPluginContract.kt`：`FN_TRANSFORM_CANDIDATES = "transformCandidates"` + 契约文档
+- `lua/LuaScriptRuntime.kt`：`transformCandidates(request)` 同步桥接（15ms 超时不中毒、解析、非法项丢弃、20 上限截断）
+- 测试：`LuaCandidateTransformTest`（11 用例）
+
+**app**：
+- `service/CandidateAction.kt`：上屏动作模型（引擎引用 / 插件候选）
+- `service/CandidateState.kt`：`candidateActions` 字段（默认空 = 纯引擎语义）
+- `service/CandidateTransformCoordinator.kt`：前置条件短路（敏感输入/T9/ascii/空编码/无插件/熔断）+ `buildDisplay` 纯函数映射（越界/重复/空文本校验）
+- `service/PluginEventDispatcher.kt`：暴露 `isCurrentEditorSensitive`
+- `service/ImeSessionController.kt`：`updateUIWithResult` / `applyComposition` 加 `pluginActions` 参数
+- `service/XimeInputMethodService.kt`：实例化 Coordinator；`updateUI()` 挂钩（含主线程 Looper 防御）
+- `service/ImeKeyRouter.kt`：`sendTransformedResult` 统一挂钩（字母/退格/词分隔/内联刷新路径）、`selectCandidateAsync` 按 actions 分流 + `commitPluginCandidate`（插件候选直接上屏）、数字选词拦截、全部候选状态清空点补 `candidateActions = emptyList()`
+- 测试：`CandidateTransformCoordinatorTest`（8 用例，buildDisplay 纯函数）
+
+**示例插件**：`plugins/quick-send-demo/`（manifest 声明 `candidate_transform: true`；Lua 前缀匹配快捷短语追加候选；`scripts/build-plugins.sh` 自动扫描打包，无需注册，不进 assets 预装）
+
+## 7. 不做的事（明确排除）
+
+- 不推翻现有插件骨架（生命周期/安全/网络门/配置存储），只收敛能力协议层。
+- 不合并 APK/Lua 双形态（各有存在理由：ASR 需要 SDK，Lua 面向轻量插件），收敛点仅在 manifest 解析产物。
+- 不在实现 candidate_transform 的 PR 里顺手做阶段 2-4 的重构（遵守"每次只做一个功能点"）。

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/api/ToolPlugin.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/api/ToolPlugin.kt
@@ -14,7 +14,7 @@ enum class ToolResult {
     /**
      * 纯展示面板（InfoPanel）：无输入框、无生成动作（enter 不触发 generate）、
      * 点击节点不上屏。插件通过 [ToolPanelState.ui] 声明式描述内容
-     * （白名单节点：section/text/metric/divider/action）；
+     * （统一 [com.kingzcheung.xime.plugin.core.config.UiNode] 白名单节点）；
      * 多条候选通过 [ToolPanelState.items] 返回，宿主渲染为点击上屏条目
      * （替代原 SELECT 全屏结果页，如 AI 智能回复）。
      */
@@ -30,11 +30,11 @@ data class ToolPanelState(
     /** 是否正在生成中（SSE 流式期间为 true，宿主据此展示 loading 并轮询刷新）。 */
     val loading: Boolean = false,
     /**
-     * passive 纯展示节点树（声明式 UI）。每节点 = { type: String, ...字段 }，
-     * 白名单 type：section(title) / text(content, style) / metric(label, value, unit?) /
-     * divider / action(label, actionId)。未知 type 宿主降级为文本渲染，不崩溃。
+     * passive 纯展示节点树（声明式 UI，统一模型 [com.kingzcheung.xime.plugin.core.config.UiNode]）。
+     * 面板展示白名单：SECTION / TEXT / METRIC / DIVIDER / BUTTON；
+     * 未知类型节点由解析层丢弃，渲染层降级为文本兜底。
      */
-    val ui: List<Map<*, *>>? = null,
+    val ui: List<com.kingzcheung.xime.plugin.core.config.UiNode>? = null,
 )
 
 /**
@@ -51,9 +51,11 @@ data class ToolPanelState(
  * - `loading`（布尔）：生成期间为 true，宿主据此轮询刷新直至 false。
  * - `inputText`（字符串，可选）：面板输入框内容回显，缺省回退为宿主传入的输入。
  * - `ui`（数组，可选）：纯展示节点树，仅 `display: passive` 时由宿主渲染（InfoPanel）。
- *   节点 = `{ type: string, ...字段 }`，白名单：
- *   `section(title)` / `text(content, style?)` / `metric(label, value, unit?)` /
- *   `divider` / `action(label, actionId)`；未知 type 降级为文本，不崩溃。
+ *   节点 = 统一 [com.kingzcheung.xime.plugin.core.config.UiNode] 结构
+ *   `{ type: string, key?, label?, value?, options?, ... }`，面板展示白名单：
+ *   `section(label)` / `text(value, style?)` / `metric(label, value, unit?)` /
+ *   `divider` / `button(key, label)`；未知 type 由解析层丢弃。
+ *   旧字段名（title/content/actionId、action→button）解析层兼容。
  *
  * 传输方式（同步 HTTP / SSE 流式）与结果呈现由插件元数据声明，宿主只消费上述结构化数据。
  *

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/config/IPluginConfigurable.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/config/IPluginConfigurable.kt
@@ -1,36 +1,73 @@
 package com.kingzcheung.xime.plugin.core.config
 
-enum class PluginFieldType { TEXT, TEXTAREA, SECRET, SELECT, MULTI_SELECT, SWITCH, NUMBER, BUTTON }
+/**
+ * 声明式 UI 节点类型：设置表单字段（TEXT..BUTTON）与面板展示节点（SECTION/METRIC/DIVIDER）
+ * 统一为一套，宿主按场景分派渲染：
+ * - 设置页：表单型（输入/开关/选择/按钮，值读写 configStore）
+ * - InfoPanel：展示型（SECTION 标题 / TEXT 文本 / METRIC 指标 / DIVIDER 分隔 / BUTTON 动作）；
+ *   表单型节点在面板出现时降级为只读文本
+ */
+enum class UiNodeType {
+    // ---- 表单字段（设置页） ----
+    TEXT,
+    TEXTAREA,
+    SECRET,
+    SELECT,
+    MULTI_SELECT,
+    SWITCH,
+    NUMBER,
+    /** 按钮：设置页触发 [IPluginConfigurable.onAction]，面板触发 onPanelAction（key 即 action id）。 */
+    BUTTON,
 
-data class PluginSettingField(
-    val key: String,
-    val label: String,
-    val type: PluginFieldType,
-    val placeholder: String? = null,
+    // ---- 面板展示（InfoPanel，dual 语义：value 由插件每次提供） ----
+    /** 分组标题。 */
+    SECTION,
+    /** 指标行（label + value + unit?）。 */
+    METRIC,
+    /** 分隔线。 */
+    DIVIDER,
+}
+
+/**
+ * 统一声明式 UI 节点（令牌化，宿主渲染，插件给数据）。
+ *
+ * Lua 契约字段与 Kotlin 一致；旧字段名（title/content/actionId/action）由解析层兼容
+ * （仅新字段写入文档）。
+ * - [key]：表单字段的 configStore key，或 BUTTON 的 action id
+ * - [value]：当前值（面板由插件动态提供；设置页初始读 configStore[key]）
+ * - [options]：SELECT / MULTI_SELECT 静态选项（空则宿主经 [IPluginConfigurable.getOptions] 动态拉取）
+ * - [section]：设置页分组名
+ * - [required]：设置页必填校验（SECRET 必填缺失时禁止保存）
+ */
+data class UiNode(
+    val type: UiNodeType,
+    val key: String? = null,
+    val label: String? = null,
+    val value: String? = null,
     val defaultValue: String? = null,
     val options: List<String> = emptyList(),
+    val placeholder: String? = null,
     val helpText: String? = null,
+    /** METRIC 单位。 */
+    val unit: String? = null,
+    /** 文本样式（如 "caption"）。 */
+    val style: String? = null,
     val section: String? = null,
-    val required: Boolean = true,
-    /**
-     * 动作标识（仅 [PluginFieldType.BUTTON] 使用）：点击按钮时触发宿主动作，
-     * 通常为插件 Lua 导出的函数名（如 "testConnection"）。
-     */
-    val action: String? = null
+    val required: Boolean = false,
 )
 
 interface IPluginConfigurable {
-    fun getSettingsSchema(): List<PluginSettingField> = emptyList()
+    fun getSettingsSchema(): List<UiNode> = emptyList()
 
     /**
-     * 动态选项：表单渲染 SELECT / MULTI_SELECT 时，若 [PluginSettingField.options]
+     * 动态选项：表单渲染 SELECT / MULTI_SELECT 时，若 [UiNode.options]
      * 为空则调用本方法异步拉取（插件自行实现，如模型列表等运行时接口数据）。
      * 返回 null 表示无动态选项。
      */
     fun getOptions(key: String): List<String>? = null
 
     /**
-     * 处理表单 BUTTON 字段点击（action 见 [PluginSettingField.action]）。
+     * 处理表单 BUTTON 节点点击（key 见 [UiNode.key]）。
      *
      * 默认实现：把 [action] 当作插件 Lua 导出的函数名调用，返回其返回值
      * （nil/空 = 成功，否则为错误消息）。

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/CandidateTransform.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/CandidateTransform.kt
@@ -1,0 +1,48 @@
+package com.kingzcheung.xime.plugin.core.lua
+
+/**
+ * 候选词变换（capabilities.candidate_transform）的请求/响应模型。
+ *
+ * 交互语义：PULL + SYNC（宿主在 key-processing 线程同步调用插件 transformCandidates，
+ * 硬超时 15ms，超时/报错回退原始候选；敏感输入框不产生请求）。
+ * 这是首个接入输入主流程（hotPath）的能力，见 docs/plugin-capability-registry.md §5。
+ */
+
+/** 引擎候选快照（与宿主 app 层 RimeCandidate 解耦的最小结构）。 */
+data class CandidateTransformCandidate(
+    val text: String,
+    val comment: String,
+)
+
+/** 变换请求：当前编码与引擎候选快照。 */
+data class CandidateTransformRequest(
+    /** 原始键入串（无分隔符）。 */
+    val inputText: String,
+    /** 引擎回显（带分隔符，如 ni'hao），可能为空。 */
+    val preedit: String,
+    /** 当前引擎候选（ascii 过滤前的原始数组，宿主在非 ascii + 非 T9 场景才发起请求）。 */
+    val candidates: List<CandidateTransformCandidate>,
+    val asciiMode: Boolean,
+)
+
+/** 插件响应中的单个候选项：引用引擎候选（engineIndex）或插件自有文本（text）二选一。 */
+data class CandidateTransformItem(
+    /** 引用引擎候选的 0 基索引；null 表示插件自有候选。 */
+    val engineIndex: Int?,
+    /** 插件候选的上屏文本（engineIndex == null 时有效）。 */
+    val text: String?,
+    /** 可选注释；engineIndex 项用于覆盖显示注释。 */
+    val comment: String?,
+)
+
+/** 变换调用结果。 */
+sealed interface CandidateTransformOutcome {
+    /** 插件不干预（未导出函数 / 返回 nil / 返回空列表）。 */
+    data object NoResponse : CandidateTransformOutcome
+
+    /** 调用失败（超时 / Lua 报错 / 响应格式错误）：宿主回退原始候选；调用方累计失败次数熔断。 */
+    data object Failed : CandidateTransformOutcome
+
+    /** 变换成功（结构解析通过；语义校验——越界/重复 engineIndex——由宿主映射层处理）。 */
+    data class Success(val items: List<CandidateTransformItem>) : CandidateTransformOutcome
+}

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/ClipboardHostApi.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/ClipboardHostApi.kt
@@ -1,0 +1,15 @@
+package com.kingzcheung.xime.plugin.core.lua
+
+/**
+ * 宿主剪贴板只读 API（Lua `host.clipboard`）。
+ *
+ * 权限门禁：仅当插件 manifest 声明 `capabilities.clipboard_read: true` 时，
+ * 宿主才注入本 API（未声明时 `host.clipboard` 不存在）。
+ * 剪贴板内容是用户复制数据，插件外发仍受网络三重门（declaredHosts → 授权 →
+ * 白名单强校验）约束；敏感输入框的候选场景由 hotPath 调用链短路兜底。
+ */
+interface ClipboardHostApi {
+
+    /** 当前剪贴板文本（非文本内容/空/无权限返回 null）。 */
+    fun getText(): String?
+}

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/LuaPluginAdapter.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/LuaPluginAdapter.kt
@@ -3,8 +3,8 @@ package com.kingzcheung.xime.plugin.core.lua
 import com.kingzcheung.xime.plugin.core.api.IPluginEntryClass
 import com.kingzcheung.xime.plugin.core.api.PluginIcon
 import com.kingzcheung.xime.plugin.core.config.IPluginConfigurable
-import com.kingzcheung.xime.plugin.core.config.PluginFieldType
-import com.kingzcheung.xime.plugin.core.config.PluginSettingField
+import com.kingzcheung.xime.plugin.core.config.UiNode
+import com.kingzcheung.xime.plugin.core.config.UiNodeType
 import com.kingzcheung.xime.plugin.core.lua.sdk.LuaPluginContract
 import com.kingzcheung.xime.plugin.core.model.PluginContext
 import org.luaj.vm2.LuaValue
@@ -19,25 +19,12 @@ open class LuaPluginAdapter(
     protected val pluginContext: PluginContext
 ) : IPluginEntryClass, IPluginConfigurable {
 
-    override fun getSettingsSchema(): List<PluginSettingField> {
+    override fun getSettingsSchema(): List<UiNode> {
         val result = runtime.call("getSettingsSchema")
         if (!result.istable()) return emptyList()
-        return LuaScriptRuntime.tableToList(result).mapNotNull { field ->
-            val map = LuaScriptRuntime.tableToMap(field)
-            val key = map["key"]?.tojstring() ?: return@mapNotNull null
-            PluginSettingField(
-                key = key,
-                label = map["label"]?.tojstring() ?: key,
-                type = parseFieldType(map["type"]?.tojstring()),
-                placeholder = map["placeholder"]?.tojstring(),
-                defaultValue = map["defaultValue"]?.tojstring(),
-                options = stringList(map["options"] ?: LuaValue.NIL),
-                helpText = map["helpText"]?.tojstring(),
-                section = map["section"]?.tojstring(),
-                required = map["required"]?.toboolean() ?: true,
-                action = map["action"]?.tojstring()
-            )
-        }
+        // 设置字段必须带 key（configStore 绑定）；无 key 的展示节点（SECTION/DIVIDER 等）
+        // 由渲染层容忍，这里仅过滤无法绑定的节点
+        return parseUiNodes(result).filter { !it.key.isNullOrBlank() }
     }
 
     override suspend fun onAction(action: String): String? {
@@ -54,15 +41,53 @@ open class LuaPluginAdapter(
         return stringList(result)
     }
 
-    private fun parseFieldType(type: String?): PluginFieldType = when (type) {
-        "textarea" -> PluginFieldType.TEXTAREA
-        "secret" -> PluginFieldType.SECRET
-        "select" -> PluginFieldType.SELECT
-        "multi_select" -> PluginFieldType.MULTI_SELECT
-        "switch" -> PluginFieldType.SWITCH
-        "number" -> PluginFieldType.NUMBER
-        "button" -> PluginFieldType.BUTTON
-        else -> PluginFieldType.TEXT
+    /**
+     * 统一声明式 UI 节点解析（设置表单 getSettingsSchema 与面板 getPanelState.ui 共用一套
+     * 契约）。Lua 节点 table → [UiNode]，字段：
+     * `{ type, key?, label?, value?, defaultValue?, options?, placeholder?, helpText?,
+     *   unit?, style?, section?, required? }`。
+     *
+* 旧字段名兼容（v0.2.0 存量插件）：title→label、content→value、actionId→key、
+ * type 的 "action" → BUTTON、BUTTON 的 action→key。未知 type 丢弃。
+     * 节点数上限 [MAX_UI_NODES]（防插件撑爆面板/表单）。
+     */
+    protected fun parseUiNodes(value: LuaValue): List<UiNode> {
+        if (!value.istable()) return emptyList()
+        val nodes = ArrayList<UiNode>()
+        for (node in LuaScriptRuntime.tableToList(value)) {
+            if (!node.istable()) continue
+            val m = LuaScriptRuntime.tableToMap(node)
+            nodes += UiNode(
+                type = parseUiNodeType(m["type"]?.tojstring()),
+                key = (m["key"] ?: m["actionId"] ?: m["action"])?.tojstring()?.takeIf { it.isNotBlank() },
+                label = (m["label"] ?: m["title"])?.tojstring(),
+                value = (m["value"] ?: m["content"])?.tojstring(),
+                defaultValue = m["defaultValue"]?.tojstring(),
+                options = stringList(m["options"] ?: LuaValue.NIL),
+                placeholder = m["placeholder"]?.tojstring(),
+                helpText = m["helpText"]?.tojstring(),
+                unit = m["unit"]?.tojstring(),
+                style = m["style"]?.tojstring(),
+                section = m["section"]?.tojstring(),
+                required = m["required"]?.toboolean() ?: false,
+            )
+            if (nodes.size >= MAX_UI_NODES) break
+        }
+        return nodes
+    }
+
+    private fun parseUiNodeType(type: String?): UiNodeType = when (type?.lowercase()) {
+        "textarea" -> UiNodeType.TEXTAREA
+        "secret" -> UiNodeType.SECRET
+        "select" -> UiNodeType.SELECT
+        "multi_select" -> UiNodeType.MULTI_SELECT
+        "switch" -> UiNodeType.SWITCH
+        "number" -> UiNodeType.NUMBER
+        "action", "button" -> UiNodeType.BUTTON // 旧契约 "action" 兼容
+        "section" -> UiNodeType.SECTION
+        "metric" -> UiNodeType.METRIC
+        "divider" -> UiNodeType.DIVIDER
+        else -> UiNodeType.TEXT // 未知 type 降级为普通文本
     }
 
     private fun stringList(value: LuaValue): List<String> {
@@ -101,7 +126,7 @@ open class LuaPluginAdapter(
     open fun isConfigured(): Boolean {
         val schema = getSettingsSchema()
         if (schema.isEmpty()) return true
-        return schema.none { it.required && pluginContext.configStore.get(it.key).isNullOrBlank() }
+        return schema.none { it.required && it.key != null && pluginContext.configStore.get(it.key).isNullOrBlank() }
     }
 
     /**
@@ -149,5 +174,8 @@ open class LuaPluginAdapter(
     companion object {
         const val FN_GET_EMOJIS = LuaPluginContract.FN_GET_EMOJIS
         const val FN_GET_CATEGORIES = LuaPluginContract.FN_GET_CATEGORIES
+
+        /** 声明式 UI 节点数上限（防插件撑爆面板/设置表单）。 */
+        private const val MAX_UI_NODES = 64
     }
 }

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/LuaScriptRuntime.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/LuaScriptRuntime.kt
@@ -50,6 +50,8 @@ class LuaScriptRuntime(
     private val httpHostApi: com.kingzcheung.xime.plugin.core.lua.http.HttpHostApi? = null,
     private val cryptoHostApi: com.kingzcheung.xime.plugin.core.lua.crypto.CryptoHostApi? = null,
     private val sseHostApi: com.kingzcheung.xime.plugin.core.lua.http.SseHostApi? = null,
+    private val quickSendHostApi: QuickSendHostApi? = null,
+    private val clipboardHostApi: ClipboardHostApi? = null,
     private val callTimeoutMs: Long = CALL_TIMEOUT_MS,
     private val callbackTimeoutMs: Long = CALLBACK_TIMEOUT_MS
 ) {
@@ -63,6 +65,13 @@ class LuaScriptRuntime(
 
         /** 网络回调（SSE/WS 事件）超时：回调应短促，恶意死循环回调会占住执行线程。 */
         private const val CALLBACK_TIMEOUT_MS = 5_000L
+
+        /** 候选词变换（hotPath 能力）超时：调用发生在按键路径，超时即回退原始候选
+         *  （不中毒——由调用方按连续失败次数熔断；15ms 足够纯内存计算的插件完成）。 */
+        const val TRANSFORM_TIMEOUT_MS = 15L
+
+        /** 候选词变换响应候选总数上限（超限截断，防插件撑爆候选栏）。 */
+        const val TRANSFORM_MAX_CANDIDATES = 20
 
         /** zlib.gunzip 解压输出上限（防压缩炸弹撑爆内存）。 */
         private const val MAX_GUNZIP_OUTPUT_BYTES = 16 * 1024 * 1024
@@ -312,6 +321,76 @@ class LuaScriptRuntime(
         return table
     }
 
+    // ---- 候选词变换（manifest capabilities.candidate_transform 声明后宿主按需同步调用） ----
+
+    /**
+     * 同步调用插件 transformCandidates(request)。
+     *
+     * 线程契约：调用方为 key-processing 线程（hotPath），本方法阻塞等待至多
+     * [TRANSFORM_TIMEOUT_MS]（luaLock 竞争可能额外等待，由调用方熔断兜底）。
+     * 超时/报错不中毒（插件可能只是偶发慢），由调用方按连续失败熔断。
+     */
+    fun transformCandidates(request: CandidateTransformRequest): CandidateTransformOutcome {
+        if (!loaded) return CandidateTransformOutcome.NoResponse
+        val reqTable = LuaValue.tableOf()
+        reqTable.set("input_text", LuaValue.valueOf(request.inputText))
+        reqTable.set("preedit", LuaValue.valueOf(request.preedit))
+        reqTable.set("ascii_mode", LuaValue.valueOf(request.asciiMode))
+        val cands = LuaValue.tableOf()
+        request.candidates.forEachIndexed { i, c ->
+            val t = LuaValue.tableOf()
+            t.set("text", LuaValue.valueOf(c.text))
+            t.set("comment", LuaValue.valueOf(c.comment))
+            cands.set(i + 1, t)
+        }
+        reqTable.set("candidates", cands)
+        return try {
+            // 函数不存在 / 插件返回 nil → block 返回 NIL；runGuarded 返回 null 仅表示超时
+            val result = runGuarded(TRANSFORM_TIMEOUT_MS, poisonOnTimeout = false) {
+                synchronized(luaLock) {
+                    if (!loaded) return@runGuarded LuaValue.NIL
+                    val fn = pluginTable.get(LuaPluginContract.FN_TRANSFORM_CANDIDATES)
+                    if (!fn.isfunction()) return@runGuarded LuaValue.NIL
+                    fn.invoke(reqTable).arg1()
+                }
+            }
+            when {
+                result == null -> CandidateTransformOutcome.Failed
+                result.isnil() -> CandidateTransformOutcome.NoResponse
+                result.istable() -> parseTransformResponse(result)
+                else -> CandidateTransformOutcome.Failed
+            }
+        } catch (e: Exception) {
+            api.log("transformCandidates 调用失败: ${e.message}")
+            CandidateTransformOutcome.Failed
+        }
+    }
+
+    /** 解析 { candidates = { {engine_index=..} | {text=.., comment=..} } }。
+     *  candidates 字段缺失/非 table = 格式错误（Failed）；
+     *  空列表或全部项非法 = 不干预（NoResponse）。 */
+    private fun parseTransformResponse(result: LuaValue): CandidateTransformOutcome {
+        val listTable = result.get("candidates")
+        if (!listTable.istable()) return CandidateTransformOutcome.Failed
+        val items = mutableListOf<CandidateTransformItem>()
+        for (v in tableToList(listTable)) {
+            if (!v.istable()) continue
+            val comment = v.get("comment").takeIf { it.isstring() }?.tojstring()
+            val engineIdx = v.get("engine_index")
+            val text = v.get("text")
+            when {
+                engineIdx.isnumber() ->
+                    items.add(CandidateTransformItem(engineIndex = engineIdx.toint(), text = null, comment = comment))
+                text.isstring() && text.tojstring().isNotEmpty() ->
+                    items.add(CandidateTransformItem(engineIndex = null, text = text.tojstring(), comment = comment))
+                else -> continue // 非法项丢弃（既非引擎引用也非文本候选）
+            }
+            if (items.size >= TRANSFORM_MAX_CANDIDATES) break
+        }
+        if (items.isEmpty()) return CandidateTransformOutcome.NoResponse
+        return CandidateTransformOutcome.Success(items)
+    }
+
     /** 把 SSE 会话的流事件转发为 Lua 回调（宿主后台线程调用）。 */
     private fun invokeSseCallback(sessionId: Int, name: String, text: String) {
         val callbacks = sseCallbacks[sessionId] ?: return
@@ -546,7 +625,45 @@ class LuaScriptRuntime(
         // ASR 结果回传桥：插件 Lua 解析结果后通知宿主后端（协议无关的接口桥）
         host.set("asr", buildAsrEmitTable())
 
+        // 快捷发送只读 API（manifest quick_send_read 声明后注入，未声明 host.quickSend 不存在）
+        if (quickSendHostApi != null) {
+            host.set("quickSend", buildQuickSendTable())
+        }
+
+        // 剪贴板只读 API（manifest clipboard_read 声明后注入，未声明 host.clipboard 不存在）
+        if (clipboardHostApi != null) {
+            host.set("clipboard", buildClipboardTable())
+        }
+
         return host
+    }
+
+    private fun buildQuickSendTable(): LuaTable {
+        val quickSend = LuaTable()
+        quickSend.set("list", luaFunction { _ ->
+            val arr = LuaTable()
+            quickSendHostApi?.list()?.forEachIndexed { i, item ->
+                val m = LuaTable()
+                // Long → double：luaj number 即 double（Lua 5.1 语义），毫秒时间戳远低于 2^53
+                m.set("id", LuaValue.valueOf(item.id.toDouble()))
+                m.set("text", LuaValue.valueOf(item.text))
+                m.set("code", LuaValue.valueOf(item.code))
+                m.set("timestamp", LuaValue.valueOf(item.timestamp.toDouble()))
+                m.set("isPinned", LuaValue.valueOf(item.isPinned))
+                arr.set(i + 1, m)
+            }
+            arr
+        })
+        return quickSend
+    }
+
+    private fun buildClipboardTable(): LuaTable {
+        val clipboard = LuaTable()
+        clipboard.set("get", luaFunction { _ ->
+            val text = clipboardHostApi?.getText()
+            if (text.isNullOrEmpty()) LuaValue.NIL else LuaValue.valueOf(text)
+        })
+        return clipboard
     }
 
     private fun buildWsTable(): LuaTable {

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/LuaToolPluginAdapter.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/LuaToolPluginAdapter.kt
@@ -29,10 +29,7 @@ class LuaToolPluginAdapter(
         val map = LuaScriptRuntime.tableToMap(result)
         val input = map["inputText"]?.tojstring()?.takeIf { it.isNotBlank() } ?: inputText
         val uiRaw = map["ui"]
-        val ui = if (uiRaw != null && uiRaw.istable()) {
-            @Suppress("UNCHECKED_CAST")
-            (LuaScriptRuntime.tableToJava(uiRaw) as? List<Map<*, *>>)
-        } else null
+        val ui = if (uiRaw != null && uiRaw.istable()) parseUiNodes(uiRaw) else null
         return ToolPanelState(
             inputText = input,
             items = parseResultItems(map["items"] ?: LuaValue.NIL, "getPanelState.items"),

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/PluginEvent.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/PluginEvent.kt
@@ -35,5 +35,14 @@ data class PluginEvent(
 
         /** FIELD_SESSION_TOTAL_COMMITS：宿主进程累计上屏提交次数。 */
         const val FIELD_SESSION_TOTAL_COMMITS = "session_total_commits"
+
+        /**
+         * 快捷发送列表变更：payload = { count: Int }。
+         * 只通知变更（conflated 只保最新），插件收到后调 host.quickSend.list() 重新拉取。
+         */
+        const val TYPE_QUICK_SEND_CHANGED = "quick_send_changed"
+
+        /** FIELD_COUNT：变更后的快捷发送条目数。 */
+        const val FIELD_COUNT = "count"
     }
 }

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/QuickSendHostApi.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/QuickSendHostApi.kt
@@ -1,0 +1,32 @@
+package com.kingzcheung.xime.plugin.core.lua
+
+/**
+ * 宿主快捷发送只读 API（Lua `host.quickSend`）。
+ *
+ * 权限门禁：仅当插件 manifest 声明 `capabilities.quick_send_read: true` 时，
+ * 宿主才注入本 API（未声明时 `host.quickSend` 不存在）。
+ * 数据来自宿主 ClipboardManager 单例的内存缓存（Room 的 isQuickSend 子集），
+ * 同步读取零 IO，可在 hotPath（候选词变换）内调用。
+ */
+interface QuickSendHostApi {
+
+    /**
+     * 列出快捷发送条目（timestamp 降序，最近优先；宿主上限 20 条）。
+     * 只读快照，宿主数据变更时经 `quick_send_changed` 事件通知插件重新拉取。
+     */
+    fun list(): List<QuickSendItem>
+}
+
+/** Quick-send entry snapshot. */
+data class QuickSendItem(
+    /** 数据库 id。 */
+    val id: Long,
+    /** 上屏文本。 */
+    val text: String,
+    /** 触发编码（如 dh）：空 = 不参与编码匹配，仅内容命中。 */
+    val code: String = "",
+    /** 最近使用时间戳（毫秒）。 */
+    val timestamp: Long,
+    /** 是否用户置顶。 */
+    val isPinned: Boolean,
+)

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/sdk/LuaPluginContract.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/sdk/LuaPluginContract.kt
@@ -21,13 +21,22 @@ package com.kingzcheung.xime.plugin.core.lua.sdk
  *   - imageUrl 可通过 host.resource.path() 获得（图片渲染由宿主完成）
  *
  * ### tool 工具
- * - `getPanelState(inputText)` -> { inputText?, items: [], loading? }
+ * - `getPanelState(inputText)` -> { inputText?, items: [], loading?, ui? }
  * - `onPanelInput(text)` 面板输入变化通知
  * - `onPanelAction(actionId)` 面板操作事件（宿主保留 `generate`）
  * - `onPanelItemClick(itemId)` 点候选上屏
+ * - `ui`（可选，display: passive 时渲染）：统一声明式 UI 节点数组（UiNode 模型），
+ *   节点 = `{ type, key?, label?, value?, defaultValue?, options?, placeholder?, helpText?,
+ *   unit?, style?, section?, required? }`。
+ *   面板展示白名单 type：`section(label)` / `text(value, style?)` / `metric(label, value, unit?)` /
+ *   `divider` / `button(key, label)`；未知 type 降级为文本；节点数上限 64。
+ *   旧字段名（title/content/actionId、type=action）解析层兼容（v0.2.0 存量插件）。
  *
- * ### speech 语音（规划中）
- * - `getSettingsSchema()` 配置字段声明（与 manifest.configSchema 等价）
+ * ### 配置表单（getSettingsSchema，统一 UiNode 模型）
+ * - `getSettingsSchema()` -> UiNode[]；表单字段 type：
+ *   `text` / `textarea` / `secret` / `select` / `multi_select` / `switch` / `number` / `button`
+ *   - 字段必须带 `key`（configStore 绑定）；`options` 为空时宿主经 `getOptions(key)` 动态拉取
+ *   - `button` 点击 → 宿主调用插件导出函数（key 即函数名），nil/空返回 = 成功
  * - `getOptions(key)` 动态选项（如 ASR 模型列表）
  * - `start()` / `pushPcm()` / `stop()` 音频流式识别（网络 API 由宿主白名单提供）
  *
@@ -41,6 +50,28 @@ package com.kingzcheung.xime.plugin.core.lua.sdk
  *   - 通道为"只保最新"（conflated）：消费慢时中间事件被合并丢弃
  *   - 敏感输入框（密码类）不产生上述任何事件
  *   - 函数未导出时事件被静默丢弃，不影响其他能力
+ *
+ * ### 候选词变换（可选，manifest 声明 `capabilities.candidate_transform: true` 才调用）
+ * - `transformCandidates(request)` -> { candidates: item[] } 或 nil（不干预）
+ *   `request`: { input_text: string, preedit: string, ascii_mode: bool,
+ *                candidates: { { text: string, comment: string }, ... } }
+ *   每项 item 二选一：
+ *   - { engine_index: int }  引用引擎候选（0 基，越界/重复被丢弃），comment 可选覆盖显示注释
+ *   - { text: string, comment?: string } 插件候选，用户点击后直接上屏 text
+ *   - 响应候选总数上限 20（超限截断）；返回 nil / 超时 / 报错 / 格式错误 → 宿主回退原始候选
+ *   - 调用发生在按键路径（key-processing 线程，硬超时 15ms）：实现必须纯内存计算，
+ *     禁止网络/文件 IO，连续超时 3 次本会话禁用
+ *
+ * ### 快捷发送只读（可选，manifest 声明 `capabilities.quick_send_read: true` 才注入）
+ * - `host.quickSend.list()` -> { { id, text, code, timestamp, isPinned }, ... }
+ *   快捷发送条目（宿主 Room 的 isQuickSend 子集，内存缓存同步读取，timestamp 降序，
+ *   宿主上限 20 条）。`code` 为触发编码（如 dh，空 = 不参与编码匹配）。
+ *   列表变更时宿主投递 `quick_send_changed` 事件（payload = { count }），
+ *   插件收到后重新拉取；未声明该能力的插件 `host.quickSend` 为 nil。
+ *
+ * ### 剪贴板只读（可选，manifest 声明 `capabilities.clipboard_read: true` 才注入）
+ * - `host.clipboard.get()` -> string 或 nil（当前剪贴板文本；非文本/空/无权限为 nil）
+ *   未声明该能力的插件 `host.clipboard` 为 nil。
  *
  * ## 数据格式
  * Lua 返回值一律使用 Lua table（数组或 map），宿主统一做 table -> Kotlin 转换；
@@ -57,7 +88,7 @@ package com.kingzcheung.xime.plugin.core.lua.sdk
 object LuaPluginContract {
 
     /** SDK 版本（宿主注入的 host.sdkVersion）。插件 manifest 可声明 `sdkVersion` 声明所需 SDK 版本。 */
-    const val SDK_VERSION = "0.2.0"
+    const val SDK_VERSION = "0.3.0"
 
     // ---- 宿主注入的全局对象 ----
     const val GLOBAL_HOST = "host"
@@ -68,6 +99,9 @@ object LuaPluginContract {
 
     // ---- 事件（可选：manifest capabilities.events 声明后才投递） ----
     const val FN_ON_PLUGIN_EVENT = "onPluginEvent"
+
+    // ---- 候选词变换（可选：manifest capabilities.candidate_transform 声明后才调用） ----
+    const val FN_TRANSFORM_CANDIDATES = "transformCandidates"
 
     // ---- emoji ----
     const val FN_GET_CATEGORIES = "getCategories"

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/model/PluginCapabilities.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/model/PluginCapabilities.kt
@@ -16,6 +16,19 @@ data class PluginCapabilities(
     val clipboardSync: ClipboardSyncCapabilities? = null,
     /** 下行事件订阅声明（如 "input_changed"）：未声明的事件宿主不投递，通道也不建立。 */
     val events: List<String> = emptyList(),
+    /** 候选词变换能力（manifest 声明 `candidate_transform: true`）：rime 返回候选后、
+     *  候选栏渲染前，宿主同步调用插件 transformCandidates 修改候选；首个接入输入
+     *  主流程（hotPath）的能力，硬超时 15ms + 敏感输入短路 + 连续超时熔断。 */
+    @kotlinx.serialization.SerialName("candidate_transform")
+    val candidateTransform: Boolean = false,
+    /** 快捷发送只读能力（manifest 声明 `quick_send_read: true`）：声明后宿主注入
+     *  `host.quickSend`（list()），并允许订阅 `quick_send_changed` 事件。 */
+    @kotlinx.serialization.SerialName("quick_send_read")
+    val quickSendRead: Boolean = false,
+    /** 剪贴板只读能力（manifest 声明 `clipboard_read: true`）：声明后宿主注入
+     *  `host.clipboard`（getText()）。 */
+    @kotlinx.serialization.SerialName("clipboard_read")
+    val clipboardRead: Boolean = false,
 ) {
     companion object {
         val EMPTY = PluginCapabilities()

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/PluginManager.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/PluginManager.kt
@@ -57,6 +57,21 @@ object PluginManager {
     @Volatile
     var cryptoHostApiFactory: (() -> com.kingzcheung.xime.plugin.core.lua.crypto.CryptoHostApi)? = null
 
+    /**
+     * 宿主快捷发送只读 API 提供者（app 层注入，读 ClipboardManager 内存缓存）。
+     * 仅当插件 manifest 声明 `capabilities.quick_send_read: true` 时，
+     * 生命周期管理器才会调用本工厂（未声明插件拿不到 host.quickSend）。
+     */
+    @Volatile
+    var quickSendHostApiFactory: ((pluginId: String) -> com.kingzcheung.xime.plugin.core.lua.QuickSendHostApi)? = null
+
+    /**
+     * 宿主剪贴板只读 API 提供者（app 层注入，读系统剪贴板）。
+     * 仅当插件 manifest 声明 `capabilities.clipboard_read: true` 时注入。
+     */
+    @Volatile
+    var clipboardHostApiFactory: ((pluginId: String) -> com.kingzcheung.xime.plugin.core.lua.ClipboardHostApi)? = null
+
     private var frameworkContext: PluginFrameworkContext? = null
     private val _loadedPluginsFlow = MutableStateFlow<Map<String, LoadedPluginInfo>>(emptyMap())
     private val _pluginInstancesFlow = MutableStateFlow<Map<String, IPluginEntryClass>>(emptyMap())

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/InstallerManager.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/InstallerManager.kt
@@ -77,7 +77,16 @@ internal data class CapabilitiesConfig(
     val tool: ToolCapabilitiesConfig? = null,
     val clipboardSync: ClipboardSyncCapabilitiesConfig? = null,
     /** 下行事件订阅（如 "input_changed"），小写 snake_case。 */
-    val events: List<String> = emptyList()
+    val events: List<String> = emptyList(),
+    /** 候选词变换能力（hotPath，硬超时 15ms）。 */
+    @kotlinx.serialization.SerialName("candidate_transform")
+    val candidateTransform: Boolean = false,
+    /** 快捷发送只读能力（注入 host.quickSend）。 */
+    @kotlinx.serialization.SerialName("quick_send_read")
+    val quickSendRead: Boolean = false,
+    /** 剪贴板只读能力（注入 host.clipboard）。 */
+    @kotlinx.serialization.SerialName("clipboard_read")
+    val clipboardRead: Boolean = false
 )
 
 @Serializable
@@ -137,7 +146,10 @@ private fun CapabilitiesConfig.toModel(): com.kingzcheung.xime.plugin.core.model
                 protocols = it.protocols.filter { p -> p.isNotBlank() }
             )
         },
-        events = events.map { it.trim().lowercase() }.filter { it.isNotBlank() }.distinct()
+        events = events.map { it.trim().lowercase() }.filter { it.isNotBlank() }.distinct(),
+        candidateTransform = candidateTransform,
+        quickSendRead = quickSendRead,
+        clipboardRead = clipboardRead
     )
 }
 

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/InstallerManager.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/InstallerManager.kt
@@ -75,6 +75,7 @@ internal data class CapabilitiesConfig(
     val emoji: EmojiCapabilitiesConfig? = null,
     val speech: SpeechCapabilitiesConfig? = null,
     val tool: ToolCapabilitiesConfig? = null,
+    @kotlinx.serialization.SerialName("clipboard_sync")
     val clipboardSync: ClipboardSyncCapabilitiesConfig? = null,
     /** 下行事件订阅（如 "input_changed"），小写 snake_case。 */
     val events: List<String> = emptyList(),

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/XmlManager.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/XmlManager.kt
@@ -245,6 +245,15 @@ class XmlManager(private val context: Application) {
         if (cap.events.isNotEmpty()) {
             root["events"] = cap.events
         }
+        if (cap.candidateTransform) {
+            root["candidateTransform"] = true
+        }
+        if (cap.quickSendRead) {
+            root["quickSendRead"] = true
+        }
+        if (cap.clipboardRead) {
+            root["clipboardRead"] = true
+        }
         return com.kingzcheung.xime.plugin.core.lua.sdk.SimpleJson.encode(root) ?: ""
     }
 
@@ -283,7 +292,10 @@ class XmlManager(private val context: Application) {
                         protocols = (m["protocols"] as? List<*>)?.mapNotNull { it as? String } ?: emptyList()
                     )
                 },
-                events = (root["events"] as? List<*>)?.mapNotNull { it as? String } ?: emptyList()
+                events = (root["events"] as? List<*>)?.mapNotNull { it as? String } ?: emptyList(),
+                candidateTransform = (root["candidateTransform"] as? Boolean) ?: false,
+                quickSendRead = (root["quickSendRead"] as? Boolean) ?: false,
+                clipboardRead = (root["clipboardRead"] as? Boolean) ?: false
             )
         }.getOrNull()
     }

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/lifecycle/PluginLifecycleManager.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/lifecycle/PluginLifecycleManager.kt
@@ -155,7 +155,14 @@ class PluginLifecycleManager(
                 wsHostApi = PluginManager.wsHostApiFactory?.invoke(plugin.id),
                 httpHostApi = PluginManager.httpHostApiFactory?.invoke(plugin.id),
                 cryptoHostApi = PluginManager.cryptoHostApiFactory?.invoke(),
-                sseHostApi = PluginManager.sseHostApiFactory?.invoke(plugin.id)
+                sseHostApi = PluginManager.sseHostApiFactory?.invoke(plugin.id),
+                // 数据类 API 按 manifest 能力声明门禁注入：未声明连实例都不创建（host 表不挂）
+                quickSendHostApi = if (plugin.capabilities?.quickSendRead == true) {
+                    PluginManager.quickSendHostApiFactory?.invoke(plugin.id)
+                } else null,
+                clipboardHostApi = if (plugin.capabilities?.clipboardRead == true) {
+                    PluginManager.clipboardHostApiFactory?.invoke(plugin.id)
+                } else null
             )
             // 按能力声明启用下行事件通道：未声明 events 的插件零开销、零行为变化。
             runtime.initEvents(plugin.capabilities?.events?.toSet() ?: emptySet())

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/api/AsrPluginTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/api/AsrPluginTest.kt
@@ -2,8 +2,8 @@ package com.kingzcheung.xime.plugin.core.api
 
 import android.content.Context
 import com.kingzcheung.xime.plugin.core.config.IPluginConfigurable
-import com.kingzcheung.xime.plugin.core.config.PluginFieldType
-import com.kingzcheung.xime.plugin.core.config.PluginSettingField
+import com.kingzcheung.xime.plugin.core.config.UiNode
+import com.kingzcheung.xime.plugin.core.config.UiNodeType
 import com.kingzcheung.xime.plugin.core.model.PluginCapabilities
 import com.kingzcheung.xime.plugin.core.model.PluginContext
 import org.junit.Assert.assertEquals
@@ -75,19 +75,19 @@ class AsrPluginDefaultImplTest {
     @Test
     fun `schema can be overridden with SECRET apiKey field`() {
         val plugin = object : FakeAsrPlugin() {
-            override fun getSettingsSchema(): List<PluginSettingField> =
+            override fun getSettingsSchema(): List<UiNode> =
                 listOf(
-                    PluginSettingField(
+                    UiNode(
                         key = "apiKey",
                         label = "API Key",
-                        type = PluginFieldType.SECRET
+                        type = UiNodeType.SECRET,
                     )
                 )
         }
 
         val field = plugin.getSettingsSchema().first()
         assertEquals("apiKey", field.key)
-        assertEquals(PluginFieldType.SECRET, field.type)
+        assertEquals(UiNodeType.SECRET, field.type)
         assertTrue(plugin.getSettingsSchema().isNotEmpty())
     }
 

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/config/PluginConfigStoreTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/config/PluginConfigStoreTest.kt
@@ -75,41 +75,42 @@ class NoopPluginConfigStoreTest {
     }
 }
 
-class PluginSettingFieldTest {
+class UiNodeTest {
 
     @Test
-    fun `PluginSettingField has correct defaults`() {
-        val field = PluginSettingField(key = "apiKey", label = "API Key", type = PluginFieldType.SECRET)
+    fun `UiNode has correct defaults`() {
+        val field = UiNode(key = "apiKey", label = "API Key", type = UiNodeType.SECRET)
 
         assertEquals("apiKey", field.key)
         assertEquals("API Key", field.label)
-        assertEquals(PluginFieldType.SECRET, field.type)
+        assertEquals(UiNodeType.SECRET, field.type)
         assertNull(field.placeholder)
         assertNull(field.defaultValue)
         assertTrue(field.options.isEmpty())
         assertNull(field.helpText)
         assertNull(field.section)
-        assertTrue("SECRET 字段默认必填", field.required)
+        assertNull(field.unit)
+        assertNull(field.style)
     }
 
     @Test
-    fun `PluginSettingField can be optional`() {
-        val field = PluginSettingField(
+    fun `UiNode can be required`() {
+        val field = UiNode(
             key = "appKey",
             label = "App Key",
-            type = PluginFieldType.SECRET,
-            required = false
+            type = UiNodeType.SECRET,
+            required = true
         )
 
-        assertFalse(field.required)
+        assertTrue(field.required)
     }
 
     @Test
-    fun `PluginSettingField can specify options for SELECT`() {
-        val field = PluginSettingField(
+    fun `UiNode can specify options for SELECT`() {
+        val field = UiNode(
             key = "region",
             label = "区域",
-            type = PluginFieldType.SELECT,
+            type = UiNodeType.SELECT,
             options = listOf("cn", "intl")
         )
 
@@ -117,11 +118,27 @@ class PluginSettingFieldTest {
     }
 
     @Test
-    fun `PluginSettingField can have defaultValue`() {
-        val field = PluginSettingField(
+    fun `UiNode supports panel display types`() {
+        val section = UiNode(type = UiNodeType.SECTION, label = "统计")
+        val metric = UiNode(type = UiNodeType.METRIC, label = "字数", value = "1024", unit = "字")
+        val divider = UiNode(type = UiNodeType.DIVIDER)
+        val action = UiNode(type = UiNodeType.BUTTON, key = "reset", label = "清零")
+
+        assertEquals("统计", section.label)
+        assertEquals("1024", metric.value)
+        assertEquals("字", metric.unit)
+        assertNull(divider.label)
+        assertEquals("reset", action.key)
+        // 面板展示节点无需 configStore 绑定
+        assertNull(section.key)
+    }
+
+    @Test
+    fun `UiNode can have defaultValue`() {
+        val field = UiNode(
             key = "vad",
             label = "静音判停",
-            type = PluginFieldType.SWITCH,
+            type = UiNodeType.SWITCH,
             defaultValue = "true"
         )
 
@@ -129,29 +146,29 @@ class PluginSettingFieldTest {
     }
 
     @Test
-    fun `PluginSettingField can be MULTI_SELECT with options`() {
-        val field = PluginSettingField(
+    fun `UiNode can be MULTI_SELECT with options`() {
+        val field = UiNode(
             key = "languageHints",
             label = "语言提示",
-            type = PluginFieldType.MULTI_SELECT,
+            type = UiNodeType.MULTI_SELECT,
             options = listOf("zh", "en", "ja")
         )
 
-        assertEquals(PluginFieldType.MULTI_SELECT, field.type)
+        assertEquals(UiNodeType.MULTI_SELECT, field.type)
         assertEquals(listOf("zh", "en", "ja"), field.options)
     }
 
     @Test
-    fun `PluginSettingField can have section`() {
-        val field = PluginSettingField(
+    fun `UiNode can have section`() {
+        val field = UiNode(
             key = "vadSensitivity",
             label = "静音灵敏度",
-            type = PluginFieldType.NUMBER,
+            type = UiNodeType.NUMBER,
             section = "高级"
         )
 
         assertEquals("高级", field.section)
-        assertNull(PluginSettingField("a", "A", PluginFieldType.TEXT).section)
+        assertNull(UiNode(type = UiNodeType.TEXT, key = "a").section)
     }
 
     @Test
@@ -164,8 +181,8 @@ class PluginSettingFieldTest {
     @Test
     fun `PluginConfigurable custom schema is returned`() {
         val configurable = object : IPluginConfigurable {
-            override fun getSettingsSchema(): List<PluginSettingField> =
-                listOf(PluginSettingField("apiKey", "API Key", PluginFieldType.SECRET))
+            override fun getSettingsSchema(): List<UiNode> =
+                listOf(UiNode(key = "apiKey", label = "API Key", type = UiNodeType.SECRET))
         }
 
         assertFalse(configurable.getSettingsSchema().isEmpty())

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaAiPluginTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaAiPluginTest.kt
@@ -276,7 +276,7 @@ class LuaAiPluginTest {
             assertNotNull("$name 应包含 prompt", prompt)
             assertEquals(
                 "$name prompt 应为 textarea 长文本编辑",
-                com.kingzcheung.xime.plugin.core.config.PluginFieldType.TEXTAREA,
+                com.kingzcheung.xime.plugin.core.config.UiNodeType.TEXTAREA,
                 prompt!!.type
             )
         }

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaCandidateTransformTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaCandidateTransformTest.kt
@@ -1,0 +1,247 @@
+package com.kingzcheung.xime.plugin.core.lua
+
+import com.kingzcheung.xime.plugin.core.config.NoopPluginConfigStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * 候选词变换（capabilities.candidate_transform + transformCandidates）桥接：
+ * - Success：engine_index / text 混合项解析、comment 覆盖透传
+ * - NoResponse：未导出函数 / 返回 nil / 空列表
+ * - Failed：超时（hotPath 15ms 不中毒）/ 报错 / 格式错误
+ * - 校验：非法项丢弃、总数上限截断
+ */
+class LuaCandidateTransformTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun writePlugin(lua: String): File {
+        val dir = tmp.newFolder("plugin")
+        File(dir, "main.lua").writeText(lua)
+        return dir
+    }
+
+    private fun runtime(lua: String): LuaScriptRuntime =
+        LuaScriptRuntime("cand-test", writePlugin(lua), "main.lua", NoopPluginConfigStore)
+
+    private fun request(
+        inputText: String = "dh",
+        candidates: List<CandidateTransformCandidate> = listOf(
+            CandidateTransformCandidate("的", ""),
+            CandidateTransformCandidate("到", ""),
+        ),
+    ) = CandidateTransformRequest(
+        inputText = inputText,
+        preedit = inputText,
+        candidates = candidates,
+        asciiMode = false,
+    )
+
+    @Test
+    fun `engine_index 与 text 混合解析 comment 透传`() {
+        val rt = runtime(
+            """
+            local plugin = {}
+            function plugin.transformCandidates(req)
+              return { candidates = {
+                { engine_index = 0, comment = "改注释" },
+                { engine_index = 1 },
+                { text = "18500000000", comment = "手机号" },
+              } }
+            end
+            return plugin
+            """.trimIndent()
+        )
+        assertTrue(rt.load())
+        val outcome = rt.transformCandidates(request())
+        val items = (outcome as CandidateTransformOutcome.Success).items
+        assertEquals(3, items.size)
+        assertEquals(0, items[0].engineIndex)
+        assertEquals("改注释", items[0].comment)
+        assertEquals(1, items[1].engineIndex)
+        assertEquals(null, items[1].comment)
+        assertEquals(null, items[2].engineIndex)
+        assertEquals("18500000000", items[2].text)
+        assertEquals("手机号", items[2].comment)
+        rt.close()
+    }
+
+    @Test
+    fun `请求字段传递 input_text 与 candidates`() {
+        val rt = runtime(
+            """
+            local plugin = {}
+            function plugin.transformCandidates(req)
+              return { candidates = {
+                { text = req.input_text .. ":" .. #req.candidates .. ":" .. tostring(req.ascii_mode) },
+              } }
+            end
+            return plugin
+            """.trimIndent()
+        )
+        assertTrue(rt.load())
+        val outcome = rt.transformCandidates(request(inputText = "dh"))
+        val text = (outcome as CandidateTransformOutcome.Success).items[0].text
+        assertEquals("dh:2:false", text)
+        rt.close()
+    }
+
+    @Test
+    fun `未导出函数返回 NoResponse`() {
+        val rt = runtime("local plugin = {}\nreturn plugin")
+        assertTrue(rt.load())
+        assertEquals(CandidateTransformOutcome.NoResponse, rt.transformCandidates(request()))
+        rt.close()
+    }
+
+    @Test
+    fun `插件返回 nil 表示不干预`() {
+        val rt = runtime(
+            """
+            local plugin = {}
+            function plugin.transformCandidates(req)
+              return nil
+            end
+            return plugin
+            """.trimIndent()
+        )
+        assertTrue(rt.load())
+        assertEquals(CandidateTransformOutcome.NoResponse, rt.transformCandidates(request()))
+        rt.close()
+    }
+
+    @Test
+    fun `空候选列表视为不干预`() {
+        val rt = runtime(
+            """
+            local plugin = {}
+            function plugin.transformCandidates(req)
+              return { candidates = {} }
+            end
+            return plugin
+            """.trimIndent()
+        )
+        assertTrue(rt.load())
+        assertEquals(CandidateTransformOutcome.NoResponse, rt.transformCandidates(request()))
+        rt.close()
+    }
+
+    @Test
+    fun `格式错误返回 Failed`() {
+        val rt = runtime(
+            """
+            local plugin = {}
+            function plugin.transformCandidates(req)
+              return { wrong_field = 1 }
+            end
+            return plugin
+            """.trimIndent()
+        )
+        assertTrue(rt.load())
+        assertEquals(CandidateTransformOutcome.Failed, rt.transformCandidates(request()))
+        rt.close()
+    }
+
+    @Test
+    fun `非法项丢弃（无 text 的非引用项）`() {
+        val rt = runtime(
+            """
+            local plugin = {}
+            function plugin.transformCandidates(req)
+              return { candidates = {
+                { comment = "孤立注释" },
+                { text = "有效" },
+              } }
+            end
+            return plugin
+            """.trimIndent()
+        )
+        assertTrue(rt.load())
+        val items = (rt.transformCandidates(request()) as CandidateTransformOutcome.Success).items
+        assertEquals(1, items.size)
+        assertEquals("有效", items[0].text)
+        rt.close()
+    }
+
+    @Test
+    fun `空 text 项丢弃`() {
+        val rt = runtime(
+            """
+            local plugin = {}
+            function plugin.transformCandidates(req)
+              return { candidates = {
+                { text = "" },
+                { text = "有效" },
+              } }
+            end
+            return plugin
+            """.trimIndent()
+        )
+        assertTrue(rt.load())
+        val items = (rt.transformCandidates(request()) as CandidateTransformOutcome.Success).items
+        assertEquals(1, items.size)
+        rt.close()
+    }
+
+    @Test
+    fun `总数上限截断到 20`() {
+        val rt = runtime(
+            """
+            local plugin = {}
+            function plugin.transformCandidates(req)
+              local out = {}
+              for i = 1, 30 do
+                table.insert(out, { text = "c" .. i })
+              end
+              return { candidates = out }
+            end
+            return plugin
+            """.trimIndent()
+        )
+        assertTrue(rt.load())
+        val items = (rt.transformCandidates(request()) as CandidateTransformOutcome.Success).items
+        assertEquals(20, items.size)
+        assertEquals("c20", items[19].text)
+        rt.close()
+    }
+
+    @Test
+    fun `超时返回 Failed（hotPath 15ms 不中毒）`() {
+        val rt = runtime(
+            """
+            local plugin = {}
+            function plugin.transformCandidates(req)
+              local x = 0
+              while true do x = x + 1 end
+              return nil
+            end
+            return plugin
+            """.trimIndent()
+        )
+        assertTrue(rt.load())
+        val outcome = rt.transformCandidates(request())
+        assertEquals(CandidateTransformOutcome.Failed, outcome)
+        // 不调用 close()：死循环线程不响应中断，close 的 unload 会等满 180s 业务超时
+    }
+
+    @Test
+    fun `Lua 报错返回 Failed`() {
+        val rt = runtime(
+            """
+            local plugin = {}
+            function plugin.transformCandidates(req)
+              error("boom")
+            end
+            return plugin
+            """.trimIndent()
+        )
+        assertTrue(rt.load())
+        assertEquals(CandidateTransformOutcome.Failed, rt.transformCandidates(request()))
+        rt.close()
+    }
+}

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaHostDataApiTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaHostDataApiTest.kt
@@ -1,0 +1,101 @@
+package com.kingzcheung.xime.plugin.core.lua
+
+import com.kingzcheung.xime.plugin.core.config.NoopPluginConfigStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * 宿主数据只读 API（host.quickSend / host.clipboard）桥接：
+ * - 声明式注入：构造传 API → host 表挂出；不传 → host 表不存在（插件内为 nil）
+ * - list() 数据映射（id/text/timestamp/isPinned）
+ * - clipboard.get() 空文本返回 nil
+ */
+class LuaHostDataApiTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun writePlugin(lua: String): File {
+        val dir = tmp.newFolder("plugin")
+        File(dir, "main.lua").writeText(lua)
+        return dir
+    }
+
+    /** 探针插件：把 host API 的观察结果序列化为字符串返回。 */
+    private val probeLua = """
+        local plugin = {}
+        function plugin.probeQuickSend()
+          if host.quickSend == nil then return "nil" end
+          local l = host.quickSend.list()
+          local first = l[1]
+          return #l .. "|" .. first.id .. "|" .. first.text .. "|" .. (first.code or "") .. "|" .. tostring(first.isPinned)
+        end
+        function plugin.probeClipboard()
+          if host.clipboard == nil then return "nil" end
+          local t = host.clipboard.get()
+          return t == nil and "nil" or t
+        end
+        return plugin
+    """.trimIndent()
+
+    private fun newRuntime(
+        quickSendApi: QuickSendHostApi? = null,
+        clipboardApi: ClipboardHostApi? = null,
+    ): LuaScriptRuntime = LuaScriptRuntime(
+        "hostdata-test", writePlugin(probeLua), "main.lua", NoopPluginConfigStore,
+        quickSendHostApi = quickSendApi,
+        clipboardHostApi = clipboardApi,
+    )
+
+    @Test
+    fun `注入 quickSendApi 后 list 数据映射正确`() {
+        val rt = newRuntime(
+            quickSendApi = object : QuickSendHostApi {
+                override fun list() = listOf(
+                    QuickSendItem(id = 7, text = "18500000000", code = "dh", timestamp = 1690000000000, isPinned = true),
+                    QuickSendItem(id = 8, text = "北京市海淀区", code = "", timestamp = 1690000000001, isPinned = false),
+                )
+            }
+        )
+        assertTrue(rt.load())
+        assertEquals("2|7|18500000000|dh|true", rt.call("probeQuickSend").tojstring())
+        rt.close()
+    }
+
+    @Test
+    fun `注入 clipboardApi 后 get 返回文本`() {
+        val rt = newRuntime(
+            clipboardApi = object : ClipboardHostApi {
+                override fun getText(): String? = "剪贴板内容"
+            }
+        )
+        assertTrue(rt.load())
+        assertEquals("剪贴板内容", rt.call("probeClipboard").tojstring())
+        rt.close()
+    }
+
+    @Test
+    fun `剪贴板为空时 get 返回 nil`() {
+        val rt = newRuntime(
+            clipboardApi = object : ClipboardHostApi {
+                override fun getText(): String? = ""
+            }
+        )
+        assertTrue(rt.load())
+        assertEquals("nil", rt.call("probeClipboard").tojstring())
+        rt.close()
+    }
+
+    @Test
+    fun `未声明能力的插件拿不到 host 表`() {
+        val rt = newRuntime()
+        assertTrue(rt.load())
+        assertEquals("nil", rt.call("probeQuickSend").tojstring())
+        assertEquals("nil", rt.call("probeClipboard").tojstring())
+        rt.close()
+    }
+}

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaScriptRuntimeEventTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaScriptRuntimeEventTest.kt
@@ -85,11 +85,12 @@ class LuaScriptRuntimeEventTest {
                 PluginEvent(PluginEvent.TYPE_INPUT_CHANGED, mapOf(PluginEvent.FIELD_INPUT_TEXT to "k$i"))
             )
         }
-        awaitUntil { runtime.call("eventCount").toint() >= 1 }
-        assertEquals("最终必须是最后一个事件", "input_changed|k20", runtime.call("lastEvent").tojstring())
-        // 消费远慢于同步连发，收到的次数应远小于 20（允许并发穿插）
+        // conflated 只保最新：消费串行处理时存在"已处理 k1、k20 尚未消费"的窗口，
+        // 必须等待最终值（k20）而不是等到任意一条后再断言
+        awaitUntil { runtime.call("lastEvent").tojstring() == "input_changed|k20" }
+        // 消费远慢于同步连发，收到的次数应远小于 20（允许并发穿插；k1 + k20 至少 2 条）
         assertTrue("conflated 应合并中间事件: count=${runtime.call("eventCount").toint()}",
-            runtime.call("eventCount").toint() <= 6)
+            runtime.call("eventCount").toint() in 2..6)
         runtime.close()
     }
 

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaToolPluginAdapterTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaToolPluginAdapterTest.kt
@@ -186,4 +186,118 @@ class LuaToolPluginAdapterTest {
         adapter.onPanelItemClick("7")
         assertEquals("7", runtime.call("_lastItem").tojstring())
     }
+
+    @Test
+    fun `getPanelState ui 节点解析为统一 UiNode 模型`() {
+        val dir = writeScript(
+            """
+            local plugin = {}
+            function plugin.getPanelState(inputText)
+              return {
+                ui = {
+                  { type = "section", label = "统计" },
+                  { type = "text", value = "说明", style = "caption" },
+                  { type = "metric", label = "字数", value = "100", unit = "字" },
+                  { type = "divider" },
+                  { type = "button", label = "清零", key = "reset" },
+                },
+              }
+            end
+            return plugin
+            """.trimIndent()
+        )
+        val adapter = createAdapter(dir)
+        val state = adapter.getPanelState("x")
+        val ui = state.ui!!
+        assertEquals(5, ui.size)
+        assertEquals(com.kingzcheung.xime.plugin.core.config.UiNodeType.SECTION, ui[0].type)
+        assertEquals("统计", ui[0].label)
+        assertEquals(com.kingzcheung.xime.plugin.core.config.UiNodeType.TEXT, ui[1].type)
+        assertEquals("说明", ui[1].value)
+        assertEquals("caption", ui[1].style)
+        assertEquals(com.kingzcheung.xime.plugin.core.config.UiNodeType.METRIC, ui[2].type)
+        assertEquals("字", ui[2].unit)
+        assertEquals(com.kingzcheung.xime.plugin.core.config.UiNodeType.DIVIDER, ui[3].type)
+        assertEquals(com.kingzcheung.xime.plugin.core.config.UiNodeType.BUTTON, ui[4].type)
+        assertEquals("reset", ui[4].key)
+        assertEquals("清零", ui[4].label)
+    }
+
+    @Test
+    fun `getPanelState ui 旧字段与新字段兼容`() {
+        // v0.2.0 存量写法（action/title/content/actionId）应被解析层兼容为 UiNode
+        val dir = writeScript(
+            """
+            local plugin = {}
+            function plugin.getPanelState(inputText)
+              return {
+                ui = {
+                  { type = "section", title = "旧标题" },
+                  { type = "text", content = "旧文本", style = "caption" },
+                  { type = "action", label = "旧按钮", actionId = "old_action" },
+                },
+              }
+            end
+            return plugin
+            """.trimIndent()
+        )
+        val adapter = createAdapter(dir)
+        val state = adapter.getPanelState("x")
+        val ui = state.ui!!
+        assertEquals(3, ui.size)
+        assertEquals(com.kingzcheung.xime.plugin.core.config.UiNodeType.SECTION, ui[0].type)
+        assertEquals("旧标题", ui[0].label)
+        assertEquals(com.kingzcheung.xime.plugin.core.config.UiNodeType.TEXT, ui[1].type)
+        assertEquals("旧文本", ui[1].value)
+        assertEquals(com.kingzcheung.xime.plugin.core.config.UiNodeType.BUTTON, ui[2].type)
+        assertEquals("old_action", ui[2].key)
+        assertEquals("旧按钮", ui[2].label)
+    }
+
+    @Test
+    fun `getSettingsSchema 旧 button action 字段兼容为 key`() {
+        val dir = writeScript(
+            """
+            local plugin = {}
+            function plugin.getSettingsSchema()
+              return {
+                { key = "apiKey", label = "API Key", type = "secret" },
+                { key = "testConnection", label = "测试连接", type = "button", action = "testConnection" },
+              }
+            end
+            return plugin
+            """.trimIndent()
+        )
+        val adapter = createAdapter(dir)
+        val schema = adapter.getSettingsSchema()
+        assertEquals(2, schema.size)
+        val button = schema.first { it.key == "testConnection" }
+        assertEquals(com.kingzcheung.xime.plugin.core.config.UiNodeType.BUTTON, button.type)
+        // 旧字段 action → key 兼容（assets 预装旧 xipk 在新宿主上按钮可点）
+        assertEquals("testConnection", button.key)
+    }
+
+    @Test
+    fun `getPanelState 未知节点 type 降级为文本不崩溃`() {
+        val dir = writeScript(
+            """
+            local plugin = {}
+            function plugin.getPanelState(inputText)
+              return {
+                ui = {
+                  { type = "future_node", value = "未来节点" },
+                  { type = "section", label = "正常" },
+                },
+              }
+            end
+            return plugin
+            """.trimIndent()
+        )
+        val adapter = createAdapter(dir)
+        val state = adapter.getPanelState("x")
+        // 未知 type 解析为 TEXT（降级），面板渲染为只读文本
+        assertEquals(com.kingzcheung.xime.plugin.core.config.UiNodeType.TEXT, state.ui!![0].type)
+        assertEquals("未来节点", state.ui!![0].value)
+        assertEquals(2, state.ui!!.size)
+    }
 }

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaWebdavClipboardSyncPluginTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaWebdavClipboardSyncPluginTest.kt
@@ -166,6 +166,27 @@ class LuaWebdavClipboardSyncPluginTest {
     }
 
     @Test
+    fun `push creates missing directories via MKCOL on 404 then retries`() {
+        val store = InMemoryConfigStore()
+        store.set("davUrl", "https://192.168.1.50:8080/dav/")
+        store.set("remotePath", "xime")
+        val http = MockHttpHostApi()
+        // 部分服务器（Alist/Nextcloud 等）对 PUT 缺失父目录返回 404 而非 409，
+        // 同样应触发 MKCOL 逐级创建后重试
+        http.responseQueue.addLast(HttpResponse(404))
+        http.responseQueue.addLast(HttpResponse(405))
+        http.responseQueue.addLast(HttpResponse(201))
+        http.responseQueue.addLast(HttpResponse(201))
+        val runtime = newRuntime(store, http)
+
+        val ok = runtime.call("push", profileTable("hello", "abc")).toboolean()
+
+        assertTrue("push 应成功", ok)
+        val methods = http.requests.map { it.first }
+        assertEquals(listOf("PUT", "MKCOL", "MKCOL", "PUT"), methods)
+    }
+
+    @Test
     fun `push honors remotePath in url`() {
         val store = InMemoryConfigStore()
         store.set("davUrl", "https://192.168.1.50:8080/dav/")

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/runtime/installer/ManifestParseTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/runtime/installer/ManifestParseTest.kt
@@ -100,6 +100,24 @@ class ManifestParseTest {
     }
 
     @Test
+    fun `capabilities 的 snake_case 键应解析为 clipboardSync protocols`() {
+        // 回归：clipboardSync 缺 SerialName("clipboard_sync") 时 kaml 静默忽略该键，
+        // 宿主因 protocols 为空拒绝启动剪贴板同步插件
+        val content = """
+            id: sync
+            type: clipboard_sync
+            capabilities:
+              clipboard_sync:
+                protocols:
+                  - webdav
+        """.trimIndent()
+
+        val config = (InstallerManager.parseManifestContent(content) as PluginParseResult.Success).config
+        val protocols = config.capabilities?.clipboardSync?.protocols
+        assertEquals(listOf("webdav"), protocols)
+    }
+
+    @Test
     fun `插件 id 支持反域名命名空间`() {
         assertTrue("反域名 id 应合法", InstallerManager.isValidPluginId("com.kingzcheung.xime.plugin.funasr_asr"))
         assertTrue("下划线/连字符 id 应合法", InstallerManager.isValidPluginId("webdav-clipboard_sync"))

--- a/plugins/ai-reply/main.lua
+++ b/plugins/ai-reply/main.lua
@@ -124,27 +124,27 @@ end
 
 -- ================= 工具面板契约 =================
 
--- ui 节点树（白名单 type：section/text/metric/divider/action）：
+-- ui 节点树（统一 UiNode 白名单 type：section/text/metric/divider/button）：
 --   未生成 → 对方消息预览 + "生成回复"按钮；失败 → 错误提示 + 重试按钮；
 --   生成中 → 空 ui（loading 字段驱动宿主显示加载态）；有候选 → 提示文字（items 由宿主渲染）
 local function buildUi()
   local ui = {}
   if #cachedItems > 0 then
-    ui[#ui + 1] = { type = "section", title = "回复候选" }
-    ui[#ui + 1] = { type = "text", content = "点击候选直接上屏", style = "caption" }
+    ui[#ui + 1] = { type = "section", label = "回复候选" }
+    ui[#ui + 1] = { type = "text", value = "点击候选直接上屏", style = "caption" }
   elseif generating then
     -- loading 态：宿主显示"加载中..."
   else
-    ui[#ui + 1] = { type = "section", title = "对方消息" }
+    ui[#ui + 1] = { type = "section", label = "对方消息" }
     if lastContext ~= "" then
-      ui[#ui + 1] = { type = "text", content = lastContext }
+      ui[#ui + 1] = { type = "text", value = lastContext }
     else
-      ui[#ui + 1] = { type = "text", content = "暂无上下文：先复制对方消息，再从工具栏打开本面板", style = "caption" }
+      ui[#ui + 1] = { type = "text", value = "暂无上下文：先复制对方消息，再从工具栏打开本面板", style = "caption" }
     end
     if lastError ~= "" then
-      ui[#ui + 1] = { type = "text", content = lastError, style = "caption" }
+      ui[#ui + 1] = { type = "text", value = lastError, style = "caption" }
     end
-    ui[#ui + 1] = { type = "action", label = lastError ~= "" and "重新生成" or "生成回复", actionId = "generate" }
+    ui[#ui + 1] = { type = "button", label = lastError ~= "" and "重新生成" or "生成回复", key = "generate" }
   end
   return ui
 end

--- a/plugins/ai-reply/manifest.yaml
+++ b/plugins/ai-reply/manifest.yaml
@@ -11,7 +11,7 @@ icon: "应"
 description: 根据对方消息生成 3~5 条回复候选，点选上屏。支持任意 OpenAI 兼容的 chat/completions 接口。
 
 # 插件版本
-version: 0.3.0
+version: 0.4.0
 
 # 插件分类：tool 工具类（多开）
 type: tool
@@ -21,7 +21,7 @@ activation: multi
 entry: main.lua
 
 # 宿主最低版本要求（工具栏按钮与工具面板契约）
-minHostVersion: 2.6.2
+minHostVersion: 2.8.0
 
 # 工具栏入口：点击打开该插件的通用面板
 toolbarButtons:
@@ -33,27 +33,7 @@ toolbarButtons:
 network:
   allowCustomHosts: true
 
-# 配置字段（插件中心渲染表单）
-configSchema:
-  - key: apiKey
-    label: API Key
-    type: secret
-    placeholder: 输入 LLM API Key
-    helpText: OpenAI 兼容接口的 API Key
-  - key: baseUrl
-    label: 接口地址
-    type: text
-    defaultValue: https://api.openai.com/v1
-    helpText: OpenAI 兼容接口地址（/chat/completions 前缀），域名将自动获得联网授权
-  - key: model
-    label: 模型
-    type: text
-    defaultValue: gpt-4o-mini
-  - key: prompt
-    label: 回复模板
-    type: textarea
-    defaultValue: "你是我的智能回复助手。请根据对方消息生成 3~5 条简洁、自然、符合我语气的中文回复候选，每条不超过 30 字。严格按以下格式输出：只输出一个 JSON 对象，格式为 {\"candidates\": [\"好的呀\", \"马上来\", \"稍等片刻\"]}，candidates 是候选文本数组，不要编号、不要解释、不要任何其他文字。对方消息：{context}"
-    helpText: 生成候选的 prompt 模板，{context} 会被替换为对方消息
+# 能力声明
 # 能力声明
 capabilities:
   tool:

--- a/plugins/ai-translate/manifest.yaml
+++ b/plugins/ai-translate/manifest.yaml
@@ -33,32 +33,7 @@ toolbarButtons:
 network:
   allowCustomHosts: true
 
-# 配置字段
-configSchema:
-  - key: apiKey
-    label: API Key
-    type: secret
-    placeholder: 输入 LLM API Key
-    helpText: OpenAI 兼容接口的 API Key
-  - key: baseUrl
-    label: 接口地址
-    type: text
-    defaultValue: https://api.openai.com/v1
-    helpText: OpenAI 兼容接口地址（/chat/completions 前缀），域名将自动获得联网授权
-  - key: model
-    label: 模型
-    type: text
-    defaultValue: gpt-4o-mini
-  - key: targetLang
-    label: 目标语言
-    type: text
-    defaultValue: 简体中文
-    helpText: 翻译目标语言（如 简体中文 / English / 日本語）
-  - key: prompt
-    label: 翻译模板
-    type: textarea
-    defaultValue: "你是专业翻译。请把下面的内容翻译成{targetLang}，只输出译文，不要解释、不要引号。\n{context}"
-    helpText: 翻译 prompt 模板，{context} 替换为待翻译文本，{targetLang} 替换为目标语言
+# 能力声明
 # 能力声明
 capabilities:
   tool:

--- a/plugins/ai-write/manifest.yaml
+++ b/plugins/ai-write/manifest.yaml
@@ -33,27 +33,7 @@ toolbarButtons:
 network:
   allowCustomHosts: true
 
-# 配置字段
-configSchema:
-  - key: apiKey
-    label: API Key
-    type: secret
-    placeholder: 输入 LLM API Key
-    helpText: OpenAI 兼容接口的 API Key
-  - key: baseUrl
-    label: 接口地址
-    type: text
-    defaultValue: https://api.openai.com/v1
-    helpText: OpenAI 兼容接口地址（/chat/completions 前缀），域名将自动获得联网授权
-  - key: model
-    label: 模型
-    type: text
-    defaultValue: gpt-4o-mini
-  - key: prompt
-    label: 写作模板
-    type: textarea
-    defaultValue: "你是我的写作助手。请根据以下上下文与要求写一段通顺的中文文字：\n{context}"
-    helpText: 写作 prompt 模板，{context} 会被替换为面板输入内容
+# 能力声明
 # 能力声明
 capabilities:
   tool:

--- a/plugins/funasr-asr/manifest.yaml
+++ b/plugins/funasr-asr/manifest.yaml
@@ -33,11 +33,3 @@ capabilities:
 network:
   hosts:
     - dashscope.aliyuncs.com
-
-# 配置字段声明（插件中心直接渲染表单）
-configSchema:
-  - key: apiKey
-    label: API Key
-    type: secret
-    placeholder: 输入阿里百炼 API Key
-    helpText: 访问阿里云百炼平台获取 API Key

--- a/plugins/kaomoji/manifest.yaml
+++ b/plugins/kaomoji/manifest.yaml
@@ -42,7 +42,3 @@ capabilities:
     supportsSearch: true   # 支持按文本搜索表情
     columns: 3             # 表情网格列数（布局元数据，插件不再运行时声明）
     itemHeightDp: 30
-
-# 配置字段声明（宿主直接渲染表单，无需先执行脚本）
-# 类型：text | secret | select | multi_select | switch | number
-configSchema: []

--- a/plugins/meme-bunny/manifest.yaml
+++ b/plugins/meme-bunny/manifest.yaml
@@ -28,6 +28,3 @@ capabilities:
     supportsSearch: true
     columns: 3
     itemHeightDp: 110
-
-# 配置字段（无）
-configSchema: []

--- a/plugins/quick-send-demo/main.lua
+++ b/plugins/quick-send-demo/main.lua
@@ -1,0 +1,88 @@
+-- 快捷发送示例插件：把宿主快捷发送内容（Room 数据，含触发编码 code）匹配进候选栏。
+--
+-- 数据流：
+--   onLoad           首次拉取 host.quickSend.list() 到内存缓存
+--   quick_send_changed  宿主推送变更事件（conflated 只保最新）→ 刷新缓存
+--   transformCandidates 纯内存匹配缓存（hotPath 硬超时 15ms，禁止网络/文件 IO）
+--
+-- 匹配与排序规则：
+--   1. 内容命中：快捷条目 text 以某个引擎候选词开头（如候选"电话"、条目"电话号码：135..."）
+--      → 该条目紧跟在该候选词之后
+--   2. 编码命中：用户输入编码是条目 code 的前缀（code 非空，如输入 dh/d 命中 code=dh）
+--      → 条目插到"引擎第一候选之后"（即候选列表第二候选位；引擎无候选则放第一）
+--   3. 去重：同一条目只出现一次（内容命中优先于编码命中的位置）
+-- 未命中返回 nil（不干预）。
+
+local plugin = {}
+
+local quickSends = {}  -- host.quickSend.list() 的缓存 { {id,text,code,timestamp,isPinned}, ... }
+
+local function refresh()
+  if host.quickSend == nil then return end
+  quickSends = host.quickSend.list() or {}
+end
+
+function plugin.onLoad()
+  refresh()
+end
+
+function plugin.onPluginEvent(eventType, payload)
+  if eventType == "quick_send_changed" then
+    refresh()
+  end
+end
+
+-- 快捷条目的候选注释：有 code 显示 code（提示触发码），否则"快捷"
+local function commentOf(q)
+  local code = (q.code or ""):gsub("%s", "")
+  if code ~= "" then return code end
+  return "快捷"
+end
+
+function plugin.transformCandidates(request)
+  local input = request.input_text or ""
+  local engineCands = request.candidates or {}
+  if input == "" or #quickSends == 0 then return nil end
+
+  local result = {}
+  local inserted = {}      -- 按 id 去重
+  local firstEnginePos = nil  -- result 中第一个引擎候选项的最终位置
+
+  -- 1. 引擎候选按序保留；每条候选后跟随 text 以其开头的快捷条目
+  for i, c in ipairs(engineCands) do
+    table.insert(result, { engine_index = i - 1 })
+    if firstEnginePos == nil then firstEnginePos = #result end
+    local ctext = c.text or ""
+    for _, q in ipairs(quickSends) do
+      local text = q.text or ""
+      if not inserted[q.id] and text ~= "" and ctext ~= "" and text:sub(1, #ctext) == ctext then
+        table.insert(result, { text = text, comment = commentOf(q) })
+        inserted[q.id] = true
+      end
+    end
+  end
+
+  -- 2. 编码命中：输入编码是 code 前缀（code 非空，未插入过）
+  local codeHits = {}
+  for _, q in ipairs(quickSends) do
+    local code = (q.code or ""):gsub("%s", "")
+    if not inserted[q.id] and code ~= "" and input:sub(1, #code) == code then
+      table.insert(codeHits, q)
+    end
+  end
+  if #codeHits > 0 then
+    local insertAt = firstEnginePos == nil and 1 or (firstEnginePos + 1)
+    local tail = {}
+    for k = insertAt, #result do tail[#tail + 1] = result[k] end
+    for k = #result, insertAt, -1 do result[k] = nil end
+    for _, q in ipairs(codeHits) do
+      table.insert(result, { text = q.text, comment = commentOf(q) })
+    end
+    for _, t in ipairs(tail) do result[#result + 1] = t end
+  end
+
+  if #result == 0 then return nil end
+  return { candidates = result }
+end
+
+return plugin

--- a/plugins/quick-send-demo/manifest.yaml
+++ b/plugins/quick-send-demo/manifest.yaml
@@ -1,0 +1,33 @@
+# =============================================
+# 快捷发送示例插件（演示 capabilities.candidate_transform 候选词变换
+#                  + capabilities.quick_send_read 宿主数据 API）
+# =============================================
+
+id: com.kingzcheung.xime.plugin.quick_send_demo
+
+name: 快捷发送
+icon: "快"
+description: 输入触发编码时把快捷发送内容（Room 数据，含 code）匹配进候选栏：
+  内容命中（text 以候选词开头）跟随该候选，编码命中（输入为 code 前缀）放第二候选位。
+  数据经 host.quickSend.list() 读取，变更经 quick_send_changed 事件刷新缓存。
+
+version: 0.3.0
+
+type: tool
+activation: multi
+
+entry: main.lua
+
+minHostVersion: 2.8.0
+
+# 无 network 声明：本插件不联网
+
+# 能力声明：
+#   candidate_transform  候选词变换（hotPath：按键路径同步调用，硬超时 15ms，须纯内存计算）
+#   quick_send_read      读取宿主快捷发送数据（注入 host.quickSend）
+#   events.quick_send_changed  快捷发送列表变更通知
+capabilities:
+  candidate_transform: true
+  quick_send_read: true
+  events:
+    - quick_send_changed

--- a/plugins/typing-stats/main.lua
+++ b/plugins/typing-stats/main.lua
@@ -203,34 +203,34 @@ function plugin.getPanelState(inputText)
   local hint = nextTitleHint()
   local now = nowSec()
   local ui = {
-    { type = "section", title = "🏆 称号" },
+    { type = "section", label = "🏆 称号" },
     { type = "metric",  label = "当前称号", value = (badge or "") .. " " .. title },
   }
   if hint ~= nil then
-    table.insert(ui, { type = "text", content = hint, style = "caption" })
+    table.insert(ui, { type = "text", value = hint, style = "caption" })
   else
-    table.insert(ui, { type = "text", content = "👑 已是最高称号", style = "caption" })
+    table.insert(ui, { type = "text", value = "👑 已是最高称号", style = "caption" })
   end
 
-  table.insert(ui, { type = "section", title = "⚡ 速度" })
+  table.insert(ui, { type = "section", label = "⚡ 速度" })
   table.insert(ui, { type = "metric", label = "💨 最近 1 分钟", value = tostring(currentKpm(now)), unit = "字/分" })
 
   local t = todayStr()
-  table.insert(ui, { type = "section", title = "📅 今日" })
+  table.insert(ui, { type = "section", label = "📅 今日" })
   table.insert(ui, { type = "metric", label = "✍️ 输入字数", value = tostring(daily[t] or 0), unit = "字" })
   table.insert(ui, { type = "metric", label = "🔢 提交次数", value = tostring(totalCommits) })
 
-  table.insert(ui, { type = "section", title = "🗓 近 7 天" })
+  table.insert(ui, { type = "section", label = "🗓 近 7 天" })
   table.insert(ui, { type = "metric", label = "✍️ 输入字数", value = tostring(sumRecentDays(7)), unit = "字" })
 
-  table.insert(ui, { type = "section", title = "📆 本月" })
+  table.insert(ui, { type = "section", label = "📆 本月" })
   table.insert(ui, { type = "metric", label = "✍️ 输入字数", value = tostring(sumMonth(t:sub(1, 6))), unit = "字" })
 
   if currentInput ~= "" then
-    table.insert(ui, { type = "text", content = "⌨️ 正在输入: " .. currentInput, style = "caption" })
+    table.insert(ui, { type = "text", value = "⌨️ 正在输入: " .. currentInput, style = "caption" })
   end
   table.insert(ui, { type = "divider" })
-  table.insert(ui, { type = "action", label = "🗑️ 清零统计", actionId = "reset" })
+  table.insert(ui, { type = "button", label = "🗑️ 清零统计", key = "reset" })
 
   return { inputText = inputText or "", items = {}, ui = ui, loading = false }
 end

--- a/plugins/typing-stats/manifest.yaml
+++ b/plugins/typing-stats/manifest.yaml
@@ -8,7 +8,7 @@ name: 输入统计
 icon: "统"
 description: 统计打字量（今日/累计字数、提交次数）。基于宿主下行事件，无网络访问。
 
-version: 0.1.0
+version: 0.2.0
 
 type: tool
 activation: multi

--- a/plugins/volc-asr/manifest.yaml
+++ b/plugins/volc-asr/manifest.yaml
@@ -33,29 +33,3 @@ capabilities:
 network:
   hosts:
     - openspeech.bytedance.com
-
-# 配置字段声明（插件中心直接渲染表单）
-configSchema:
-  - key: apiKey
-    label: API Key
-    type: secret
-    placeholder: 输入火山方舟 API Key
-    helpText: 在火山引擎方舟平台申请开通流式语音识别后获取
-  - key: appKey
-    label: App Key（旧鉴权）
-    type: secret
-    required: false
-    placeholder: 旧版 App Key（可选）
-    section: 旧鉴权
-  - key: accessKey
-    label: Access Key（旧鉴权）
-    type: secret
-    required: false
-    placeholder: 旧版 Access Key（可选）
-    section: 旧鉴权
-  - key: resourceId
-    label: 模型资源 ID
-    type: text
-    defaultValue: volc.seedasr.sauc.duration
-    placeholder: volc.seedasr.sauc.duration
-    helpText: 默认流式识别 2.0（volc.seedasr.sauc.duration）；1.0 模型填 volc.bigasr.sauc.duration

--- a/plugins/webdav-clipboard-sync/main.lua
+++ b/plugins/webdav-clipboard-sync/main.lua
@@ -15,7 +15,8 @@
 --          davUrl = 服务器根（如 https://dav.jianguoyun.com/dav/）
 --          remotePath = 远程目录（如 xime，留空为根目录）
 --   push   PUT 文件，body = Profile JSON（Content-Type: application/json）
---          目录不存在（409）→ 逐级 MKCOL 创建后重试
+--          目录不存在（409；部分服务器如 Alist/Nextcloud 返回 404）
+--          → 逐级 MKCOL 创建后重试
 --   pull   GET 文件，If-None-Match（ETag 缓存，ximed 无此优化，插件增强保留），
 --          304 → 无变更；404 → 远端尚无文件；200 → 解析 Profile JSON
 --   兼容   远端若为旧版纯文本（无 JSON 结构），按纯文本 profile 处理
@@ -77,8 +78,9 @@ local function ensureDirectories(fileUrl)
     dirPart = dirPart:gsub("/[^/]+$", "") or ""
     local basePath = base:gsub("^https?://[^/]+", ""):gsub("/+$", "")
     -- 去掉 davUrl 已有路径前缀，只创建剩余层级
-    if basePath ~= "" then
-        dirPart = dirPart:gsub("^" .. basePath, "")
+    -- （纯字符串前缀匹配，避免 gsub pattern 中 . - + 等特殊字符或前缀误匹配）
+    if basePath ~= "" and dirPart:sub(1, #basePath) == basePath then
+        dirPart = dirPart:sub(#basePath + 1)
     end
     dirPart = dirPart:gsub("^/+", "")
     local parts = {}
@@ -191,9 +193,10 @@ function plugin.push(profile)
         host.log("push ok: PUT " .. url .. " -> " .. resp.status)
         return true
     end
-    -- 409 Conflict：目录不存在，逐级 MKCOL 后重试一次
-    if resp.status == 409 then
-        host.log("push: 409 目录不存在，尝试 MKCOL 创建")
+    -- 409 Conflict / 404 Not Found：目录不存在（部分服务器对 PUT 缺失父目录返回 404），
+    -- 逐级 MKCOL 后重试一次
+    if resp.status == 409 or resp.status == 404 then
+        host.log("push: " .. resp.status .. " 目录不存在，尝试 MKCOL 创建")
         if ensureDirectories(url) then
             local retry = host.http.request("PUT", url, headers, body)
             if retry ~= nil and retry.status >= 200 and retry.status < 300 then

--- a/plugins/webdav-clipboard-sync/main.lua
+++ b/plugins/webdav-clipboard-sync/main.lua
@@ -150,7 +150,6 @@ function plugin.getSettingsSchema()
             key = "testConnection",
             label = "测试连接",
             type = "button",
-            action = "testConnection",
             required = false,
         },
     }

--- a/plugins/webdav-clipboard-sync/manifest.yaml
+++ b/plugins/webdav-clipboard-sync/manifest.yaml
@@ -11,7 +11,7 @@ icon: "☁️"
 description: 通过 WebDAV 文件同步剪贴板（文本，多设备）,目前仅测试了坚果云盘的 WebDAV 接口。
 
 # 插件版本（字符串）
-version: 0.2.0
+version: 0.3.0
 
 # 插件分类：clipboard_sync 剪贴板同步（单选激活）
 type: clipboard_sync
@@ -21,7 +21,7 @@ activation: single
 entry: main.lua
 
 # 宿主最低版本要求
-minHostVersion: 2.6.0
+minHostVersion: 2.8.0
 
 # 能力声明
 capabilities:
@@ -34,30 +34,3 @@ capabilities:
 network:
   hosts: []
   allowCustomHosts: true
-
-# 配置字段声明（插件中心直接渲染表单）
-configSchema:
-  - key: davUrl
-    label: WebDAV 服务器
-    type: text
-    placeholder: https://host:port/dav/
-    helpText: WebDAV 服务地址（形如 https://192.168.1.50:8080/dav/，需支持 Basic Auth 的 PUT/GET）
-  - key: remotePath
-    label: 远程目录
-    type: text
-    placeholder: xime
-    required: false
-    helpText: 剪贴板文件所在目录（留空为根目录，同步到 {地址}/{目录}/clipboard/current.json）
-  - key: username
-    label: 用户名
-    type: text
-    required: false
-  - key: password
-    label: 密码
-    type: secret
-    required: false
-  - key: testConnection
-    label: 测试连接
-    type: button
-    action: testConnection
-    required: false

--- a/plugins/webdav-clipboard-sync/manifest.yaml
+++ b/plugins/webdav-clipboard-sync/manifest.yaml
@@ -11,7 +11,7 @@ icon: "☁️"
 description: 通过 WebDAV 文件同步剪贴板（文本，多设备）,目前仅测试了坚果云盘的 WebDAV 接口。
 
 # 插件版本（字符串）
-version: 0.3.0
+version: 0.4.0
 
 # 插件分类：clipboard_sync 剪贴板同步（单选激活）
 type: clipboard_sync

--- a/plugins/ximed-clipboard-sync/main.lua
+++ b/plugins/ximed-clipboard-sync/main.lua
@@ -84,7 +84,6 @@ function plugin.getSettingsSchema()
             key = "testConnection",
             label = "测试连接",
             type = "button",
-            action = "testConnection",
             required = false,
         },
     }

--- a/plugins/ximed-clipboard-sync/manifest.yaml
+++ b/plugins/ximed-clipboard-sync/manifest.yaml
@@ -11,7 +11,7 @@ icon: "🔗"
 description: 对接 ximed HTTP 接口的双向剪贴板同步（文本），需要安装 ximed 服务器端和 ximed 客户端(https://github.com/kingzcheung/ximed)
 
 # 插件版本（字符串）
-version: 0.2.0
+version: 0.3.0
 
 # 插件分类：clipboard_sync 剪贴板同步（单选激活）
 type: clipboard_sync
@@ -21,7 +21,7 @@ activation: single
 entry: main.lua
 
 # 宿主最低版本要求
-minHostVersion: 2.6.0
+minHostVersion: 2.8.0
 
 # 能力声明
 capabilities:
@@ -34,24 +34,3 @@ capabilities:
 network:
   hosts: []
   allowCustomHosts: true
-
-# 配置字段声明（插件中心直接渲染表单）
-configSchema:
-  - key: serverUrl
-    label: 服务器地址
-    type: text
-    placeholder: https://host:port
-    helpText: ximed 服务器地址（形如 https://192.168.1.50:8080）
-  - key: username
-    label: 用户名
-    type: text
-    required: false
-  - key: password
-    label: 密码
-    type: secret
-    required: false
-  - key: testConnection
-    label: 测试连接
-    type: button
-    action: testConnection
-    required: false


### PR DESCRIPTION
- 为 ClipboardItem 数据类添加 code 属性，用于存储快捷发送触发编码
- 修改数据库结构，增加 code 列并实现从版本 2 到 3 的迁移
- 更新 QuickSendHostApiImpl 和相关接口以支持编码参数
- 在 XimeApplication 中初始化新的 HostApi 工厂
- 为快速发送项目增删改操作添加编码参数支持
- 实现数据库 DAO 层对编码字段的更新和插入操作
- 更新 UI 状态管理以处理编辑模式下的编码字段

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
