### PR TITLE
feat(input-service): 添加快捷发送表单编码框焦点管理功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
@@ -38,8 +38,12 @@ import kotlinx.coroutines.runBlocking
  */
 class T9InputController(
     private val rimeEngine: RimeEngine = RimeEngine.getInstance(),
-    private val onCompositionRefresh: ((RimeComposition) -> Unit)? = null,
+    private val onCompositionRefresh: ((RimeComposition, List<com.kingzcheung.xime.service.T9CandidateInjection>) -> Unit)? = null,
     private val onRightCommitUndone: ((Int) -> Unit)? = null,
+    /** 候选词变换（hotPath 插件能力）：后台取数后、post 主线程前同步调用
+     *  （阻塞至多 15ms，主线程零等待）；返回带引擎锚点的插件候选注入列表
+     *  （text 追加项），引擎结果原样使用（T9 不支持引擎引用替换）。null = 不干预。 */
+    private val candidateTransform: ((RimeProcessResult) -> List<com.kingzcheung.xime.service.T9CandidateInjection>?)? = null,
 ) {
     companion object {
         private const val TAG = "T9InputController"
@@ -163,6 +167,15 @@ class T9InputController(
     }
 
     /**
+     * 候选词变换（hotPath 插件能力）：引擎结果原样 + 插件候选注入列表。
+     * t9Dispatcher 线程同步等插件至多 15ms；失败/不干预返回空注入。
+     */
+    private fun transformInjections(result: RimeProcessResult): Pair<RimeProcessResult, List<com.kingzcheung.xime.service.T9CandidateInjection>> {
+        val injections = candidateTransform?.invoke(result) ?: emptyList()
+        return result to injections
+    }
+
+    /**
      * 后台线程：flush 后一次取全量结果 + 左栏数据，经 [mainHandler] 投递到 Main
      * 更新 Compose 状态，并携带 composition 通知服务层刷新（避免其内部重复
      * getComposition）。post 为 fire-and-forget，任务完成不依赖 Main 线程；
@@ -170,12 +183,13 @@ class T9InputController(
      */
     private fun refreshOnBackground() {
         val data = fetchAll()
-        val composition = data.result.toComposition()
+        val (finalResult, injections) = transformInjections(data.result)
+        val composition = finalResult.toComposition()
         val gen = ++uiGeneration
         mainHandler.post {
             if (gen != uiGeneration) return@post
-            onCompositionRefresh?.invoke(composition)
-            applyCandidates(data.result, data.panel, data.options)
+            onCompositionRefresh?.invoke(composition, injections)
+            applyCandidates(finalResult, data.panel, data.options)
         }
     }
 
@@ -365,7 +379,8 @@ class T9InputController(
         rimeEngine.t9FlushRimeInput()
         val undoneCount = rimeEngine.t9GetAndConsumeUndoneRightCommitCount()
         val data = fetchAll()
-        val composition = data.result.toComposition()
+        val (finalResult, injections) = transformInjections(data.result)
+        val composition = finalResult.toComposition()
         val deleteResult = if (result) DeleteResult.DELETED else DeleteResult.NOT_CONSUMED
         val gen = ++uiGeneration
         mainHandler.post {
@@ -375,8 +390,8 @@ class T9InputController(
                 onRightCommitUndone?.invoke(undoneCount)
             }
             if (gen == uiGeneration) {
-                onCompositionRefresh?.invoke(composition)
-                applyCandidates(data.result, data.panel, data.options)
+                onCompositionRefresh?.invoke(composition, injections)
+                applyCandidates(finalResult, data.panel, data.options)
             }
             callback(deleteResult)
         }

--- a/app/src/main/java/com/kingzcheung/xime/service/CandidateTransformCoordinator.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/CandidateTransformCoordinator.kt
@@ -1,5 +1,6 @@
 package com.kingzcheung.xime.service
 
+import android.util.Log
 import com.kingzcheung.xime.plugin.core.lua.CandidateTransformCandidate
 import com.kingzcheung.xime.plugin.core.lua.CandidateTransformItem
 import com.kingzcheung.xime.plugin.core.lua.CandidateTransformOutcome
@@ -15,6 +16,24 @@ import com.kingzcheung.xime.util.FileLogger
 internal data class CandidateTransformResult(
     val candidates: List<RimeCandidate>,
     val actions: List<CandidateAction>,
+)
+
+/** T9 场景插件候选快照（text + comment）：引擎候选原样保留，插件候选追加右栏。 */
+data class PluginCandidateSnapshot(
+    val text: String,
+    val comment: String,
+)
+
+/**
+ * T9 插件候选注入：锚定在某个引擎候选之后。
+ * [anchorEngineIndex] = 该条目在插件响应 items 中前一个引擎引用项（engine_index）；
+ * null = 无引擎锚点（追加末尾）。两条命中规则在插件 Lua 侧已表达为输出顺序
+ * （编码命中紧跟引擎第一候选 → anchor=0 即第二候选位；内容命中紧跟对应候选 → anchor=k），
+ * 本模型把该顺序语义无损带过 T9 索引不可信的问题。
+ */
+data class T9CandidateInjection(
+    val anchorEngineIndex: Int?,
+    val snapshot: PluginCandidateSnapshot,
 )
 
 /**
@@ -98,7 +117,7 @@ internal class CandidateTransformCoordinator(private val service: XimeInputMetho
         if (asciiMode) return null
         if (isT9Schema(service.uiState.value.currentSchemaId)) return null
         if (service.pluginEvents.isCurrentEditorSensitive) return null
-        val runtime = findRuntime() ?: return null
+        val (pluginId, runtime) = findRuntime() ?: return null
         val outcome = runtime.transformCandidates(
             CandidateTransformRequest(
                 inputText = inputText,
@@ -110,10 +129,12 @@ internal class CandidateTransformCoordinator(private val service: XimeInputMetho
         return when (outcome) {
             is CandidateTransformOutcome.NoResponse -> {
                 consecutiveFailures = 0
+                logTransform("QWERTY", pluginId, inputText, "no-intervention", 0)
                 null
             }
             is CandidateTransformOutcome.Failed -> {
                 consecutiveFailures++
+                logTransform("QWERTY", pluginId, inputText, "failed", 0)
                 if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
                     disabledThisSession = true
                     FileLogger.w(
@@ -125,17 +146,88 @@ internal class CandidateTransformCoordinator(private val service: XimeInputMetho
             }
             is CandidateTransformOutcome.Success -> {
                 consecutiveFailures = 0
-                buildDisplay(outcome.items, engineCandidates)
+                val transformed = buildDisplay(outcome.items, engineCandidates)
+                logTransform("QWERTY", pluginId, inputText, "inject", transformed?.candidates?.size ?: 0)
+                transformed
             }
         }
     }
 
-    /** 第一个声明 candidate_transform 且已加载的插件运行时（v1 单插件；链式变换为后续增强）。 */
-    private fun findRuntime(): LuaScriptRuntime? {
-        for ((_, loaded) in PluginManager.loadedPluginsFlow.value) {
+    /**
+     * T9 场景变换入口（t9Dispatcher/key-processing 线程，阻塞至多 15ms）。
+     * 与 [transform] 的区别：T9 候选索引可能被引擎 partial 展示态替换，engine_index
+     * 引用不可信 → 响应只取 text 追加项（引擎引用丢弃），但记录每条 text 项的
+     * 引擎锚点（其前最近一次引擎引用的 index），供 applyComposition T9 分支按锚点
+     * 插入（插件 Lua 的输出顺序已表达"编码命中→第二候选位、内容命中→跟随候选"）。
+     * 短路条件同 [transform]；T9 本身不作短路（本方法即 T9 路径）。
+     */
+    fun transformForT9(result: RimeProcessResult): List<T9CandidateInjection>? {
+        if (disabledThisSession) return null
+        if (result.isAsciiMode) return null
+        if (result.inputText.isEmpty() && result.candidates.isEmpty()) return null
+        if (service.pluginEvents.isCurrentEditorSensitive) return null
+        val (pluginId, runtime) = findRuntime() ?: return null
+        val outcome = runtime.transformCandidates(
+            CandidateTransformRequest(
+                inputText = result.inputText,
+                preedit = result.preeditText,
+                candidates = result.candidates.map { CandidateTransformCandidate(it.text, it.comment) },
+                asciiMode = result.isAsciiMode,
+            )
+        )
+        return when (outcome) {
+            is CandidateTransformOutcome.NoResponse -> {
+                consecutiveFailures = 0
+                logTransform("T9", pluginId, result.inputText, "no-intervention", 0)
+                null
+            }
+            is CandidateTransformOutcome.Failed -> {
+                consecutiveFailures++
+                logTransform("T9", pluginId, result.inputText, "failed", 0)
+                if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+                    disabledThisSession = true
+                    FileLogger.w(
+                        XimeInputMethodService.TAG,
+                        "candidate_transform(T9) 连续失败 $consecutiveFailures 次，本会话禁用该插件变换"
+                    )
+                }
+                null
+            }
+            is CandidateTransformOutcome.Success -> {
+                consecutiveFailures = 0
+                val injections = mutableListOf<T9CandidateInjection>()
+                var lastEngineAnchor: Int? = null
+                for (item in outcome.items) {
+                    if (item.engineIndex != null) {
+                        lastEngineAnchor = item.engineIndex
+                        continue
+                    }
+                    val text = item.text?.takeIf { it.isNotEmpty() } ?: continue
+                    injections.add(
+                        T9CandidateInjection(lastEngineAnchor, PluginCandidateSnapshot(text, item.comment ?: ""))
+                    )
+                }
+                logTransform("T9", pluginId, result.inputText, "inject", injections.size)
+                injections.takeIf { it.isNotEmpty() }
+            }
+        }
+    }
+
+    /** 第一个声明 candidate_transform 且已加载的插件运行时（v1 单插件；链式变换为后续增强）。
+     *  返回 (插件 id, 运行时)；无可用插件返回 null。 */
+    private fun findRuntime(): Pair<String, LuaScriptRuntime>? {
+        for ((pluginId, loaded) in PluginManager.loadedPluginsFlow.value) {
             if (loaded.pluginInfo.capabilities?.candidateTransform != true) continue
-            return loaded.script ?: continue
+            val script = loaded.script ?: continue
+            return pluginId to script
         }
         return null
+    }
+
+    /** 诊断日志：hotPath 每键调用。调用点只传原始值（零字符串操作），
+     *  isLoggable 未开启时立即返回（唯一开销是一次 int 读+比较，~1ns）。 */
+    private fun logTransform(mode: String, pluginId: String?, input: String, state: String, count: Int) {
+        if (!Log.isLoggable(XimeInputMethodService.TAG, Log.DEBUG)) return
+        Log.d(XimeInputMethodService.TAG, "candidate_transform[$mode] plugin=$pluginId input='$input' $state=$count")
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
@@ -157,6 +157,7 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                     service.uiState.value = s.copy(
                         showQuickSendForm = false,
                         quickSendFormFocused = false,
+                        quickSendCodeFocused = false,
                         quickSendEditingItemId = null,
                         quickSendEditingItemText = "",
                         quickSendEditingItemCode = ""
@@ -178,18 +179,8 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                         }
                         sendTransformedResult(result)
                     } else {
-                        // 无组合态 → 直接操作 EditText 删除已上屏文字
-                        QuickSendFormEditTextHolder.editText?.let { et ->
-                            val start = et.selectionStart.coerceAtLeast(0)
-                            val end = et.selectionEnd.coerceAtLeast(start)
-                            if (start == end && start > 0) {
-                                et.text?.delete(start - 1, start)
-                                try { et.setSelection(start - 1) } catch (_: Exception) {}
-                            } else if (end > start) {
-                                et.text?.delete(start, end)
-                                try { et.setSelection(start) } catch (_: Exception) {}
-                            }
-                        }
+                        // 无组合态 → 按焦点路由删除表单内（文本框/触发编码框）已上屏文字
+                        service.deleteInQuickSendForm()
                     }
                     return
                 }
@@ -788,6 +779,11 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
 
     /** 单次退格处理（service.keyProcessingDispatcher 上执行）。 */
     internal suspend fun processDeleteKey() {
+        // 快捷发送表单显示：退格按焦点路由到表单内 EditText（与单击退格同一路径），不进入 Rime
+        if (service.uiState.value.showQuickSendForm) {
+            withContext(Dispatchers.Main) { service.deleteInQuickSendForm() }
+            return
+        }
         val candState = service.candidateState.value
         // 退格改变输入上下文：使在途的联想预测结果失效，防止过期结果迟到回填
         // associationCandidates，导致长按退格删除时候选栏在"联想词↔空"之间闪动。

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
@@ -706,7 +706,11 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                             service.serviceScope.launch {
                                 val candidates = service.predictionManager.getEnglishAssociations(pendingEnglish, PredictionManager.MAX_ASSOCIATION_COUNT)
                                 withContext(Dispatchers.Main) {
-                                    service.candidateState.value = service.candidateState.value.copy(associationCandidates = candidates)
+                                    val current = service.candidateState.value
+                                    // 在途联想过期校验：pendingEnglish 已变/已清 → 丢弃迟到回填
+                                    if (current.pendingEnglishText == pendingEnglish) {
+                                        service.candidateState.value = current.copy(associationCandidates = candidates)
+                                    }
                                 }
                             }
                         }
@@ -1081,6 +1085,14 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                 hasNextPage = false,
                 hasPrevPage = false,
                 candidateActions = emptyList()
+            )
+            // T9：清 partial 累积与左栏状态（与引擎候选 full commit 同款清理，
+            // 防残留 partial 混入下一轮 preedit / 左侧面板残留）
+            service.t9PartialSegments.clear()
+            service.uiState.value = service.uiState.value.copy(
+                t9ResetSignal = service.uiState.value.t9ResetSignal + 1,
+                t9RightCandidateSelectedCount = 0,
+                t9SelectedCandidatePinyin = ""
             )
         }
         service.rimeEngine.clearComposition()

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalView
 import com.kingzcheung.xime.keyboard.OverlayRoute
 import com.kingzcheung.xime.rime.T9InputController
+import com.kingzcheung.xime.rime.RimeProcessResult
 import com.kingzcheung.xime.settings.SettingsPreferences
 import com.kingzcheung.xime.ui.keyboard.KeyboardCallbacks
 import com.kingzcheung.xime.ui.keyboard.isT9Schema
@@ -97,7 +98,13 @@ internal fun rememberImeKeyboardCallbacks(
                 }
             },
             onClearAssociation = {
-                service.candidateState.value = service.candidateState.value.copy(associationCandidates = emptyList())
+                // 清空英文联想候选，并结束英文输入态：pendingEnglish 清空后，
+                // 后续刷新不再触发联想异步回填（否则"清了又冒出来"，见
+                // ImeSessionController/updateUIWithResult 的在途回填校验）。
+                service.candidateState.value = service.candidateState.value.copy(
+                    associationCandidates = emptyList(),
+                    pendingEnglishText = ""
+                )
             },
             onToggleDarkMode = { service.toggleDarkMode() },
             onClipboard = {},
