### PR TITLE
feat(RimeEngine): 添加长按候选删除自造词功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
@@ -339,6 +339,19 @@ class RimeEngine {
         }
     }
 
+    /**
+     * 删除当前页候选（长按候选栏删除自造词）。
+     * 标准 C API delete_candidate_on_current_page：librime 对用户词典词条
+     * 执行 tombstone 标记（UpdateEntry -1），键盘无关（T9/全键盘通用）。
+     * @param index 当前页内的候选索引
+     */
+    fun deleteCandidateOnCurrentPage(index: Int): Boolean {
+        return tryLocked(false) {
+            if (!nativeHasSession()) return@tryLocked false
+            nativeDeleteCandidateOnCurrentPage(index)
+        }
+    }
+
     fun pageDown(): Boolean {
         return tryLocked(false) {
             if (!nativeHasSession()) return@tryLocked false
@@ -632,6 +645,7 @@ class RimeEngine {
     private external fun nativeGetInput(): String?
     private external fun nativeGetComposition(): RimeComposition
     private external fun nativeSelectCandidate(index: Int): Boolean
+    private external fun nativeDeleteCandidateOnCurrentPage(index: Int): Boolean
     private external fun nativePageDown(): Boolean
     private external fun nativePageUp(): Boolean
     private external fun nativeHasNextPage(): Boolean

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
@@ -1228,6 +1228,33 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
             }
         }
     }
