### PR TITLE
fix(keyboard): 优化平板按键文字与横屏布局

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -65,6 +66,27 @@ val LocalKeyVisualPadding = staticCompositionLocalOf {
 /** 按键圆角半径，由各布局在根层通过 CompositionLocalProvider 提供。
  *  独立于 shadow.shape_radius，为统一配置化而设。 */
 val LocalKeyCornerRadius = staticCompositionLocalOf { 8.dp }
+
+/** 按键内容随按键实际高度放大；手机尺寸下保持原字号。 */
+internal fun adaptiveKeyContentScale(
+    keyHeightDp: Float,
+    referenceHeightDp: Float = 56f,
+): Float {
+    if (!keyHeightDp.isFinite() || keyHeightDp <= 0f) return 1f
+    return (keyHeightDp / referenceHeightDp).coerceIn(1f, 1.5f)
+}
+
+/** 滑动提示在大按键上比主字符增长稍快，避免视觉上仍然偏小。 */
+internal fun adaptiveHintScale(contentScale: Float): Float =
+    (1f + (contentScale - 1f) * 1.5f).coerceIn(1f, 1.7f)
+
+/** 气泡跟随提示放大，但略微收敛，避免在平板上显得过重。 */
+internal fun adaptiveBubbleScale(contentScale: Float): Float =
+    adaptiveHintScale(contentScale).coerceAtMost(1.5f)
+
+/** 主字符放大时同步拉开上下提示，手机尺寸下保持原来的 14dp 间距。 */
+internal fun adaptiveHintOffsetDp(contentScale: Float): Float =
+    (14f + (contentScale - 1f) * 25f).coerceIn(14f, 24f)
 
 data class SwipeState(
     val isSwiping: Boolean = false,
@@ -436,7 +458,7 @@ fun SwipeableKeyButton(
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
     val chaiPuaFontFamily = AppFonts.chaiPuaFontFamily
 
-    Box(
+    BoxWithConstraints(
         modifier = modifier
             .fillMaxHeight()
             .fillMaxWidth()
@@ -651,6 +673,11 @@ fun SwipeableKeyButton(
             ),
         contentAlignment = if (layoutMode == ButtonLayout.COMPACT) Alignment.TopStart else Alignment.Center
     ) {
+        val contentScale = adaptiveKeyContentScale(maxHeight.value)
+        val hintScale = adaptiveHintScale(contentScale)
+        val hintOffset = adaptiveHintOffsetDp(contentScale).dp
+        val effectiveSwipeFontSize = (swipeFontSize.value * hintScale).sp
+
         if (layoutMode == ButtonLayout.COMPACT) {
             Box(modifier = Modifier.fillMaxSize()) {
                 if (icon != null) {
@@ -667,7 +694,7 @@ fun SwipeableKeyButton(
                     Text(
                         text = text,
                         color = textColor,
-                        fontSize = if (fontSize != androidx.compose.ui.unit.TextUnit.Unspecified) fontSize else if (text.length > 2) 13.sp else 16.sp,
+                        fontSize = ((if (fontSize != androidx.compose.ui.unit.TextUnit.Unspecified) fontSize.value else if (text.length > 2) 13f else 16f) * contentScale).sp,
                         fontWeight = if (text.length > 2) FontWeight.Medium else FontWeight.Normal,
                         textAlign = TextAlign.Start,
                         maxLines = 1,
@@ -691,7 +718,7 @@ fun SwipeableKeyButton(
                         Text(
                             text = displayText,
                             color = textColor.copy(alpha = 0.6f),
-                            fontSize = swipeFontSize,
+                            fontSize = effectiveSwipeFontSize,
                             fontWeight = FontWeight.Medium,
                             textAlign = TextAlign.End,
                             maxLines = 1,
@@ -702,7 +729,7 @@ fun SwipeableKeyButton(
                     val swipeDownHint = swipeDownKeyLabel
                     if (!swipeDownHint.isNullOrEmpty()) {
                         val hasChinese = swipeDownHint.any { it in '\u4e00'..'\u9fff' || it in '\u3400'..'\u4dbf' || it in '\uf900'..'\ufaff' }
-                        val adjustedFontSize = if (hasChinese && swipeFontSize > 6.sp) (swipeFontSize.value * 0.85f).sp else swipeFontSize
+                        val adjustedFontSize = if (hasChinese && effectiveSwipeFontSize > 6.sp) (effectiveSwipeFontSize.value * 0.85f).sp else effectiveSwipeFontSize
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -736,7 +763,7 @@ fun SwipeableKeyButton(
                 Text(
                     text = text,
                     color = textColor,
-                    fontSize = if (fontSize != androidx.compose.ui.unit.TextUnit.Unspecified) fontSize else if (text.length > 2) 14.sp else 18.sp,
+                    fontSize = ((if (fontSize != androidx.compose.ui.unit.TextUnit.Unspecified) fontSize.value else if (text.length > 2) 14f else 18f) * contentScale).sp,
                     fontWeight = if (text.length > 2) FontWeight.Medium else FontWeight.Normal,
                     textAlign = TextAlign.Center,
                     maxLines = 1
@@ -749,11 +776,11 @@ fun SwipeableKeyButton(
                 Text(
                     text = displayText,
                     color = textColor.copy(alpha = 0.6f),
-                    fontSize = swipeFontSize,
+                    fontSize = effectiveSwipeFontSize,
                     fontWeight = FontWeight.Medium,
                     textAlign = TextAlign.Center,
                     maxLines = 1,
-                    modifier = Modifier.offset(y = (-14).dp)
+                    modifier = Modifier.offset(y = -hintOffset)
                 )
             }
 
@@ -762,11 +789,11 @@ fun SwipeableKeyButton(
                 Text(
                     text = displayText,
                     color = textColor.copy(alpha = 0.5f),
-                    fontSize = swipeFontSize,
+                    fontSize = effectiveSwipeFontSize,
                     fontWeight = FontWeight.Normal,
                     textAlign = TextAlign.Center,
                     maxLines = 1,
-                    modifier = Modifier.offset(y = (14).dp)
+                    modifier = Modifier.offset(y = hintOffset)
                 )
             }
 
@@ -774,7 +801,7 @@ fun SwipeableKeyButton(
                 Text(
                     text = badgeText,
                     color = textColor.copy(alpha = 0.5f),
-                    fontSize = 10.sp,
+                    fontSize = (10f * hintScale).sp,
                     fontWeight = FontWeight.Normal,
                     textAlign = TextAlign.End,
                     maxLines = 1,

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -1499,7 +1500,7 @@ private fun LandscapeKeyboardContent(
                     iconColor = specialKeyTextColor,
                     modifier = Modifier
                         .padding(1.dp)
-                        .width(48.dp)
+                        .weight(1f)
                         .fillMaxHeight(),
                     onLongClick = { onKeyPress("delete") },
                     onPress = { onKeyPressDown?.invoke("delete") },
@@ -1701,7 +1702,7 @@ fun SwipeableKeyButtonLandscape(
         )
     }
 
-    Box(
+    BoxWithConstraints(
         modifier = modifier
             .fillMaxHeight()
             .fillMaxWidth()
@@ -1909,6 +1910,15 @@ fun SwipeableKeyButtonLandscape(
             .background(if (isPressed) darkenColor(backgroundColor) else backgroundColor),
         contentAlignment = Alignment.TopStart
     ) {
+        val contentScale = adaptiveKeyContentScale(
+            keyHeightDp = maxHeight.value,
+            referenceHeightDp = 44f,
+        )
+        val hintScale = adaptiveHintScale(contentScale)
+        val effectiveFontSize = (
+            if (fontSize != androidx.compose.ui.unit.TextUnit.Unspecified) fontSize.value else 14f
+        ) * contentScale
+        val effectiveSwipeFontSize = swipeFontSize.value * hintScale
 
         Box(
             modifier = Modifier.fillMaxSize(),
@@ -1917,7 +1927,7 @@ fun SwipeableKeyButtonLandscape(
             Text(
                 text = text,
                 color = textColor,
-                fontSize = if (fontSize != androidx.compose.ui.unit.TextUnit.Unspecified) fontSize else 14.sp,
+                fontSize = effectiveFontSize.sp,
                 fontWeight = FontWeight.Medium,
                 textAlign = TextAlign.Center,
                 maxLines = 1,
@@ -1930,11 +1940,11 @@ fun SwipeableKeyButtonLandscape(
             Text(
                 text = keyLabel,
                 color = textColor.copy(alpha = 0.5f),
-                fontSize = swipeFontSize,
+                fontSize = effectiveSwipeFontSize.sp,
                 fontWeight = FontWeight.Normal,
                 textAlign = TextAlign.End,
                 maxLines = 1,
-                lineHeight = 8.sp,
+                lineHeight = (8f * hintScale).sp,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .padding(top = 2.dp, end = 4.dp)
@@ -1944,12 +1954,12 @@ fun SwipeableKeyButtonLandscape(
             Text(
                 text = swipeDownKeyLabel,
                 color = textColor.copy(alpha = 0.5f),
-                fontSize = swipeFontSize,
+                fontSize = effectiveSwipeFontSize.sp,
                 fontWeight = FontWeight.Normal,
                 fontFamily = chaiPuaFontFamily,
                 textAlign = TextAlign.Start,
                 maxLines = 1,
-                lineHeight = 8.sp,
+                lineHeight = (8f * hintScale).sp,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .padding(start = 4.dp, bottom = 2.dp)

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SwipeBubble.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SwipeBubble.kt
@@ -1,5 +1,6 @@
 package com.kingzcheung.xime.ui.keyboard
 
+import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.Paint
 import android.graphics.Path
@@ -17,6 +18,7 @@ import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -135,16 +137,23 @@ fun rememberSwipeBubbleDrawData(
     if (!isLongPressMode && displayText.isNullOrEmpty()) return null
 
     val density = LocalDensity.current
-    val bodyHeightPx = with(density) { BubbleBodyHeight.toPx() }
+    val referenceHeightDp =
+        if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) 44f else 56f
+    val contentScale = adaptiveKeyContentScale(
+        keyHeightDp = keyBounds.height / density.density,
+        referenceHeightDp = referenceHeightDp,
+    )
+    val bubbleScale = adaptiveBubbleScale(contentScale)
+    val bodyHeightPx = with(density) { BubbleBodyHeight.toPx() } * bubbleScale
     // 尖端完整覆盖按下的按键（与按键同高），宽体锚定按键顶部悬在上方（见 boxTop）。
     // 全部基于真实按键 bounds 计算，不再用 KeyHeight 估算值——
     // 键盘高度被调大时估算失准，宽体会下沉进按键被手指挡住。
     val pointerHeightPx = keyBounds.height
-    val cornerRadiusPx = with(density) { BubbleCornerRadius.toPx() }
+    val cornerRadiusPx = with(density) { BubbleCornerRadius.toPx() } * bubbleScale
     val screenMarginPx = with(density) { BubbleScreenMargin.toPx() }
     val keyWidthPx = keyWidth
     val minBodyWidthPx = keyWidthPx * 1.8f
-    val shadowRadiusPx = with(density) { 4.dp.toPx() }
+    val shadowRadiusPx = with(density) { 4.dp.toPx() } * bubbleScale
 
     val accentArgb = accentColor.toArgb()
     val isDarkTheme = keyTextColor == Color(0xFFE8EAED)
@@ -155,9 +164,9 @@ fun rememberSwipeBubbleDrawData(
 
     val chaiTypeface = AppFonts.chaiPuaTypeface
 
-    val textPaint = remember {
+    val textPaint = remember(bubbleScale) {
         Paint().apply {
-            textSize = with(density) { 16.sp.toPx() }
+            textSize = with(density) { 16.sp.toPx() } * bubbleScale
             isAntiAlias = true
         }
     }
@@ -169,13 +178,13 @@ fun rememberSwipeBubbleDrawData(
             maxOf(swipeState.longPressItems.size, 3)
         cellMin * keyWidthPx
     } else {
-        maxOf(textPaint.measureText(displayText!!) + with(density) { 20.dp.toPx() }, minBodyWidthPx)
+        maxOf(textPaint.measureText(displayText!!) + with(density) { 20.dp.toPx() } * bubbleScale, minBodyWidthPx)
     }
 
-    val textSizePx = with(density) { 16.sp.toPx() }
-    val selectedFontSizePx = with(density) { 20.sp.toPx() }
-    val normalFontSizePx = with(density) { 16.sp.toPx() }
-    val selectedBgRadiusPx = with(density) { 6.dp.toPx() }
+    val textSizePx = with(density) { 16.sp.toPx() } * bubbleScale
+    val selectedFontSizePx = with(density) { 20.sp.toPx() } * bubbleScale
+    val normalFontSizePx = with(density) { 16.sp.toPx() } * bubbleScale
+    val selectedBgRadiusPx = with(density) { 6.dp.toPx() } * bubbleScale
 
     val pointerCenterX = keyBounds.left + keyBounds.width / 2f
     val bodyLeft = (pointerCenterX - bodyWidth / 2f).coerceIn(
@@ -202,7 +211,7 @@ fun rememberSwipeBubbleDrawData(
     val pathBodyLeft = if (isLeftFlush && leftRoom <= cornerRadiusPx) pointerLeftInBox else bodyLeftInBox
     val pathBodyWidth = (if (isRightFlush && rightRoom <= cornerRadiusPx) pointerRightInBox else (bodyLeftInBox + bodyWidth)) - pathBodyLeft
 
-    val paddingPx = with(density) { 10.dp.toPx() }
+    val paddingPx = with(density) { 10.dp.toPx() } * bubbleScale
 
     val longPressIconBitmaps = remember(swipeState.longPressDrawableIds, textColor) {
         swipeState.longPressDrawableIds.mapNotNull { id ->

--- a/app/src/test/java/com/kingzcheung/xime/ui/keyboard/KeyboardResponsiveSizingTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/ui/keyboard/KeyboardResponsiveSizingTest.kt
@@ -1,0 +1,29 @@
+package com.kingzcheung.xime.ui.keyboard
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class KeyboardResponsiveSizingTest {
+    private val tolerance = 0.0001f
+
+    @Test
+    fun phoneSizedKeyKeepsOriginalSizing() {
+        assertEquals(1f, adaptiveKeyContentScale(keyHeightDp = 56f), tolerance)
+        assertEquals(1f, adaptiveHintScale(contentScale = 1f), tolerance)
+        assertEquals(14f, adaptiveHintOffsetDp(contentScale = 1f), tolerance)
+    }
+
+    @Test
+    fun largerKeyScalesLabelsAndHintsWithinLimits() {
+        assertEquals(1.25f, adaptiveKeyContentScale(keyHeightDp = 70f), tolerance)
+        assertEquals(1.7f, adaptiveHintScale(contentScale = 1.5f), tolerance)
+        assertEquals(1.5f, adaptiveBubbleScale(contentScale = 1.5f), tolerance)
+        assertEquals(24f, adaptiveHintOffsetDp(contentScale = 1.5f), tolerance)
+    }
+
+    @Test
+    fun smallerKeysAreNotShrunkAndLargeKeysAreClamped() {
+        assertEquals(1f, adaptiveKeyContentScale(keyHeightDp = 20f), tolerance)
+        assertEquals(1.5f, adaptiveKeyContentScale(keyHeightDp = 120f), tolerance)
+    }
+}


### PR DESCRIPTION
## 概述

针对 #773 中平板按键变大后，按键文字和滑动提示相对偏小的问题，让按键内容根据按键的实际高度适当缩放。

主要改动：

- 主字符随按键高度缩放，最大为原字号的 1.5 倍
- 按键上的上滑、下滑符号单独放宽到最大 1.7 倍，并适当调整与主字符之间的位置
- 滑动时弹出的提示气泡随按键尺寸缩放，最大为原尺寸的 1.5 倍
- 横竖屏使用同一套按键高度缩放逻辑，不再单独提高平板横屏的基础字号
- 横屏删除键不再使用固定宽度，改为和同一行的字母键按比例分配空间
- 添加缩放倍率和边界值的单元测试

本次没有调整键盘整体高度、横屏分离布局和中间间距。

## 关联 Issue

Closes #773

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机上验证

实机效果

8.8 英寸平板

竖屏：
<img width="1880" height="2920" alt="Screenshot_2026-09-02-13-11-22-028_com kingzcheung xime" src="https://github.com/user-attachments/assets/fedb8bbe-adac-4cac-bdf4-5945d219fe8a" />

横屏：
<img width="3008" height="1789" alt="Screenshot_2026-09-02-13-11-12-932_com kingzcheung xime" src="https://github.com/user-attachments/assets/599bf33b-a459-4d68-bd16-8cca7d7ef881" />

手机端回归测试

竖屏：
<img width="1264" height="2660" alt="Screenshot_20260902_141646_com_kingzcheung_xime_MainActivity" src="https://github.com/user-attachments/assets/4e1884c4-f705-4a0a-bc02-7b0a7fd540b9" />

横屏：
<img width="2800" height="1160" alt="Screenshot_20260902_141655_com_kingzcheung_xime_MainActivity" src="https://github.com/user-attachments/assets/27052288-fab6-4cc6-a420-4470cdb1f7d4" />

滑动提示气泡
<img width="1880" height="2904" alt="Screenshot_2026-09-02-11-54-04-873_com kingzcheung xime" src="https://github.com/user-attachments/assets/240c189b-7a49-4758-a5aa-2c1e8a852073" />


## 备注

已在 8.8 英寸 Redmi K Pad 上测试横屏和竖屏，也在手机上对比了横屏、竖屏效果，目前没有发现明显的显示异常。

测试过程中还检查了滑动提示气泡，以及横屏删除键改为比例宽度后的布局。相关测试构建已通过 [GitHub Actions](https://github.com/CloudThick/Xime/actions/runs/33589644037)。

由于手边没有 10 英寸或 12 英寸平板，更大尺寸设备上的实际效果暂时还没有验证。
