### PR TITLE
fix: 修复内置 xime.yaml 的 keyboard.fonts 空值导致自定义字体加载失败

### DIFF
--- a/app/src/main/assets/xime.yaml
+++ b/app/src/main/assets/xime.yaml
@@ -407,10 +407,10 @@ keyboard:
   #   - 相对路径（包含 /）：相对于 rime/ 目录，如 fonts/myfont.ttf
   #   - 仅文件名：相对于 rime/ 目录查找，如 myfont.ttf
   fonts:
-    # key_font: "rime/fonts/Xim-Sans-ShouXieTi-2.ttf"          # 按键主字字体
-    # key_label_font: "rime/fonts/Xim-Sans-ShouXieTi-2.ttf"    # 字根/标签字体（默认使用 ChaiPUA）
-    # candidate_font: "rime/fonts/Xim-Sans-ShouXieTi-2.ttf"     # 候选项字体
-    # comment_font: "rime/fonts/Xim-Sans-ShouXieTi-2.ttf"       # 候选注释字体
+    key_font: ""
+    key_label_font: ""
+    candidate_font: ""
+    comment_font: ""
 
   qwerty:
     # ── 按键布局模式 ──


### PR DESCRIPTION
## 概述

内置 `xime.yaml` 的 `keyboard.fonts` 段所有字段被注释掉，YAML 解析器将其视为 null。`parseKeyboardFontsYamlText` 尝试解析为 YamlMap 时抛出 `IncorrectTypeException`，导致整个字体加载流程被跳过，用户在 `xime.custom.yaml` 中配置的自定义字体完全无效。

## 关联 Issue

还是昨天这个问题，本机配置了半天没有生效，让ai分析了一下有个小问题

https://github.com/ximeiorg/Xime/issues/410

## 改动类型

- [x] Bug 修复

## 改动内容

将 `app/src/main/assets/xime.yaml` 中 `keyboard.fonts` 段注释掉的空值改为显式空字符串：

```yaml
  fonts:
    key_font: ""
    key_label_font: ""
    candidate_font: ""
    comment_font: ""
```

## 自测清单

- [x] 代码编译通过
- [x] 已在真机上验证（PKX110, arm64-v8a）
- [x] logcat 中 `IncorrectTypeException` 不再出现
- [x] `xime.custom.yaml` 中配置的 `comment_font` 正常加载

自测的 zip 链接 https://github.com/aizigao/Xime_wubi_xinshiji/releases/download/v2.3.0/wubixsj-2.3.0.zip 
选中新世纪五笔时会出现 
<img width="1766" height="846" alt="image" src="https://github.com/user-attachments/assets/4ab30106-0c8a-468a-8c99-780c235b06af" />
