### PR TITLE
feat: 升级手写识别为IPC架构并修复模型自愈机制 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,8 +43,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 20260903
-        versionName = "2.8.0-beta2"
+        versionCode = 20260904
+        versionName = "2.8.0-beta3"
 
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/aidl/com/kingzcheung/xime/service/IInferenceService.aidl
+++ b/app/src/main/aidl/com/kingzcheung/xime/service/IInferenceService.aidl
@@ -9,8 +9,9 @@ interface IInferenceService {
     /** 智能联想预测 — 返回交替 [word, score, word, score, ...] */
     List<String> predict(String modelId, String text, int topK);
 
-    /** 手写识别 — 返回交替 [index, score, index, score, ...] */
-    List<String> recognizeHandwriting(String modelId, in float[] strokeData, in byte[] mask, int topK);
+    /** 手写识别 — 传入原始笔画（points = 扁平 [x0,y0,x1,y1,...]，strokePointCounts = 每笔画点数），
+        服务端完成预处理与汉字映射，返回交替 [字, score, 字, score, ...] */
+    List<String> recognizeHandwriting(String modelId, in float[] points, in int[] strokePointCounts, int topK);
 
     /** 语音前处理（AGC 等） */
     byte[] processAudioBytes(in byte[] input, int sampleRate);

--- a/app/src/main/java/com/kingzcheung/xime/association/AssociationManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/association/AssociationManager.kt
@@ -82,6 +82,19 @@ object AssociationManager {
             }
         }
         
