### PR TITLE
chore(submodule): 更新 librime 子模块 URL 和提交版本

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "librime"]
 	path = app/src/main/jni/librime
-	url = https://github.com/rime/librime.git
+	url = git@github.com:ximeiorg/librime.git
 [submodule "app/src/main/jni/snappy"]
 	path = app/src/main/jni/snappy
 	url = https://github.com/google/snappy.git


### PR DESCRIPTION
- 将 librime 子模块的 URL 从 HTTPS 方式改为 SSH 方式
- 更新主项目中 rime 配置的子模块提交版本
- 修正 librime-lua-deps 子模块的提交状态标记

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [x] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