@@ -316,10 +323,16 @@ internal fun rememberImeKeyboardCallbacks(
                     }
                 }
             },
-            onT9RefreshComposition = { composition ->
+            onT9RefreshComposition = { composition, injections ->
                 // composition 由 T9 控制器在 flush 后一次取回并传入，
                 // 避免在此再次 getComposition 造成重复 JNI 往返。
-                service.mainHandler.post { service.sessionController.applyComposition(composition) }
+                service.mainHandler.post {
+                    service.sessionController.applyComposition(composition, emptyList(), injections)
+                }
+            },
+            onTCandidateTransform = { result ->
+                // T9 后台线程（t9Dispatcher）调用：同步等插件至多 15ms，主线程零等待
+                service.candidateTransform.transformForT9(result)
             },
             onT9SwitchAway = {
                 service.keyRouter.postRimeJob {

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
@@ -361,6 +361,7 @@ internal fun rememberImeKeyboardCallbacks(
                 service.uiState.value = current.copy(
                     showQuickSendForm = true,
                     quickSendFormFocused = true,
+                    quickSendCodeFocused = false,
                     quickSendEditingItemId = null,
                     quickSendEditingItemText = "",
                     quickSendEditingItemCode = "",
@@ -375,6 +376,7 @@ internal fun rememberImeKeyboardCallbacks(
                 service.uiState.value = service.uiState.value.copy(
                     showQuickSendForm = true,
                     quickSendFormFocused = true,
+                    quickSendCodeFocused = false,
                     quickSendEditingItemId = id,
                     quickSendEditingItemText = text,
                     quickSendEditingItemCode = code,
@@ -390,6 +392,7 @@ internal fun rememberImeKeyboardCallbacks(
                 service.uiState.value = service.uiState.value.copy(
                     showQuickSendForm = false,
                     quickSendFormFocused = false,
+                    quickSendCodeFocused = false,
                     quickSendEditingItemId = null,
                     quickSendEditingItemText = "",
                     quickSendEditingItemCode = "",
@@ -407,9 +410,19 @@ internal fun rememberImeKeyboardCallbacks(
                 // 关闭表单时由 onHideQuickSendForm / onWindowHidden 统一还原"发送"。
                 val s = service.uiState.value
                 service.uiState.value = if (focused) {
-                    s.copy(quickSendFormFocused = true, enterKeyText = "确定")
+                    // 文本框抢回焦点：编码焦点清除，按键输入回到文本框
+                    s.copy(quickSendFormFocused = true, quickSendCodeFocused = false, enterKeyText = "确定")
                 } else {
-                    s.copy(quickSendFormFocused = false)
+                    s.copy(quickSendFormFocused = false, quickSendCodeFocused = false)
+                }
+            },
+            onQuickSendCodeFocusChange = { focused: Boolean ->
+                val s = service.uiState.value
+                service.uiState.value = if (focused) {
+                    // 编码框获得焦点：同样视为表单聚焦（回车"确定"/按键路由生效）
+                    s.copy(quickSendFormFocused = true, quickSendCodeFocused = true, enterKeyText = "确定")
+                } else {
+                    s.copy(quickSendCodeFocused = false)
                 }
             },
         )

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeSessionController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeSessionController.kt
@@ -22,6 +22,7 @@ internal class ImeSessionController(private val service: XimeInputMethodService)
     internal fun applyComposition(
         composition: com.kingzcheung.xime.rime.RimeComposition,
         pluginActions: List<CandidateAction> = emptyList(),
+        t9PluginInjections: List<T9CandidateInjection> = emptyList(),
     ) {
         val inputText = composition.input
         val codeInInputBox = SettingsPreferences.getInputTextLocation(service) == SettingsPreferences.INPUT_TEXT_INPUT_BOX
@@ -54,6 +55,7 @@ internal class ImeSessionController(private val service: XimeInputMethodService)
         val displayCandidates: List<String>
         val displayComments: List<String>
         val isComposing: Boolean
+        var t9CandidateActions: List<CandidateAction> = emptyList()
         if (isT9Schema) {
             val rawPreedit = if (preeditText.isNotEmpty()) preeditText else inputText
             // preedit 转换由 C++ t9_filter 完成，Kotlin 侧直接使用引擎输出的 preedit
@@ -61,9 +63,35 @@ internal class ImeSessionController(private val service: XimeInputMethodService)
                 service.t9PartialSegments.map { it.text }, rawPreedit, inputText, t9FilteredTexts, t9FilteredComments
             )
             displayText = display.displayText
-            displayCandidates = display.displayCandidates
-            displayComments = display.displayComments
+            // T9 插件候选按引擎锚点插入（transformForT9 已把插件输出顺序折叠为
+            // anchorEngineIndex；编码命中→锚 0→第二候选位，内容命中→跟随对应候选；
+            // 无锚点追加末尾）。引擎段 actions 用平行 index 引用（T9 点击走引擎分支，
+            // 不实际消费 engineIndex，仅用于插件候选分流）
+            val baseCands = display.displayCandidates
+            val baseComments = display.displayComments
+            val byAnchor = t9PluginInjections.groupBy { it.anchorEngineIndex }
+            val mergedCands = ArrayList<String>(baseCands.size + t9PluginInjections.size)
+            val mergedComments = ArrayList<String>(mergedCands.size)
+            val mergedActions = ArrayList<CandidateAction>(mergedCands.size)
+            for ((idx, cand) in baseCands.withIndex()) {
+                byAnchor[idx]?.forEach { inj ->
+                    mergedCands.add(inj.snapshot.text)
+                    mergedComments.add(inj.snapshot.comment)
+                    mergedActions.add(CandidateAction.plugin(inj.snapshot.text))
+                }
+                mergedCands.add(cand)
+                mergedComments.add(baseComments.getOrElse(idx) { "" })
+                mergedActions.add(CandidateAction.engine(idx))
+            }
+            byAnchor[null]?.forEach { inj ->
+                mergedCands.add(inj.snapshot.text)
+                mergedComments.add(inj.snapshot.comment)
+                mergedActions.add(CandidateAction.plugin(inj.snapshot.text))
+            }
+            displayCandidates = mergedCands
+            displayComments = mergedComments
             isComposing = display.isComposing
+            t9CandidateActions = mergedActions
         } else {
             // 非 T9 方案：preeditText 用引擎回显（带音节分隔符，如全拼 ni'hao）供候选栏展示；
             // inputText 保留原始键入串（无分隔）——空格/切模式等提交路径会把它直接上屏，
@@ -91,8 +119,8 @@ internal class ImeSessionController(private val service: XimeInputMethodService)
             isShowingRecentClipboard = false,
             hasNextPage = hasNextPage,
             hasPrevPage = hasPrevPage,
-            // 候选词变换映射（T9 不接入变换，防御清空）
-            candidateActions = if (isT9Schema) emptyList() else pluginActions
+            // 候选词变换映射（全键盘 pluginActions / T9 平行 actions；防御空）
+            candidateActions = if (isT9Schema) t9CandidateActions else pluginActions
         )
         if (isAsciiMode != service.uiState.value.isAsciiMode) {
             FileLogger.i(XimeInputMethodService.TAG, "applyComposition: ascii ${service.uiState.value.isAsciiMode}->$isAsciiMode")
@@ -104,7 +132,12 @@ internal class ImeSessionController(private val service: XimeInputMethodService)
             service.serviceScope.launch {
                 val candidates = service.predictionManager.getEnglishAssociations(pendingEnglish, PredictionManager.MAX_ASSOCIATION_COUNT)
                 withContext(Dispatchers.Main) {
-                    service.candidateState.value = service.candidateState.value.copy(associationCandidates = candidates)
+                    val current = service.candidateState.value
+                    // 在途联想过期校验：pendingEnglish 已变/已清（如点击候选栏"清空"）→
+                    // 丢弃迟到回填，防止"清了又冒出来"与旧联想覆盖新联想的竞态
+                    if (current.pendingEnglishText == pendingEnglish) {
+                        service.candidateState.value = current.copy(associationCandidates = candidates)
+                    }
                 }
             }
         }
@@ -211,7 +244,11 @@ internal class ImeSessionController(private val service: XimeInputMethodService)
             service.serviceScope.launch {
                 val candidates = service.predictionManager.getEnglishAssociations(pendingEnglish, PredictionManager.MAX_ASSOCIATION_COUNT)
                 withContext(Dispatchers.Main) {
-                    service.candidateState.value = service.candidateState.value.copy(associationCandidates = candidates)
+                    val current = service.candidateState.value
+                    // 在途联想过期校验：pendingEnglish 已变/已清 → 丢弃迟到回填
+                    if (current.pendingEnglishText == pendingEnglish) {
+                        service.candidateState.value = current.copy(associationCandidates = candidates)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/kingzcheung/xime/service/InputUIState.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/InputUIState.kt
@@ -50,6 +50,8 @@ data class InputUIState(
     val cursorVisible: Boolean = false,
     val showQuickSendForm: Boolean = false,
     val quickSendFormFocused: Boolean = false,
+    /** 快捷发送表单内焦点是否在"触发编码"输入框（false=在文本输入框）；决定按键输入路由目标。 */
+    val quickSendCodeFocused: Boolean = false,
     val quickSendEditingItemId: Long? = null,
     val quickSendEditingItemText: String = "",
     val quickSendEditingItemCode: String = "",

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -802,6 +802,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             uiState.value = uiState.value.copy(
                 showQuickSendForm = false,
                 quickSendFormFocused = false,
+                quickSendCodeFocused = false,
                 quickSendEditingItemId = null,
                 quickSendEditingItemText = "",
                 quickSendEditingItemCode = "",
@@ -1929,6 +1930,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             uiState.value = uiState.value.copy(
                 showQuickSendForm = false,
                 quickSendFormFocused = false,
+                quickSendCodeFocused = false,
                 quickSendEditingItemId = null,
                 quickSendEditingItemText = "",
                 quickSendEditingItemCode = "",
@@ -2230,6 +2232,30 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     }
 
     /**
+     * 快捷发送表单内退格：按焦点路由到文本框/触发编码框，删除光标前字符或选区。
+     * 与原行为对齐：表单显示即处理（未聚焦时删文本框），焦点在编码框时删编码框。
+     * 需在主线程调用；返回 false 表示表单未显示（调用方继续常规退格流程）。
+     */
+    internal fun deleteInQuickSendForm(): Boolean {
+        if (!uiState.value.showQuickSendForm) return false
+        val et = if (uiState.value.quickSendFormFocused && uiState.value.quickSendCodeFocused)
+            QuickSendFormCodeEditTextHolder.editText
+        else QuickSendFormEditTextHolder.editText
+        et?.let { box ->
+            val start = box.selectionStart.coerceAtLeast(0)
+            val end = box.selectionEnd.coerceAtLeast(start)
+            if (end > start) {
+                box.text?.delete(start, end)
+                try { box.setSelection(start) } catch (_: Exception) {}
+            } else if (start > 0) {
+                box.text?.delete(start - 1, start)
+                try { box.setSelection(start - 1) } catch (_: Exception) {}
+            }
+        }
+        return true
+    }
+
+    /**
      * 静默上屏：与 [commitText] 相同的落盘路径（内部编辑器重定向、InputConnection、
      * text_committed 事件、联想上下文/输入统计），但不触发联想推理。
      * 手写叠写自动上屏/替换使用——笔画替换频率高，逐次推理既浪费又会闪烁候选栏。
@@ -2237,12 +2263,16 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
      */
     internal fun commitTextSilently(text: String) {
         if (uiState.value.quickSendFormFocused) {
+            // 焦点在触发编码输入框时路由到编码框，否则路由到快捷发送文本框
+            val codeFocused = uiState.value.quickSendCodeFocused
             mainHandler.post {
-                QuickSendFormEditTextHolder.editText?.let { et ->
-                    val start = et.selectionStart.coerceAtLeast(0)
+                val et = if (codeFocused) QuickSendFormCodeEditTextHolder.editText
+                else QuickSendFormEditTextHolder.editText
+                et?.let { box ->
+                    val start = box.selectionStart.coerceAtLeast(0)
                     val textLen = text.length
-                    et.text?.replace(start, et.selectionEnd.coerceAtLeast(start), text)
-                    try { et.setSelection(start + textLen) } catch (_: Exception) {}
+                    box.text?.replace(start, box.selectionEnd.coerceAtLeast(start), text)
+                    try { box.setSelection(start + textLen) } catch (_: Exception) {}
                 }
             }
             return
@@ -2291,8 +2321,12 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     internal fun deleteBeforeCursor(count: Int) {
         val quickSendFocused = uiState.value.quickSendFormFocused
         if (quickSendFocused || uiState.value.toolPanelInputFocused) {
-            val et = if (quickSendFocused) QuickSendFormEditTextHolder.editText
-            else ToolPanelEditTextHolder.editText
+            val et = when {
+                quickSendFocused && uiState.value.quickSendCodeFocused ->
+                    QuickSendFormCodeEditTextHolder.editText
+                quickSendFocused -> QuickSendFormEditTextHolder.editText
+                else -> ToolPanelEditTextHolder.editText
+            }
             et?.let { box ->
                 val end = box.selectionStart.coerceAtLeast(0)
                 val start = (end - count).coerceAtLeast(0)
@@ -2311,8 +2345,12 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     internal fun replaceBeforeCursor(expected: String, replacement: String): Boolean {
         val quickSendFocused = uiState.value.quickSendFormFocused
         if (quickSendFocused || uiState.value.toolPanelInputFocused) {
-            val et = (if (quickSendFocused) QuickSendFormEditTextHolder.editText
-            else ToolPanelEditTextHolder.editText) ?: return false
+            val et = when {
+                quickSendFocused && uiState.value.quickSendCodeFocused ->
+                    QuickSendFormCodeEditTextHolder.editText
+                quickSendFocused -> QuickSendFormEditTextHolder.editText
+                else -> ToolPanelEditTextHolder.editText
+            } ?: return false
             val selStart = et.selectionStart.coerceAtLeast(0)
             val start = (selStart - expected.length).coerceAtLeast(0)
             val before = et.text?.substring(start, selStart)

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
@@ -105,6 +105,8 @@ data class KeyboardCallbacks(
     val onHideQuickSendForm: (() -> Unit)? = null,
     val onQuickSendEditItem: ((Long, String, String) -> Unit)? = null,
     val onQuickSendFormFocusChange: ((Boolean) -> Unit)? = null,
+    /** 快捷发送表单"触发编码"输入框焦点变化（决定按键输入路由到编码框）。 */
+    val onQuickSendCodeFocusChange: ((Boolean) -> Unit)? = null,
     /**
      * 全键盘（中文/英文）切离至其他键盘（数字/符号）时调用。
      * 服务层负责上屏首位候选词或待确认英文，再由键盘层切换布局。

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
@@ -2,6 +2,7 @@ package com.kingzcheung.xime.ui.keyboard
 
 import com.kingzcheung.xime.keyboard.GestureAction
 import com.kingzcheung.xime.rime.RimeComposition
+import com.kingzcheung.xime.rime.RimeProcessResult
 import com.kingzcheung.xime.viewmodel.SchemaSwitchUiState
 
 data class KeyboardCallbacks(
@@ -95,7 +96,10 @@ data class KeyboardCallbacks(
      * T9 键盘状态变更后通知服务层刷新 UI（候选区、preedit 等）。
      * 携带 flush 后一次取回的 composition，服务层直接应用，避免内部重复 getComposition。
      */
-    var onT9RefreshComposition: ((RimeComposition) -> Unit)? = null,
+    var onT9RefreshComposition: ((RimeComposition, List<com.kingzcheung.xime.service.T9CandidateInjection>) -> Unit)? = null,
+    /** T9 候选词变换（hotPath 插件能力）：T9 控制器后台取数后调用，
+     *  返回带引擎锚点的插件候选注入列表（text 追加项），null/空 = 不干预。 */
+    val onTCandidateTransform: ((RimeProcessResult) -> List<com.kingzcheung.xime.service.T9CandidateInjection>?)? = null,
     val onShowQuickSendForm: (() -> Unit)? = null,
     /**
      * 从剪贴板面板主动拉取远端剪贴板内容（仅剪贴板同步已启用时非空）。

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -300,6 +300,9 @@ fun KeyboardView(
                     onFocusChange = { focused: Boolean ->
                         callbacks.onQuickSendFormFocusChange?.invoke(focused)
                     },
+                    onCodeFocusChange = { focused: Boolean ->
+                        callbacks.onQuickSendCodeFocusChange?.invoke(focused)
+                    },
                 )
             }
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -103,10 +103,11 @@ fun KeyboardView(
 
     val t9Controller = remember {
         T9InputController(
-            onCompositionRefresh = { composition ->
-                callbacks.onT9RefreshComposition?.invoke(composition)
+            onCompositionRefresh = { composition, snapshots ->
+                callbacks.onT9RefreshComposition?.invoke(composition, snapshots)
             },
             onRightCommitUndone = callbacks.onT9RightCommitUndone,
+            candidateTransform = callbacks.onTCandidateTransform,
         )
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/QuickSendFormArea.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/QuickSendFormArea.kt
@@ -34,6 +34,7 @@ fun QuickSendFormArea(
     editingItemId: Long? = null,
     onClose: (text: String, code: String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
+    onCodeFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val closeButtonBg = androidx.compose.ui.graphics.lerp(
@@ -123,8 +124,13 @@ fun QuickSendFormArea(
                         imeOptions = EditorInfo.IME_FLAG_NO_ENTER_ACTION or
                             EditorInfo.IME_ACTION_DONE
 
+                        // 焦点回调 + 点击抢焦点：宿主按键输入按焦点路由（文本框 vs 编码框）
+                        onFocusChangeListener = View.OnFocusChangeListener { _, hasFocus ->
+                            if (hasFocus) onCodeFocusChange(true) else onCodeFocusChange(false)
+                        }
                         setOnClickListener {
-                            onFocusChange(true)
+                            requestFocus()
+                            onCodeFocusChange(true)
                         }
                         QuickSendFormCodeEditTextHolder.editText = this
                     }


### PR DESCRIPTION
## 概述

- 新增 quickSendCodeFocused 状态字段用于跟踪快捷发送表单中编码输入框的焦点状态
- 实现 deleteInQuickSendForm 方法，支持根据焦点位置路由退格键到对应的输入框
- 重构 commitTextSilently 和 deleteBeforeCursor 方法，使其能够根据焦点位置正确处理输入
- 在键盘回调中添加 onQuickSendCodeFocusChange 回调函数，用于同步编码框焦点状态
- 更新快捷发送表单区域的焦点管理逻辑，确保按键输入能正确路由到文本框或编码框

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