+        // :inference 进程被系统回收（空闲回收是设计内行为，同 AsrInferenceService 的
+        // 空闲释放）后，OnnxAssociationEngine 检测到失联会重置自身状态，而本类的
+        // isInitialized 仍为 true。必须在这里检测引擎状态并按需重载（重新 bind +
+        // loadModel），否则所有预测入口都会被本方法上方的 isInitialized 守卫放行、
+        // 撞上引擎的 "Engine not initialized" 空转，联想永远失效。
+        if (!OnnxAssociationEngine.isInitialized()) {
+            val reloaded = ModelRuntime.load("predictive_text")
+            if (!reloaded) {
+                FileLogger.e(TAG, "Reload predictive_text failed after service reclaim")
+                return@withContext emptyList()
+            }
+        }
+
         try {
             val modelCandidates = OnnxAssociationEngine.predict(contextText, topK * 2)
             

--- a/app/src/main/java/com/kingzcheung/xime/association/OnnxAssociationEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/association/OnnxAssociationEngine.kt
@@ -17,6 +17,7 @@ import java.io.File
 object OnnxAssociationEngine {
     private const val TAG = "OnnxAssociationEngine"
 
+    @Volatile
     private var isInitialized = false
     private var warmupStarted = false
     private val warmupScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
@@ -63,6 +64,14 @@ object OnnxAssociationEngine {
             // （ServiceConnectionLeaked：切换预测设置时反复 initialize 累积泄漏）
             inferenceClient?.unbind()
             inferenceClient = client
+            client.onDisconnected = {
+                // 服务进程被回收后 AUTO_CREATE 自动重启只恢复 binder，模型不会自己回来：
+                // 软重置本地状态（不 unbind，保留系统自动重启与连接），下次预测由
+                // AssociationManager.predict 的引擎状态守卫检测并重新 load，
+                // 避免"重启抢先→服务端空返回→联想静默失效"
+                isInitialized = false
+                ModelRuntime.markUnloaded("predictive_text")
+            }
 
             if (!client.ensureBound()) {
                 FileLogger.e(TAG, "Failed to bind to InferenceService")
@@ -95,9 +104,10 @@ object OnnxAssociationEngine {
             return@withContext emptyList()
         }
 
-        // 服务进程崩溃后 binder 失效：这里必须重置本地"已初始化"假象，
-        // 否则联想将永远空转（无法重新 bind + loadModel）。重置后由
-        // AssociationManager.predict 的现有重试路径自动重新加载，实现自愈。
+        // 服务进程被系统回收（设计内行为）后 binder 失效：这里必须重置本地
+        // "已初始化"假象，否则联想将永远空转（无法重新 bind + loadModel）。
+        // 重置后由 AssociationManager.predict 的引擎状态守卫检测到并按需
+        // 重新加载（ModelRuntime.load → 本类 initialize），实现自愈。
         if (!client.isBound()) {
             FileLogger.w(TAG, "InferenceService not bound, resetting engine state for recovery")
             release()

--- a/app/src/main/java/com/kingzcheung/xime/handwriting/HandwritingEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/handwriting/HandwritingEngine.kt
@@ -1,61 +1,86 @@
 package com.kingzcheung.xime.handwriting
 
 import android.content.Context
+import android.os.SystemClock
 import android.util.Log
 import com.kingzcheung.xime.model.ModelStorage
+import com.kingzcheung.xime.service.InferenceClient
 import com.kingzcheung.xime.util.FileLogger
-import org.json.JSONArray
-import org.json.JSONObject
+import kotlinx.coroutines.runBlocking
 import java.io.File
-import kotlin.math.max
-import kotlin.math.min
-import kotlin.math.roundToInt
-import kotlin.math.sqrt
 
 data class HandwritingCandidate(
     val char: String,
     val score: Float,
 )
 
+/**
+ * 手写识别客户端（主进程）：只负责模型生命周期管理与 IPC 代理。
+ * 笔画预处理、ONNX 推理与 idx→汉字映射全部在 :inference 进程完成
+ * （见 [HandwritingInference]），主进程不加载 ONNX 运行库、不常驻词表。
+ */
 object HandwritingEngine {
     private const val TAG = "HandwritingEngine"
-    private const val FIXED_LEN = 200
-    private const val MAX_POINTS_PER_STROKE = 8
     private const val DEFAULT_TOP_K = 10
+    /** 自愈重试节流：:inference 进程回收后重载失败时，短时间内不重复 bind 空转。 */
+    private const val REINIT_RETRY_INTERVAL_MS = 5_000L
 
+    @Volatile
     private var initialized = false
-    private var chars: List<String> = emptyList()
-    private var modelFile: File? = null
-    private var charIndexFile: File? = null
+    private var inferenceClient: InferenceClient? = null
+    private var appContext: Context? = null
+
+    @Volatile
+    private var lastReinitAttemptMs = 0L
 
     fun initialize(context: Context): Boolean {
-        if (initialized) return true
+        if (initialized && inferenceClient?.isBound() == true) return true
 
-        val modelDir = ModelStorage.getModelDir(context, "ochwpro")
+        val ctx = context.applicationContext
+        val modelDir = ModelStorage.getModelDir(ctx, "ochwpro")
         // 兼容旧版：旧版手写模型在 filesDir 根目录
-        ModelStorage.migrateLegacyForModel(context, "ochwpro")
-        modelFile = File(modelDir, "ochwpro.onnx")
-        charIndexFile = File(modelDir, "char_index.json")
+        ModelStorage.migrateLegacyForModel(ctx, "ochwpro")
+        val modelFile = File(modelDir, "ochwpro.onnx")
+        val charIndexFile = File(modelDir, "char_index.json")
 
-        if (!modelFile!!.exists() || !charIndexFile!!.exists()) {
+        if (!modelFile.exists() || !charIndexFile.exists()) {
             Log.w(TAG, "Model files not found: $modelFile, $charIndexFile")
             return false
         }
 
         try {
-            if (!loadCharIndex(context)) {
-                Log.e(TAG, "Failed to load char_index.json")
-                return false
+            val client = InferenceClient(ctx)
+            // 先释放旧 client 的绑定，避免重复 initialize 泄漏 ServiceConnection
+            inferenceClient?.unbind()
+            inferenceClient = client
+            appContext = ctx
+            client.onDisconnected = {
+                // 进程被回收后系统 AUTO_CREATE 自动重启只恢复 binder，模型不会自己回来：
+                // 仅软重置本地"已加载"标志（不 unbind，保留自动重启），下次落笔由
+                // ensureEngineReady 检测到未初始化后重载，避免"重启抢先→静默空结果"
+                initialized = false
             }
 
-            val ok = HandwritingNativeEngine.initialize(context, modelFile!!.absolutePath)
-            if (!ok) {
-                Log.e(TAG, "Failed to initialize HandwritingNativeEngine")
+            // 调用方均在后台线程（键盘 LaunchedEffect(IO)/切方案 Thread），runBlocking 桥接 IPC
+            val bound = runBlocking { client.ensureBound() }
+            if (!bound) {
+                Log.e(TAG, "Failed to bind InferenceService for handwriting")
+                return false
+            }
+            val loaded = runBlocking {
+                client.loadModel(
+                    InferenceClient.MODEL_HANDWRITING,
+                    modelFile.absolutePath,
+                    charIndexFile.absolutePath
+                )
+            }
+            if (!loaded) {
+                Log.e(TAG, "Failed to load handwriting model in inference process")
                 return false
             }
 
             initialized = true
-            Log.i(TAG, "Handwriting engine initialized: ${chars.size} chars")
+            Log.i(TAG, "Handwriting engine initialized via IPC")
             return true
         } catch (e: Exception) {
             Log.e(TAG, "HandwritingEngine init failed: ${e.message}", e)
@@ -73,193 +98,65 @@ object HandwritingEngine {
         return File(modelDir, "ochwpro.onnx").exists() && File(modelDir, "char_index.json").exists()
     }
 
-    override fun toString(): String {
-        return "HandwritingEngine(initialized=$initialized, chars=${chars.size})"
-    }
-
-    private fun loadCharIndex(context: Context): Boolean {
-        return try {
-            val text = charIndexFile!!.readText().trimStart('\uFEFF')
-            val json = JSONObject(text)
-
-            val extracted = mutableListOf<String>()
-
-            if (json.has("chars")) {
-                val arr = json.getJSONArray("chars")
-                for (i in 0 until arr.length()) {
-                    extracted.add(arr.getString(i))
-                }
-            } else if (json.has("char_index")) {
-                val obj = json.getJSONObject("char_index")
-                val keys = obj.keys()
-                val indexed = mutableMapOf<Int, String>()
-                while (keys.hasNext()) {
-                    val ch = keys.next()
-                    indexed[obj.getInt(ch)] = ch
-                }
-                val maxIdx = indexed.keys.maxOrNull() ?: 0
-                extracted.addAll(Array(maxIdx + 1) { "" }.toList())
-                for ((idx, ch) in indexed) {
-                    extracted[idx] = ch
-                }
-            } else if (json.has("labels")) {
-                val arr = json.getJSONArray("labels")
-                for (i in 0 until arr.length()) {
-                    extracted.add(arr.optString(i, ""))
-                }
-            } else {
-                val keys = json.keys()
-                val indexed = mutableMapOf<Int, String>()
-                while (keys.hasNext()) {
-                    val key = keys.next()
-                    indexed[json.getInt(key)] = key
-                }
-                val maxIdx = indexed.keys.maxOrNull() ?: 0
-                extracted.addAll(Array(maxIdx + 1) { "" }.toList())
-                for ((idx, ch) in indexed) {
-                    extracted[idx] = ch
-                }
-            }
-
-            chars = extracted.toList()
-            true
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to load char_index: ${e.message}", e)
-            FileLogger.e(TAG, "Failed to load char_index: ${e.message}", e)
-            false
-        }
-    }
-
-    fun isCjk(ch: String): Boolean {
-        if (ch.length != 1) return false
-        val cp = ch[0].code
-        return (cp in 0x4E00..0x9FFF) ||
-               (cp in 0x3400..0x4DBF) ||
-               (cp in 0x20000..0x2A6DF) ||
-               (cp in 0x2A700..0x2B73F) ||
-               (cp in 0x2B740..0x2B81F) ||
-               (cp in 0x2B820..0x2CEAF) ||
-               (cp in 0xF900..0xFAFF) ||
-               (cp in 0x2F800..0x2FA1F)
-    }
-
-    internal fun simplifyStrokes(
-        strokes: List<List<Pair<Float, Float>>>
-    ): List<List<Pair<Float, Float>>> {
-        val simplified = mutableListOf<List<Pair<Float, Float>>>()
-        for (stroke in strokes) {
-            if (stroke.size <= MAX_POINTS_PER_STROKE) {
-                simplified.add(stroke)
-            } else {
-                val step = (stroke.size - 1).toFloat() / (MAX_POINTS_PER_STROKE - 1)
-                val indices = (0 until MAX_POINTS_PER_STROKE).map { i ->
-                    (i * step).roundToInt().coerceIn(0, stroke.size - 1)
-                }
-                simplified.add(indices.map { stroke[it] })
-            }
-        }
-        return simplified
-    }
-
-    internal data class SequenceData(
-        val data: FloatArray,
-        val originalLen: Int,
-    )
-
-    internal fun strokesToSequence(
-        strokes: List<List<Pair<Float, Float>>>
-    ): SequenceData {
-        val allPoints = mutableListOf<Pair<Float, Float>>()
-        val penDownFlags = mutableListOf<Int>()
-
-        for (stroke in strokes) {
-            for (pt in stroke) {
-                allPoints.add(pt)
-                penDownFlags.add(1)
-            }
-            if (penDownFlags.isNotEmpty()) {
-                penDownFlags[penDownFlags.size - 1] = 0
-            }
-        }
-
-        val T = allPoints.size
-        if (T == 0) {
-            return SequenceData(FloatArray(FIXED_LEN * 5) { 0f }, 0)
-        }
-
-        val xs = allPoints.map { it.first }
-        val ys = allPoints.map { it.second }
-
-        val minX = xs.min()
-        val maxX = xs.max()
-        val minY = ys.min()
-        val maxY = ys.max()
-
-        val rangeX = max(maxX - minX, 1.0f)
-        val rangeY = max(maxY - minY, 1.0f)
-
-        val seq = FloatArray(T * 5)
-        for (i in 0 until T) {
-            val xNorm = (allPoints[i].first - minX) / rangeX
-            val yNorm = (allPoints[i].second - minY) / rangeY
-            val dx = if (i == 0) 0f else (allPoints[i].first - allPoints[i - 1].first) / rangeX
-            val dy = if (i == 0) 0f else (allPoints[i].second - allPoints[i - 1].second) / rangeY
-            val base = i * 5
-            seq[base] = xNorm
-            seq[base + 1] = yNorm
-            seq[base + 2] = dx
-            seq[base + 3] = dy
-            seq[base + 4] = penDownFlags[i].toFloat()
-        }
-
-        val paddedLen = min(T, FIXED_LEN)
-        val padded = FloatArray(FIXED_LEN * 5) { 0f }
-        System.arraycopy(seq, 0, padded, 0, paddedLen * 5)
-        return SequenceData(padded, min(T, FIXED_LEN))
-    }
-
-    internal fun buildMask(seqLen: Int): ByteArray {
-        val mask = ByteArray(FIXED_LEN) { 0 }
-        for (i in 0 until min(seqLen, FIXED_LEN)) {
-            mask[i] = 1
-        }
-        return mask
-    }
-
     fun predict(
         strokes: List<List<Pair<Float, Float>>>,
         topK: Int = DEFAULT_TOP_K
     ): List<HandwritingCandidate> {
-        if (!initialized || strokes.isEmpty()) return emptyList()
+        if (strokes.isEmpty()) return emptyList()
+        if (!ensureEngineReady()) return emptyList()
+        val client = inferenceClient ?: return emptyList()
 
-        val simplified = simplifyStrokes(strokes)
-        if (simplified.isEmpty()) return emptyList()
-
-        val seqData = strokesToSequence(simplified)
-        val mask = buildMask(seqData.originalLen)
-
-        val rawResults = HandwritingNativeEngine.predict(seqData.data, mask, topK)
-        if (rawResults.isEmpty()) return emptyList()
-
-        val results = mutableListOf<HandwritingCandidate>()
-        val seen = mutableSetOf<String>()
-
-        for ((idx, score) in rawResults) {
-            if (idx < 0 || idx >= chars.size) continue
-            val ch = chars[idx]
-            if (ch.isEmpty()) continue
-            if (ch in seen) continue
-            seen.add(ch)
-            results.add(HandwritingCandidate(ch, score))
+        // 原始笔画扁平化：points = [x0,y0,x1,y1,...]，counts = 每笔画点数
+        var totalPoints = 0
+        for (stroke in strokes) totalPoints += stroke.size
+        val points = FloatArray(totalPoints * 2)
+        val counts = IntArray(strokes.size)
+        var pi = 0
+        strokes.forEachIndexed { i, stroke ->
+            counts[i] = stroke.size
+            for (pt in stroke) {
+                points[pi++] = pt.first
+                points[pi++] = pt.second
+            }
         }
 
-        return results.take(topK)
+        val candidates = runBlocking { client.recognizeHandwriting(points, counts, topK) }
+
+        // IPC 期间服务进程被回收（客户端已吞 DeadObjectException 并重置绑定）：
+        // 重置本地状态，下次 predict 由 ensureEngineReady 自愈重载
+        if (!client.isBound()) {
+            release()
+            return emptyList()
+        }
+        return candidates
+    }
+
+    /**
+     * 预测前确保引擎可用。:inference 进程被系统回收（设计内行为，同联想模型）
+     * 后在此按需重载（重新 bind + loadModel）实现自愈。从未初始化过时直接返回
+     * false，保持"无模型时 predict 返回空"的既有语义，不自动拉起服务。
+     */
+    private fun ensureEngineReady(): Boolean {
+        val ctx = appContext ?: return false
+        if (initialized && inferenceClient?.isBound() == true) return true
+
+        release()
+        val now = SystemClock.elapsedRealtime()
+        if (now - lastReinitAttemptMs < REINIT_RETRY_INTERVAL_MS) return false
+        lastReinitAttemptMs = now
+        return initialize(ctx)
     }
 
     fun release() {
-        if (!initialized) return
-        HandwritingNativeEngine.release()
+        if (!initialized && inferenceClient == null) return
         initialized = false
-        chars = emptyList()
+        inferenceClient?.apply {
+            try {
+                runBlocking { unloadModel(InferenceClient.MODEL_HANDWRITING) }
+            } catch (_: Exception) {
+            }
+            unbind()
+        }
+        inferenceClient = null
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/handwriting/HandwritingInference.kt
+++ b/app/src/main/java/com/kingzcheung/xime/handwriting/HandwritingInference.kt
@@ -1,0 +1,214 @@
+package com.kingzcheung.xime.handwriting
+
+import android.util.Log
+import com.kingzcheung.xime.util.FileLogger
+import org.json.JSONObject
+import java.io.File
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/**
+ * 手写完整推理管线，运行于 :inference 进程（仅由 [com.kingzcheung.xime.service.InferenceService] 调用）。
+ *
+ * 主进程客户端（[HandwritingEngine]）只传原始笔画、收最终候选字；
+ * 笔画预处理、ONNX 推理与 idx→汉字映射全部在本对象内完成，
+ * 保证输入法主进程不加载 ONNX 运行库、不常驻词表。
+ */
+object HandwritingInference {
+    private const val TAG = "HandwritingInference"
+    private const val FIXED_LEN = 200
+    private const val MAX_POINTS_PER_STROKE = 8
+
+    private var chars: List<String> = emptyList()
+
+    /** 加载 idx→汉字词表（char_index.json，路径由 loadModel 的 extraPath 传入）。 */
+    fun loadCharIndex(charIndexPath: String): Boolean {
+        return try {
+            val text = File(charIndexPath).readText().trimStart('\uFEFF')
+            val json = JSONObject(text)
+
+            val extracted = mutableListOf<String>()
+
+            if (json.has("chars")) {
+                val arr = json.getJSONArray("chars")
+                for (i in 0 until arr.length()) {
+                    extracted.add(arr.getString(i))
+                }
+            } else if (json.has("char_index")) {
+                val obj = json.getJSONObject("char_index")
+                val keys = obj.keys()
+                val indexed = mutableMapOf<Int, String>()
+                while (keys.hasNext()) {
+                    val ch = keys.next()
+                    indexed[obj.getInt(ch)] = ch
+                }
+                val maxIdx = indexed.keys.maxOrNull() ?: 0
+                extracted.addAll(Array(maxIdx + 1) { "" }.toList())
+                for ((idx, ch) in indexed) {
+                    extracted[idx] = ch
+                }
+            } else if (json.has("labels")) {
+                val arr = json.getJSONArray("labels")
+                for (i in 0 until arr.length()) {
+                    extracted.add(arr.optString(i, ""))
+                }
+            } else {
+                val keys = json.keys()
+                val indexed = mutableMapOf<Int, String>()
+                while (keys.hasNext()) {
+                    val key = keys.next()
+                    indexed[json.getInt(key)] = key
+                }
+                val maxIdx = indexed.keys.maxOrNull() ?: 0
+                extracted.addAll(Array(maxIdx + 1) { "" }.toList())
+                for ((idx, ch) in indexed) {
+                    extracted[idx] = ch
+                }
+            }
+
+            chars = extracted.toList()
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to load char_index: ${e.message}", e)
+            FileLogger.e(TAG, "Failed to load char_index: ${e.message}", e)
+            false
+        }
+    }
+
+    fun clearChars() {
+        chars = emptyList()
+    }
+
+    /** AIDL 原始笔画解码：points = [x0,y0,x1,y1,...]，strokePointCounts = 每笔画点数。 */
+    internal fun decodeStrokes(
+        points: FloatArray,
+        strokePointCounts: IntArray
+    ): List<List<Pair<Float, Float>>> {
+        val strokes = mutableListOf<List<Pair<Float, Float>>>()
+        var offset = 0
+        for (count in strokePointCounts) {
+            val stroke = mutableListOf<Pair<Float, Float>>()
+            repeat(count) {
+                if (offset + 1 < points.size) {
+                    stroke.add(points[offset] to points[offset + 1])
+                }
+                offset += 2
+            }
+            strokes.add(stroke)
+        }
+        return strokes
+    }
+
+    internal fun simplifyStrokes(
+        strokes: List<List<Pair<Float, Float>>>
+    ): List<List<Pair<Float, Float>>> {
+        val simplified = mutableListOf<List<Pair<Float, Float>>>()
+        for (stroke in strokes) {
+            if (stroke.size <= MAX_POINTS_PER_STROKE) {
+                simplified.add(stroke)
+            } else {
+                val step = (stroke.size - 1).toFloat() / (MAX_POINTS_PER_STROKE - 1)
+                val indices = (0 until MAX_POINTS_PER_STROKE).map { i ->
+                    (i * step).roundToInt().coerceIn(0, stroke.size - 1)
+                }
+                simplified.add(indices.map { stroke[it] })
+            }
+        }
+        return simplified
+    }
+
+    internal data class SequenceData(
+        val data: FloatArray,
+        val originalLen: Int,
+    )
+
+    internal fun strokesToSequence(
+        strokes: List<List<Pair<Float, Float>>>
+    ): SequenceData {
+        val allPoints = mutableListOf<Pair<Float, Float>>()
+        val penDownFlags = mutableListOf<Int>()
+
+        for (stroke in strokes) {
+            for (pt in stroke) {
+                allPoints.add(pt)
+                penDownFlags.add(1)
+            }
+            if (penDownFlags.isNotEmpty()) {
+                penDownFlags[penDownFlags.size - 1] = 0
+            }
+        }
+
+        val T = allPoints.size
+        if (T == 0) {
+            return SequenceData(FloatArray(FIXED_LEN * 5) { 0f }, 0)
+        }
+
+        val xs = allPoints.map { it.first }
+        val ys = allPoints.map { it.second }
+
+        val minX = xs.min()
+        val maxX = xs.max()
+        val minY = ys.min()
+        val maxY = ys.max()
+
+        val rangeX = max(maxX - minX, 1.0f)
+        val rangeY = max(maxY - minY, 1.0f)
+
+        val seq = FloatArray(T * 5)
+        for (i in 0 until T) {
+            val xNorm = (allPoints[i].first - minX) / rangeX
+            val yNorm = (allPoints[i].second - minY) / rangeY
+            val dx = if (i == 0) 0f else (allPoints[i].first - allPoints[i - 1].first) / rangeX
+            val dy = if (i == 0) 0f else (allPoints[i].second - allPoints[i - 1].second) / rangeY
+            val base = i * 5
+            seq[base] = xNorm
+            seq[base + 1] = yNorm
+            seq[base + 2] = dx
+            seq[base + 3] = dy
+            seq[base + 4] = penDownFlags[i].toFloat()
+        }
+
+        val paddedLen = min(T, FIXED_LEN)
+        val padded = FloatArray(FIXED_LEN * 5) { 0f }
+        System.arraycopy(seq, 0, padded, 0, paddedLen * 5)
+        return SequenceData(padded, min(T, FIXED_LEN))
+    }
+
+    internal fun buildMask(seqLen: Int): ByteArray {
+        val mask = ByteArray(FIXED_LEN) { 0 }
+        for (i in 0 until min(seqLen, FIXED_LEN)) {
+            mask[i] = 1
+        }
+        return mask
+    }
+
+    /** 完整推理：预处理 → native ONNX → idx→汉字映射（去重、截断）。 */
+    fun recognize(
+        strokes: List<List<Pair<Float, Float>>>,
+        topK: Int
+    ): List<HandwritingCandidate> {
+        val simplified = simplifyStrokes(strokes)
+        if (simplified.isEmpty()) return emptyList()
+
+        val seqData = strokesToSequence(simplified)
+        val mask = buildMask(seqData.originalLen)
+
+        val rawResults = HandwritingNativeEngine.predict(seqData.data, mask, topK)
+        if (rawResults.isEmpty()) return emptyList()
+
+        val results = mutableListOf<HandwritingCandidate>()
+        val seen = mutableSetOf<String>()
+
+        for ((idx, score) in rawResults) {
+            if (idx < 0 || idx >= chars.size) continue
+            val ch = chars[idx]
+            if (ch.isEmpty()) continue
+            if (ch in seen) continue
+            seen.add(ch)
+            results.add(HandwritingCandidate(ch, score))
+        }
+
+        return results.take(topK)
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/handwriting/HandwritingNativeEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/handwriting/HandwritingNativeEngine.kt
@@ -6,7 +6,16 @@ import java.io.File
 
 object HandwritingNativeEngine {
     private const val TAG = "HandwritingNativeEngine"
-    private var nativeLoaded = false
+
+    /**
+     * native 生命周期 Java 侧镜像。libhandwriting_jni.so 懒加载（首次 initialize
+     * 才装载），此前任何裸调 nativeIsInitialized/nativeRelease 都会抛
+     * UnsatisfiedLinkError 炸掉 binder 线程（:inference 进程启动后首次
+     * loadModel/isModelLoaded/unloadModel 即触发）。状态由 initialize/release
+     * 维护，库未加载时各查询安全返回 false。
+     */
+    @Volatile
+    private var nativeReady = false
 
     fun loadNativeLibrary(context: Context): Boolean {
         val libsToLoad = listOf("libonnxruntime.so", "libhandwriting_jni.so")
@@ -16,7 +25,6 @@ object HandwritingNativeEngine {
                 return false
             }
         }
-        nativeLoaded = true
         return true
     }
 
@@ -51,6 +59,7 @@ object HandwritingNativeEngine {
     fun initialize(context: Context, modelPath: String): Boolean {
         try {
             nativeInitialize(modelPath)
+            nativeReady = true
             return true
         } catch (e: UnsatisfiedLinkError) {
         }
@@ -59,18 +68,21 @@ object HandwritingNativeEngine {
             return false
         }
         return try {
-            nativeInitialize(modelPath)
-        } catch (e: UnsatisfiedLinkError) {
-            Log.e(TAG, "Native method still unavailable: ${e.message}")
-            nativeLoaded = false
-            false
+            nativeReady = nativeInitialize(modelPath)
+            nativeReady
+    } catch (e: UnsatisfiedLinkError) {
+        Log.e(TAG, "Native method still unavailable: ${e.message}")
+        nativeReady = false
+        false
         } catch (e: Exception) {
             Log.e(TAG, "Native method failed: ${e.message}", e)
+            nativeReady = false
             false
         }
     }
 
     fun predict(strokeData: FloatArray, mask: ByteArray, topK: Int): Array<Pair<Int, Float>> {
+        if (!nativeReady) return emptyArray()
         val result = nativePredict(strokeData, mask, topK) ?: return emptyArray()
         val pairs = mutableListOf<Pair<Int, Float>>()
         for (i in result.indices step 2) {
@@ -82,11 +94,14 @@ object HandwritingNativeEngine {
     }
 
     fun release() {
-        nativeRelease()
+        if (nativeReady) {
+            nativeRelease()
+            nativeReady = false
+        }
     }
 
     fun isInitialized(): Boolean {
-        return nativeIsInitialized()
+        return nativeReady
     }
 
     private external fun nativeInitialize(modelPath: String): Boolean

--- a/app/src/main/java/com/kingzcheung/xime/handwriting/capture/HandwritingSample.kt
+++ b/app/src/main/java/com/kingzcheung/xime/handwriting/capture/HandwritingSample.kt
@@ -6,7 +6,7 @@ package com.kingzcheung.xime.handwriting.capture
  * 坐标语义与键盘手写（HandwritingKeyboardLayout）一致：
  * - x/y 为作画区局部像素坐标（左上角原点，y 向下），未做任何归一化；
  * - 时间为相对本次样本首笔起点的毫秒数（首笔起点 = 0）。
- * 归一化由训练侧复刻推理侧 HandwritingEngine.strokesToSequence 的
+ * 归一化由训练侧复刻推理侧 HandwritingInference.strokesToSequence 的
  * bounding-box 算法完成，采集端只存原材料。
  */
 data class HandwritingSample(

--- a/app/src/main/java/com/kingzcheung/xime/handwriting/capture/HandwritingSampleCodec.kt
+++ b/app/src/main/java/com/kingzcheung/xime/handwriting/capture/HandwritingSampleCodec.kt
@@ -28,7 +28,7 @@ import java.nio.charset.Charset
  * ```
  * - x/y 为作画区局部像素坐标（原点左上，y 向下），未归一化；
  * - t0 为笔画起点相对样本首笔起点的毫秒数，pts 内第三列为相对 t0 的毫秒数；
- * - 归一化在训练侧执行，算法与推理侧 HandwritingEngine.strokesToSequence 一致。
+ * - 归一化在训练侧执行，算法与推理侧 HandwritingInference.strokesToSequence 一致。
  */
 object HandwritingSampleCodec {
 
@@ -79,7 +79,7 @@ object HandwritingSampleCodec {
         root.put(
             "normalization",
             "per-sample bounding box: (x-minX)/max(rangeX,1), (y-minY)/max(rangeY,1); " +
-                "identical to HandwritingEngine.strokesToSequence"
+                "identical to HandwritingInference.strokesToSequence"
         )
         root.put(
             "meta",

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeSchemaController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeSchemaController.kt
@@ -287,13 +287,9 @@ internal class ImeSchemaController(private val service: XimeInputMethodService) 
             service.previousSchemaId = service.rimeEngine.getCurrentSchema()
             SettingsPreferences.setCurrentSchema(service, schemaId)
             service.keyboardViewModel.switchMain(com.kingzcheung.xime.keyboard.MainType.HANDWRITING)
-            // 手写方案：模型文件已确认存在，后台加载引擎
-            Thread {
-                try {
-                    com.kingzcheung.xime.handwriting.HandwritingEngine.initialize(service)
-                } catch (_: Exception) {
-                }
-            }.start()
+            // 手写模型按"用键盘时加载"管理：切到手写方案即展示手写键盘，
+            // 由 HandwritingKeyboardLayout 创建时（LaunchedEffect）负责加载，
+            // 此处不重复加载（避免与布局初始化并发双 bind/load）
             service.sessionController.updateSchemaName()
             return
         }

--- a/app/src/main/java/com/kingzcheung/xime/service/InferenceClient.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/InferenceClient.kt
@@ -7,6 +7,7 @@ import android.content.ServiceConnection
 import android.os.DeadObjectException
 import android.os.IBinder
 import com.kingzcheung.xime.association.AssociationCandidate
+import com.kingzcheung.xime.handwriting.HandwritingCandidate
 import com.kingzcheung.xime.util.FileLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -24,6 +25,11 @@ class InferenceClient(private val context: Context) {
     private var service: IInferenceService? = null
     private var bound = false
 
+    /** 服务进程死亡/绑定失效时通知宿主：宿主据此重置本地"已加载"假象实现自愈
+     *  （AUTO_CREATE 会自动重启服务，但新进程里模型是空的，客户端标志必须跟着复位）。 */
+    @Volatile
+    var onDisconnected: (() -> Unit)? = null
+
     @Volatile
     private var connectLatch = CountDownLatch(1)
 
@@ -38,6 +44,7 @@ class InferenceClient(private val context: Context) {
         override fun onServiceDisconnected(name: ComponentName) {
             service = null
             bound = false
+            onDisconnected?.invoke()
             FileLogger.w(TAG, "InferenceService disconnected (crash?)")
         }
 
@@ -45,6 +52,7 @@ class InferenceClient(private val context: Context) {
             service = null
             bound = false
             connectLatch.countDown()
+            onDisconnected?.invoke()
             FileLogger.e(TAG, "InferenceService binding died")
         }
     }
@@ -131,6 +139,28 @@ class InferenceClient(private val context: Context) {
             emptyList()
         } catch (e: Exception) {
             FileLogger.e(TAG, "predict failed", e)
+            emptyList()
+        }
+    }
+
+    /** 手写识别：客户端传原始笔画，服务端完成预处理与汉字映射，直接返回候选字。 */
+    suspend fun recognizeHandwriting(points: FloatArray, strokePointCounts: IntArray, topK: Int): List<HandwritingCandidate> = withContext(Dispatchers.IO) {
+        try {
+            val result = requireService().recognizeHandwriting(MODEL_HANDWRITING, points, strokePointCounts, topK)
+            val candidates = mutableListOf<HandwritingCandidate>()
+            for (i in result.indices step 2) {
+                val ch = result.getOrNull(i) ?: continue
+                val score = result.getOrNull(i + 1)?.toFloatOrNull() ?: continue
+                candidates.add(HandwritingCandidate(ch, score))
+            }
+            candidates
+        } catch (e: DeadObjectException) {
+            // 服务进程被回收：重置绑定状态，让上层（HandwritingEngine）感知失联并自愈
+            invalidateBinding()
+            FileLogger.e(TAG, "recognizeHandwriting failed: service died", e)
+            emptyList()
+        } catch (e: Exception) {
+            FileLogger.e(TAG, "recognizeHandwriting failed", e)
             emptyList()
         }
     }

--- a/app/src/main/java/com/kingzcheung/xime/service/InferenceService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/InferenceService.kt
@@ -8,6 +8,7 @@ import android.os.IBinder
 import android.util.Log
 import com.kingzcheung.xime.association.AssociationCandidate
 import com.kingzcheung.xime.association.NativeOnnxEngine
+import com.kingzcheung.xime.handwriting.HandwritingInference
 import com.kingzcheung.xime.handwriting.HandwritingNativeEngine
 import org.json.JSONObject
 import java.io.File
@@ -49,7 +50,10 @@ class InferenceService : Service() {
                         NativeOnnxEngine.release()
                         predictionVocab = null
                     }
-                    MODEL_HANDWRITING -> HandwritingNativeEngine.release()
+                    MODEL_HANDWRITING -> {
+                        HandwritingNativeEngine.release()
+                        HandwritingInference.clearChars()
+                    }
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "unloadModel($modelId) failed", e)
@@ -85,8 +89,22 @@ class InferenceService : Service() {
             return result
         }
 
-        override fun recognizeHandwriting(modelId: String, strokeData: FloatArray, mask: ByteArray, topK: Int): MutableList<String> {
-            return mutableListOf()
+        override fun recognizeHandwriting(modelId: String, points: FloatArray, strokePointCounts: IntArray, topK: Int): MutableList<String> {
+            if (modelId != MODEL_HANDWRITING) return mutableListOf()
+            // 模型未加载时（如进程重启后客户端状态未同步）直接返回空，
+            // 避免在未初始化的 native 引擎上推理导致进程崩溃
+            if (!HandwritingNativeEngine.isInitialized()) {
+                Log.w(TAG, "recognizeHandwriting called before model loaded, returning empty")
+                return mutableListOf()
+            }
+            val strokes = HandwritingInference.decodeStrokes(points, strokePointCounts)
+            val candidates = HandwritingInference.recognize(strokes, topK)
+            val result = mutableListOf<String>()
+            for (c in candidates) {
+                result.add(c.char)
+                result.add(c.score.toString())
+            }
+            return result
         }
 
         override fun processAudioBytes(input: ByteArray, sampleRate: Int): ByteArray {
@@ -178,29 +196,20 @@ class InferenceService : Service() {
 
     private fun loadHandwritingModel(modelPath: String, charIndexPath: String): Boolean {
         if (!loadOnnxLibs()) return false
-        return HandwritingNativeEngine.initialize(this, modelPath)
-    }
-
-    private fun findFile(dir: File, fileName: String): File? {
-        val direct = File(dir, fileName)
-        if (direct.exists()) return direct
-        dir.listFiles()?.forEach { child ->
-            if (child.isDirectory) {
-                val found = findFile(child, fileName)
-                if (found != null) return found
-            }
+        // 先释放旧 session：重复加载时避免 ORT 双 session 并存推高内存（同联想模型）
+        if (HandwritingNativeEngine.isInitialized()) {
+            HandwritingNativeEngine.release()
+            HandwritingInference.clearChars()
         }
-        return null
-    }
-
-    private fun findFile(dir: File, predicate: (String) -> Boolean): File? {
-        dir.listFiles()?.forEach { child ->
-            if (child.isFile && predicate(child.name)) return child
-            if (child.isDirectory) {
-                val found = findFile(child, predicate)
-                if (found != null) return found
-            }
+        if (!HandwritingNativeEngine.initialize(this, modelPath)) {
+            Log.e(TAG, "HandwritingNativeEngine.initialize failed")
+            return false
         }
-        return null
+        // idx→汉字词表在本进程加载，客户端只收最终候选字
+        if (!HandwritingInference.loadCharIndex(charIndexPath)) {
+            HandwritingNativeEngine.release()
+            return false
+        }
+        return true
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -579,6 +579,8 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                 if (!alreadyHandwriting) {
                                     keyboardViewModel.switchMain(com.kingzcheung.xime.keyboard.MainType.HANDWRITING)
                                 }
+                                // 手写模型按"用键盘时加载"管理：不在此预载，
+                                // HandwritingKeyboardLayout 创建时（LaunchedEffect）负责加载
                             } else {
                                 Log.w(TAG, "initRimeEngine: handwriting model missing, keep full keyboard")
                                 android.widget.Toast.makeText(
@@ -1457,8 +1459,32 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             // 容器物理高度 = Compose 内容总高，小于全屏窗口时若默认 top-left
             // 对齐会让键盘跑到屏顶。高度由 SideEffect 的 updateHeight 动态设置。
             view.updateLayoutParams<android.widget.FrameLayout.LayoutParams> {
-                height = android.view.ViewGroup.LayoutParams.MATCH_PARENT
                 gravity = android.view.Gravity.BOTTOM
+            }
+            val state = uiState.value
+            if (state.isFloatingMode || state.isCompact) {
+                view.updateLayoutParams<android.widget.FrameLayout.LayoutParams> {
+                    height = android.view.ViewGroup.LayoutParams.MATCH_PARENT
+                }
+            } else {
+                // 首显前预设容器高度：容器初始 MATCH_PARENT（贴底 → 顶部 y=0）会让窗口
+                // 第一次 traversal 的 onComputeInsets 报告"键盘占满全屏"，而 SideEffect 的
+                // updateHeight 下一帧才生效；部分应用按首次 inset 布局后不再响应修正，
+                // 输入框被顶到屏顶、与键盘间留大片空白（重进时容器已带正确高度故不复现）。
+                // 按偏好高度预设首帧真实几何，之后仍由 SideEffect 统一维护。
+                val isLandscape =
+                    resources.configuration.screenWidthDp > resources.configuration.screenHeightDp
+                val displayHeight = SettingsPreferences.getKeyboardHeightDp(this, isLandscape)
+                    .coerceAtMost((resources.configuration.screenHeightDp * 8) / 10)
+                val density = resources.displayMetrics.density
+                val rawDp = if (bottomInsetPxState.value > 0)
+                    (bottomInsetPxState.value / density).toInt() else 0
+                val extraShrink = if (rawDp >= 120) 8 else 0
+                val bottomSpace = if (rawDp > 0) (rawDp - 8 - extraShrink).coerceAtLeast(0) else 0
+                val activeBottomDp = if (bottomSpace == 0) 18 else bottomSpace
+                view.updateLayoutParams<android.widget.FrameLayout.LayoutParams> {
+                    height = ((displayHeight + state.keyboardBottomPaddingDp + activeBottomDp) * density).toInt()
+                }
             }
         } catch (_: Exception) {}
     }
@@ -1624,6 +1650,8 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                         } else {
                             debugLog("onStartInput: saved schema is handwriting, keeping handwriting mode")
                             keyboardViewModel.switchMain(com.kingzcheung.xime.keyboard.MainType.HANDWRITING)
+                            // 手写模型按"用键盘时加载"管理：不在此加载/重载，
+                            // 布局创建（LaunchedEffect）与落笔时的 predict 自愈兜底
                             actualSchema = savedSchema
                         }
                     }
@@ -1919,6 +1947,14 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         recentClipboardItemsState.value = emptyList()
     }
     
+    override fun onFinishInputView(finishingInput: Boolean) {
+        super.onFinishInputView(finishingInput)
+        // 手写模型轻量，按"用键盘时加载、键盘收起即卸载"管理：输入会话结束
+        // （收起键盘/焦点离开）即释放，:inference 侧同步卸载模型；未初始化时
+        // release() 幂等空操作。下次落笔由 predict 自愈或布局重建重载。
+        com.kingzcheung.xime.handwriting.HandwritingEngine.release()
+    }
+
     override fun onWindowHidden() {
         super.onWindowHidden()
         clearInputState()

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -759,6 +759,8 @@ fun KeyboardView(
                                     "symbol" -> viewModel.enterPanel(PanelType.COMMON_SYMBOL)
                                     "number" -> viewModel.enterPanel(PanelType.NUMBER)
                                     "ime_switch" -> {
+                                        // 离开手写页即卸载手写模型（回到手写页时布局重建重载）
+                                        com.kingzcheung.xime.handwriting.HandwritingEngine.release()
                                         viewModel.switchMain(MainType.FULL)
                                         callbacks.onKeyPress("ime_switch", false)
                                     }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/HandwritingCaptureScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/HandwritingCaptureScreen.kt
@@ -226,7 +226,7 @@ class HandwritingCaptureViewModel(app: android.app.Application) : AndroidViewMod
  * 粘贴一段文本 → 点击目标字 → 内嵌画布书写 → 识别预览人工确认 → 自动跳下一个未采字 → JSON 导出。
  *
  * 坐标语义与键盘手写一致：作画区局部像素坐标（左上原点，y 向下），模型侧按笔迹
- * bounding box 归一化（HandwritingEngine.strokesToSequence），画布尺寸不影响分布。
+ * bounding box 归一化（HandwritingInference.strokesToSequence），画布尺寸不影响分布。
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/jni/handwriting_jni.cc
+++ b/app/src/main/jni/handwriting_jni.cc
@@ -14,6 +14,10 @@
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
 #define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
 
+// 每次推理的输出维度/候选数日志默认关闭（叠写一笔触发多次推理，正常时纯刷屏）；
+// 需要排查时在 CMakeLists 的目标上加 -DXIME_HW_VERBOSE 重新编译即可打开
+// #define XIME_HW_VERBOSE
+
 static OrtSession* g_hw_session = nullptr;
 static OrtAllocator* g_hw_allocator = nullptr;
 static std::mutex g_hw_mutex;
@@ -302,10 +306,12 @@ Java_com_kingzcheung_xime_handwriting_HandwritingNativeEngine_nativePredict(
         return nullptr;
     }
 
+#ifdef XIME_HW_VERBOSE
     LOGD("Output shape: [%ld]", (long)output_dims[0]);
     for (size_t i = 0; i < dims_count; i++) {
         LOGD("  dim[%zu] = %ld", i, (long)output_dims[i]);
     }
+#endif
 
     int64_t num_classes = output_dims[dims_count - 1];
 
@@ -363,7 +369,9 @@ Java_com_kingzcheung_xime_handwriting_HandwritingNativeEngine_nativePredict(
 
     api->ReleaseValue(output_tensor);
 
+#ifdef XIME_HW_VERBOSE
     LOGD("Predicted %lld candidates", (long long)k);
+#endif
     return result;
 }
 


### PR DESCRIPTION
## 概述

- 将手写识别从本地native引擎改为通过AIDL的IPC调用到:inference进程
- 更新IInferenceService.aidl接口，recognizeHandwriting方法参数改为原始笔画数据
- 实现HandwritingEngine重构，移除本地预处理逻辑，改为IPC代理模式
- 修复联想预测和手写识别的进程回收自愈机制，添加onDisconnected回调处理
- 优化HandwritingNativeEngine的native库加载状态管理，避免UnsatisfiedLinkError
- 调整模型加载时机：手写模型按"用键盘时加载、键盘收起即卸载"管理
- 修复键盘窗口高度计算问题，预设容器高度避免首次显示异常
- 版本号从2.8.0-beta2升级至2.8.0-beta3

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [x] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
