### PR TITLE
feat(input-service): 优化工具面板上下文收集逻辑

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1042,22 +1042,35 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     }
 
     /** 收集面板上下文：仅选中文本；未选中时返回空串（不预填输入框全文/剪贴板，待用户自行输入）。 */
+    /**
+     * 工具面板上下文收集（选区 > 输入框选区 > 剪贴板）：
+     * 对方消息通常来自聊天 App 复制而非输入框选区，剪贴板兜底是 AI 回复等
+     * 插件拿到上下文的关键路径（插件契约见 plugins/ai-reply/main.lua）。
+     */
     private fun collectToolPanelContext(): String {
-        val ic = currentInputConnection ?: return ""
-        runCatching {
-            val sel = ic.getSelectedText(0)?.toString()
-            if (!sel.isNullOrBlank()) return sel
-        }
-        runCatching {
-            val req = android.view.inputmethod.ExtractedTextRequest()
-            val extracted = ic.getExtractedText(req, 0)
-            if (extracted != null && extracted.selectionStart >= 0 && extracted.selectionEnd > extracted.selectionStart) {
-                val t = extracted.text?.toString()
-                if (t != null) {
-                    val s = extracted.selectionStart.coerceIn(0, t.length)
-                    val e = extracted.selectionEnd.coerceIn(s, t.length)
-                    if (e > s) return t.substring(s, e)
+        val ic = currentInputConnection
+        if (ic != null) {
+            runCatching {
+                val sel = ic.getSelectedText(0)?.toString()
+                if (!sel.isNullOrBlank()) return sel
+            }
+            runCatching {
+                val req = android.view.inputmethod.ExtractedTextRequest()
+                val extracted = ic.getExtractedText(req, 0)
+                if (extracted != null && extracted.selectionStart >= 0 && extracted.selectionEnd > extracted.selectionStart) {
+                    val t = extracted.text?.toString()
+                    if (t != null) {
+                        val s = extracted.selectionStart.coerceIn(0, t.length)
+                        val e = extracted.selectionEnd.coerceIn(s, t.length)
+                        if (e > s) return t.substring(s, e)
+                    }
                 }
+            }
+        }
+        // 剪贴板兜底：无选区/无输入连接时取系统剪贴板
+        runCatching {
+            if (::clipboardManager.isInitialized) {
+                clipboardManager.getCurrentClipboardText()?.takeIf { it.isNotBlank() }?.let { return it }
             }
         }
         return ""

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaAiPluginTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaAiPluginTest.kt
@@ -1,6 +1,7 @@
 package com.kingzcheung.xime.plugin.core.lua
 
 import com.kingzcheung.xime.plugin.core.config.PluginConfigStore
+import com.kingzcheung.xime.plugin.core.config.UiNodeType
 import com.kingzcheung.xime.plugin.core.lua.http.HttpHostApi
 import com.kingzcheung.xime.plugin.core.lua.http.HttpResponse
 import com.kingzcheung.xime.plugin.core.lua.http.SseHostApi
@@ -139,6 +140,81 @@ class LuaAiPluginTest {
         adapter.onPanelInput("你好")
         adapter.onPanelAction("generate")
         assertTrue("未配置 Key 不应产生候选", adapter.getPanelState("你好").items.isEmpty())
+    }
+
+    @Test
+    fun `ai-reply 点选上屏后重置面板状态`() {
+        val dir = File("../plugins/ai-reply")
+        assertTrue(dir.exists())
+        val store = InMemoryConfigStore()
+        store.set("apiKey", "test-key")
+        store.set("baseUrl", "https://api.example.com/v1")
+        val runtime = LuaScriptRuntime(
+            "com.kingzcheung.xime.plugin.ai_reply", dir, "main.lua", store,
+            httpHostApi = MockHttpHostApi(
+                HttpResponse(
+                    status = 200,
+                    body = """{"choices":[{"message":{"content":"好的！\n好的呀！"}}]}""".toByteArray()
+                )
+            )
+        )
+        assertTrue(runtime.load())
+        val adapter = LuaToolPluginAdapter(runtime, com.kingzcheung.xime.plugin.core.model.PluginContext(
+            application = android.app.Application(),
+            pluginInfo = com.kingzcheung.xime.plugin.core.model.PluginInfo(
+                id = "com.kingzcheung.xime.plugin.ai_reply", name = "AI 智能回复", description = "测试",
+                iconResId = 0, versionCode = 1, versionName = "0.1.0",
+                path = File(dir, "main.lua").absolutePath, type = "tool"
+            ),
+            configStore = store,
+        ))
+
+        adapter.onPanelInput("明天有空吗")
+        adapter.onPanelAction("generate")
+        assertTrue("生成后应有候选", adapter.getPanelState("明天有空吗").items.isNotEmpty())
+
+        // 点选上屏：状态重置，下次打开面板回到初始态
+        adapter.onPanelItemClick("1")
+        val state = adapter.getPanelState("")
+        assertTrue("上屏后候选应清空", state.items.isEmpty())
+        assertTrue("重置后应回到初始态（含生成按钮）", state.ui?.any { it.type == UiNodeType.BUTTON } == true)
+    }
+
+    @Test
+    fun `ai-reply 上下文变化时旧候选自动失效`() {
+        val dir = File("../plugins/ai-reply")
+        assertTrue(dir.exists())
+        val store = InMemoryConfigStore()
+        store.set("apiKey", "test-key")
+        store.set("baseUrl", "https://api.example.com/v1")
+        val runtime = LuaScriptRuntime(
+            "com.kingzcheung.xime.plugin.ai_reply", dir, "main.lua", store,
+            httpHostApi = MockHttpHostApi(
+                HttpResponse(
+                    status = 200,
+                    body = """{"choices":[{"message":{"content":"好的！"}}]}""".toByteArray()
+                )
+            )
+        )
+        assertTrue(runtime.load())
+        val adapter = LuaToolPluginAdapter(runtime, com.kingzcheung.xime.plugin.core.model.PluginContext(
+            application = android.app.Application(),
+            pluginInfo = com.kingzcheung.xime.plugin.core.model.PluginInfo(
+                id = "com.kingzcheung.xime.plugin.ai_reply", name = "AI 智能回复", description = "测试",
+                iconResId = 0, versionCode = 1, versionName = "0.1.0",
+                path = File(dir, "main.lua").absolutePath, type = "tool"
+            ),
+            configStore = store,
+        ))
+
+        adapter.onPanelInput("明天有空吗")
+        adapter.onPanelAction("generate")
+        assertTrue(adapter.getPanelState("明天有空吗").items.isNotEmpty())
+
+        // 用户复制了新消息后重新打开面板（新上下文）→ 旧候选失效，回到初始态
+        val state = adapter.getPanelState("周六怎么样")
+        assertTrue("新上下文应清空旧候选", state.items.isEmpty())
+        assertTrue("新上下文应回到初始态（含生成按钮）", state.ui?.any { it.type == UiNodeType.BUTTON } == true)
     }
 
     @Test

--- a/plugins/ai-reply/main.lua
+++ b/plugins/ai-reply/main.lua
@@ -151,9 +151,16 @@ end
 
 function plugin.getPanelState(inputText)
   -- openToolPanel 时宿主传入收集的上下文（选区 > 输入框 > 剪贴板）；
-  -- action 点击后的单次重拉传空串，不覆盖已有上下文
+  -- action 点击后的单次重拉传空串，不覆盖已有上下文。
+  -- 上下文变化（用户复制了新消息）→ 旧候选/错误状态失效，回到初始态
   if inputText ~= nil and trim(inputText) ~= "" then
-    lastContext = trim(inputText)
+    local ctx = trim(inputText)
+    if ctx ~= lastContext then
+      cachedItems = {}
+      lastError = ""
+      generating = false
+    end
+    lastContext = ctx
   end
   return {
     items = cachedItems,
@@ -237,7 +244,11 @@ function plugin.onPanelAction(actionId)
 end
 
 function plugin.onPanelItemClick(itemId)
-  -- 上屏由宿主完成，插件无需处理
+  -- 点选上屏即本次任务完成：重置面板状态，下次打开回到初始态
+  -- （否则旧候选残留，新复制的消息看起来"没效果"）
+  cachedItems = {}
+  lastError = ""
+  generating = false
 end
 
 return plugin

--- a/plugins/ai-reply/manifest.yaml
+++ b/plugins/ai-reply/manifest.yaml
@@ -11,7 +11,7 @@ icon: "应"
 description: 根据对方消息生成 3~5 条回复候选，点选上屏。支持任意 OpenAI 兼容的 chat/completions 接口。
 
 # 插件版本
-version: 0.4.0
+version: 0.5.0
 
 # 插件分类：tool 工具类（多开）
 type: tool


### PR DESCRIPTION
- 实现多层级上下文获取：选区 > 输入框选区 > 剪贴板兜底
- 增强健壮性：处理currentInputConnection为null的情况
- 添加详细注释说明上下文收集策略

feat(ai-reply-plugin): 实现面板状态自动重置机制

- 新增UiNodeType导入用于UI类型判断
- 当上下文变化时自动清空旧候选并重置状态
- 点选上屏后重置面板状态，确保下次打开回到初始态
- 新增单元测试验证状态重置功能

test(ai-reply-plugin): 添加面板状态管理测试用例

- 测试ai-reply点选上屏后的面板状态重置功能
- 验证上下文变化时旧候选自动失效机制
- 确保重置后能正确回到包含生成按钮的初始态

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [x] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
