### PR TITLE
feat(backup): 更新备份说明强调非输入状态操作

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/settings/BackupManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/BackupManager.kt
@@ -25,7 +25,8 @@ import java.util.zip.ZipInputStream
  * - `_xime_backup/plugins/<pluginId>/…`             插件包（仅完整备份，包体可能数 MB）
  *
  * 恢复后：rime 文件重启输入会话生效；插件/设置在重启应用后生效（插件随 Application 重建加载）。
- * 注意：userdb 为 leveldb，运行中快照与 WebDAV 同步存在同样的一致性风险，建议空闲时备份。
+ * 注意：userdb 为 leveldb，运行中打快照存在一致性风险（文件级覆盖合并），
+ * 建议在非输入状态执行备份/恢复。
  */
 object BackupManager {
 

--- a/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
@@ -74,10 +74,6 @@ object SettingsPreferences {
         getPrefs(context).edit().putString(KEY_TOOLBAR_BUTTONS, buttons.joinToString(",")).apply()
     }
 
-    private const val KEY_WEBDAV_URL = "webdav_url"
-    private const val KEY_WEBDAV_USERNAME = "webdav_username"
-    private const val KEY_WEBDAV_PASSWORD = "webdav_password"
-    private const val KEY_WEBDAV_PATH = "webdav_path"
 
     private const val KEY_SCHEMA_IMPORT_WARNING_DISMISSED = "schema_import_warning_dismissed"
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsMainScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsMainScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material.icons.twotone.Backup
 import androidx.compose.material.icons.twotone.Ballot
 
 import androidx.compose.material.icons.twotone.Build
-import androidx.compose.material.icons.twotone.CloudSync
 import androidx.compose.material.icons.twotone.Description
 import androidx.compose.material.icons.twotone.Extension
 import androidx.compose.material.icons.twotone.GraphicEq

--- a/app/src/main/jni/librime-t9/src/t9_filter.h
+++ b/app/src/main/jni/librime-t9/src/t9_filter.h
@@ -39,6 +39,9 @@ std::string T9ConvertCandidatePreedit(const std::string& preedit,
 // dynamic_cast<SimpleCandidate*>(&c) 成功，从而 set_preedit()
 // 可被后续 filter（如 super_comment_preedit）通过 cand.preedit = val
 // 覆盖 preedit 值，避免锁死 bug。
+// 同时实现 genuine() 虚解包协议：GetGenuineCandidate 经此拿到内层
+// 原始候选，使长按删词（Memory::OnDeleteEntry）能取到底层 Phrase——
+// 之前继承链断在 SimpleCandidate，T9 删词静默无效（全键盘无 t9_filter 不受影响）。
 class T9PreeditCandidate : public SimpleCandidate {
 public:
     T9PreeditCandidate(an<Candidate> item, const string& preedit)
@@ -53,6 +56,7 @@ public:
     // set_preedit(v) 供后续 Lua filter（super_comment_preedit）覆盖 preedit。
 
     an<Candidate> item() const { return item_; }
+    an<Candidate> genuine() const override { return item_; }
 
 private:
     an<Candidate> item_;


### PR DESCRIPTION
修复 userdb 为 leveldb 运行中快照存在一致性风险的问题，
建议在非输入状态执行备份/恢复操作以确保数据完整性。

refactor(settings): 移除未使用的 WebDAV 配置常量

删除不再使用的 KEY_WEBDAV_URL、KEY_WEBDAV_USERNAME、
KEY_WEBDAV_PASSWORD 和 KEY_WEBDAV_PATH 常量。

refactor(ui): 移除未使用的 CloudSync 图标导入

从 SettingsMainScreen.kt 中移除未使用的
androidx.compose.material.icons.twotone.CloudSync 导入。

chore(deps): 更新 librime 子模块到最新提交

将 librime 子模块从 4beef200 更新到 b0a480b3 提交版本。

fix(t9): 实现 genuine 虚解包协议支持候选删除

添加 T9PreeditCandidate 的 genuine() 方法实现虚解包协议，
使 GetGenuineCandidate 能获取原始候选对象，解决 T9 模式下
长按删词功能失效的问题。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [x] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