+
+    /**
+     * 长按候选删除自造词（键盘无关，T9/全键盘通用）。
+     * 标准 C API delete_candidate_on_current_page：librime 对 userdb 词条
+     * 做 tombstone 标记（UpdateEntry -1），对非用户词由 rime 侧自行判定。
+     * 显示索引经 resolveRimeCandidateIndex 映射回引擎原始索引（插件候选
+     * 注入会使两者错位，与 selectCandidateAsync 同口径），删除后刷新候选。
+     */
+    internal fun deleteCandidate(displayIndex: Int) {
+        postRimeJob {
+            val text = service.candidateState.value.candidates.getOrNull(displayIndex)
+            if (text.isNullOrEmpty()) return@postRimeJob
+            val engineIndex = resolveRimeCandidateIndex(
+                displayIndex, text, service.rimeEngine.getCandidates().toList()
+            )
+            val ok = service.rimeEngine.deleteCandidateOnCurrentPage(engineIndex)
+            FileLogger.i(
+                XimeInputMethodService.TAG,
+                "DeleteCandidate: text='$text' display=$displayIndex engine=$engineIndex ok=$ok"
+            )
+            if (ok) {
+                withContext(Dispatchers.Main) {
+                    service.updateUI()
+                }
+            }
+        }
+    }
     
     internal fun pageDown() {
         postRimeJob {

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyboardCallbacks.kt
@@ -46,6 +46,9 @@ internal fun rememberImeKeyboardCallbacks(
             onCandidateSelect = { index ->
                 service.keyRouter.selectCandidate(index)
             },
+            onCandidateDelete = { index ->
+                service.keyRouter.deleteCandidate(index)
+            },
             onAssociationSelect = { index ->
                 service.feedbackManager.performKeyPressEffect(view = view)
                 val cs = service.candidateState.value

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidateBar.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidateBar.kt
@@ -2,8 +2,10 @@ package com.kingzcheung.xime.ui.keyboard
 
 import com.kingzcheung.xime.service.PredictionManager
 import android.annotation.SuppressLint
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -94,7 +96,10 @@ data class CandidateBarCallbacks(
     val onShowMoreCandidates: (() -> Unit)? = null,
     val onClearAssociation: (() -> Unit)? = null,
     val onInputTextClick: (() -> Unit)? = null,
-    val onAssociationSelect: ((Int) -> Unit)? = null
+    val onAssociationSelect: ((Int) -> Unit)? = null,
+    // 长按候选：抛事件给宿主（键盘视图内弹确认覆盖层，不弹独立窗口——
+    // 焦点型弹窗会抢焦点导致 IME 被系统收起）。
+    val onCandidateLongPress: ((Int) -> Unit)? = null
 )
 
 @Composable
@@ -399,6 +404,9 @@ fun CandidateBar(
                         text = candidate,
                         index = index,
                         onClick = { callbacks.onCandidateSelect(index) },
+                        onLongClick = if (callbacks.onCandidateLongPress != null) {
+                            { callbacks.onCandidateLongPress(index) }
+                        } else null,
                         textColor = visuals.textColor,
                         comment = if (showComments) {
                             when (val s = state) {
@@ -601,6 +609,7 @@ fun CandidateBar(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun CandidateItem(
     text: String,
@@ -615,6 +624,7 @@ fun CandidateItem(
     fontSize: androidx.compose.ui.unit.TextUnit = 19.sp,
     candidateFontFamily: androidx.compose.ui.text.font.FontFamily = androidx.compose.ui.text.font.FontFamily.Default,
     commentFontFamily: androidx.compose.ui.text.font.FontFamily = androidx.compose.ui.text.font.FontFamily.Default,
+    onLongClick: (() -> Unit)? = null,
 ) {
     Row(
         modifier = modifier
@@ -623,7 +633,10 @@ fun CandidateItem(
                 if (isSelected) accentColor.copy(alpha = 0.2f)
                 else Color.Transparent
             )
-            .clickable(onClick = onClick)
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick
+            )
             .padding(horizontal = 4.dp, vertical = 2.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
@@ -10,6 +10,8 @@ data class KeyboardCallbacks(
     val onKeyPressDown: ((String) -> Unit)? = null,
     val onKeyRelease: ((String) -> Unit)? = null,
     val onCandidateSelect: (Int) -> Unit,
+    // 长按候选删除自造词：index 为候选栏显示索引（候选栏→服务层透传）
+    val onCandidateDelete: ((Int) -> Unit)? = null,
     val onAssociationSelect: ((Int) -> Unit)? = null,
     val onClearAssociation: (() -> Unit)? = null,
     val onToggleDarkMode: (() -> Unit)? = null,

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -6,8 +6,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,11 +17,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -226,6 +234,9 @@ fun KeyboardView(
     ) {
     Box(modifier = contentModifier) {
         Box {
+        // 长按候选删除自造词：确认覆盖层状态（键盘视图内渲染，不弹独立
+        // 窗口——焦点型弹窗会抢焦点导致 IME 被系统收起）
+        var deletePendingIndex by remember { mutableStateOf<Int?>(null) }
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -406,6 +417,9 @@ fun KeyboardView(
                         } else {
                             callbacks.onCandidateSelect(index)
                         }
+                    },
+                    onCandidateLongPress = { index ->
+                        deletePendingIndex = index
                     },
                     onClearAssociation = {
                         if (showHandwritingCandidates) {
@@ -976,6 +990,61 @@ fun KeyboardView(
                             color = keyTextColor.copy(alpha = 0.7f),
                             style = androidx.compose.material3.MaterialTheme.typography.bodyMedium
                         )
+                    }
+                }
+            }
+        }
+
+        // 长按候选删除自造词：键盘视图内确认覆盖层（同窗口不夺焦点，
+        // 避免焦点型弹窗导致 IME 被系统收起）；确认后经服务层调用标准
+        // C API delete_candidate_on_current_page，刷新后词条从候选消失。
+        deletePendingIndex?.let { deleteIndex ->
+            val deleteWord = candidateState.value.candidates.getOrNull(deleteIndex).orEmpty()
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(Color.Black.copy(alpha = 0.45f))
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null
+                    ) { deletePendingIndex = null },
+                contentAlignment = Alignment.Center
+            ) {
+                Card(
+                    shape = RoundedCornerShape(16.dp),
+                    modifier = Modifier.widthIn(max = 300.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surface
+                    )
+                ) {
+                    Column(Modifier.padding(horizontal = 20.dp, vertical = 18.dp)) {
+                        Text(
+                            text = "删除自造词",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Text(
+                            text = "将「$deleteWord」从用户词典中移除？",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(Modifier.height(12.dp))
+                        Row(
+                            horizontalArrangement = Arrangement.End,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            TextButton(onClick = { deletePendingIndex = null }) {
+                                Text("取消", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                            Spacer(Modifier.width(4.dp))
+                            TextButton(onClick = {
+                                deletePendingIndex = null
+                                callbacks.onCandidateDelete?.invoke(deleteIndex)
+                            }) {
+                                Text("删除", color = MaterialTheme.colorScheme.error)
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/jni/librime_jni/rime_jni.cc
+++ b/app/src/main/jni/librime_jni/rime_jni.cc
@@ -401,6 +401,14 @@ public:
         if (!rime || !session_id_) return false;
         return rime->select_candidate_on_current_page(session_id_, index);
     }
+
+    // 删除当前页候选（标准 C API delete_candidate_on_current_page）：
+    // librime 对 Phrase 候选执行 userdb tombstone（UpdateEntry -1），
+    // 即自造词/调频词删除；非用户词由 rime 侧自行判定，无副作用。
+    bool deleteCandidateOnCurrentPage(int index) {
+        if (!rime || !session_id_) return false;
+        return rime->delete_candidate_on_current_page(session_id_, index);
+    }
     
     bool pageDown() {
         if (!rime || !session_id_) return false;
@@ -1234,6 +1242,17 @@ Java_com_kingzcheung_xime_rime_RimeEngine_nativeSelectCandidate(
     jint index
 ) {
     return Rime::Instance().selectCandidate(index) ? JNI_TRUE : JNI_FALSE;
+}
+
+// 删除当前页候选（长按候选栏删除自造词）：标准 C API
+// delete_candidate_on_current_page，index 为当前页内索引。
+JNIEXPORT jboolean JNICALL
+Java_com_kingzcheung_xime_rime_RimeEngine_nativeDeleteCandidateOnCurrentPage(
+    JNIEnv* env,
+    jobject thiz,
+    jint index
+) {
+    return Rime::Instance().deleteCandidateOnCurrentPage(index) ? JNI_TRUE : JNI_FALSE;
 }
 
 // 翻页 - 下一页


### PR DESCRIPTION
- 实现 deleteCandidateOnCurrentPage 方法，调用 librime 标准 C API delete_candidate_on_current_page 对用户词典词条执行 tombstone 标记
- 在 JNI 层添加对应的 nativeDeleteCandidateOnCurrentPage 实现
- 支持 T9/全键盘通用的用户词删除功能

feat(CandidateBar): 候选栏支持长按操作

- 使用 combinedClickable 替代 clickable 以支持长按事件
- 添加 onCandidateLongPress 回调传递长按事件到宿主
- 导入 ExperimentalFoundationApi 注解支持组合点击操作

feat(ImeKeyRouter): 实现候选删除逻辑

- 添加 deleteCandidate 方法处理长按删除请求
- 通过 resolveRimeCandidateIndex 将显示索引映射回引擎原始索引
- 删除后刷新 UI 并记录删除结果日志

feat(KeyboardView): 长按候选弹出确认覆盖层

- 在键盘视图内实现删除确认对话框，避免焦点型弹窗导致 IME 被系统收起
- 使用 Card 组件显示删除确认界面，包含目标词汇和确认按钮
- 保持在同窗口内操作以维持输入法焦点状态

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] 新功能
- [x] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
