### PR TITLE
feat(keyboard): 为非按键交互添加振动反馈支持

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1361,6 +1361,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                             }
                             val callbacks = rememberImeKeyboardCallbacks(this@XimeInputMethodService, floatingMinY, state, effectiveScreenH)
                             keyboardCallbacks = callbacks
+                            val hapticView = LocalView.current
                             KeyboardView(
                                 viewModel = keyboardViewModel,
                                 state = kbState,
@@ -1369,6 +1370,9 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                 voiceSpectrumState = this@XimeInputMethodService.voiceSpectrumState,
                                 callbacks = callbacks,
                                 inlineSuggestions = inlineSuggestionManager?.suggestions.orEmpty(),
+                                // 非按键交互（符号/表情面板、菜单栏、候选栏按钮）的振动，
+                                // 语义与按键按下反馈完全一致（模式/时长/振幅走同一配置）
+                                onHapticFeedback = { feedbackManager.hapticFeedback(hapticView) },
                                 onCardPositioned = { _: Int, top: Int, _: Int, bottom: Int ->
                                     val cardHeightPx = bottom - top
                                     if (cardHeightPx > 0) {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/EmojiKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/EmojiKeyboardLayout.kt
@@ -67,7 +67,9 @@ fun EmojiKeyboardLayout(
     textColor: Color,
     accentColor: Color,
     bottomPaddingDp: Int = 0,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    /** 分类 tab 切换的振动钩子（emoji 点击/删除经 onEmojiSelect 由调用方统一振动）。 */
+    onHapticFeedback: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
     val clipboardManager = remember { ClipboardManager.getInstance(context) }
@@ -196,6 +198,7 @@ fun EmojiKeyboardLayout(
                                     else Color.Transparent
                                 )
                                 .clickable {
+                                    onHapticFeedback?.invoke()
                                     selectedTopTabIndex = 0
                                     selectedSubCategoryIndex = 0
                                 }
@@ -221,6 +224,7 @@ fun EmojiKeyboardLayout(
                                         else Color.Transparent
                                     )
                                     .clickable {
+                                        onHapticFeedback?.invoke()
                                         selectedTopTabIndex = index + 1
                                         selectedSubCategoryIndex = 0
                                     }
@@ -437,7 +441,10 @@ fun EmojiKeyboardLayout(
                                 icon = category.name,
                                 pluginIcon = null,
                                 isSelected = index == selectedSubCategoryIndex,
-                                onClick = { selectedSubCategoryIndex = index },
+                                onClick = {
+                                    onHapticFeedback?.invoke()
+                                    selectedSubCategoryIndex = index
+                                },
                                 backgroundColor = backgroundColor,
                                 textColor = textColor,
                                 selectedBackgroundColor = accentColor,
@@ -448,7 +455,10 @@ fun EmojiKeyboardLayout(
                                 icon = category.icon,
                                 pluginIcon = category.pluginIcon,
                                 isSelected = index == selectedSubCategoryIndex,
-                                onClick = { selectedSubCategoryIndex = index },
+                                onClick = {
+                                    onHapticFeedback?.invoke()
+                                    selectedSubCategoryIndex = index
+                                },
                                 backgroundColor = backgroundColor,
                                 textColor = textColor,
                                 selectedBackgroundColor = accentColor,

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -92,6 +92,12 @@ fun KeyboardView(
     candidateState: State<CandidateState> = remember { mutableStateOf(CandidateState()) },
     voiceAmplitudeState: State<Float> = remember { mutableFloatStateOf(0f) },
     voiceSpectrumState: State<FloatArray> = remember { mutableStateOf(FloatArray(16)) },
+    /**
+     * 非按键交互（符号/表情面板、菜单栏、候选栏按钮等）的振动钩子。
+     * 按键本身的反馈走 onKeyPressDown 回调（服务层 FeedbackManager），
+     * 此处只覆盖没有经过按键回调链路的点击交互，宿主按按键振动同款语义实现。
+     */
+    onHapticFeedback: (() -> Unit)? = null,
 ) {
     val isShifted by viewModel.isShifted.collectAsStateWithLifecycle()
     val keyboardState by viewModel.keyboardState.collectAsStateWithLifecycle()
@@ -380,7 +386,10 @@ fun KeyboardView(
                             }
                         })
                     }
-                    ToolbarAction(item, onClick)
+                    ToolbarAction(item) {
+                        onHapticFeedback?.invoke()
+                        onClick()
+                    }
                 },
                 visuals = CandidateBarVisuals(
                     backgroundColor = Color.Transparent,
@@ -422,6 +431,7 @@ fun KeyboardView(
                         deletePendingIndex = index
                     },
                     onClearAssociation = {
+                        onHapticFeedback?.invoke()
                         if (showHandwritingCandidates) {
                             handwritingCandidates = emptyList()
                             handwritingComments = emptyList()
@@ -432,6 +442,7 @@ fun KeyboardView(
                     },
                     onLogoClick = { viewModel.showOverlay(OverlayRoute.Menu) },
                     onBack = {
+                        onHapticFeedback?.invoke()
                         if (showHandwritingCandidates) {
                             handwritingCandidates = emptyList()
                             handwritingComments = emptyList()
@@ -449,10 +460,14 @@ fun KeyboardView(
                         }
                     },
                     onHideKeyboard = {
+                        onHapticFeedback?.invoke()
                         callbacks.onHideKeyboard?.invoke()
                         viewModel.resetKeyboard(state.isAsciiMode, state.currentSchemaId)
                     },
-                    onShowMoreCandidates = { viewModel.showOverlay(OverlayRoute.CandidatePage) },
+                    onShowMoreCandidates = {
+                        onHapticFeedback?.invoke()
+                        viewModel.showOverlay(OverlayRoute.CandidatePage)
+                    },
                     onInputTextClick = {
                         if (candidateState.value.inputText.isNotEmpty()) {
                             callbacks.onClipboardSelect?.invoke(candidateState.value.inputText)
@@ -1034,11 +1049,15 @@ fun KeyboardView(
                             horizontalArrangement = Arrangement.End,
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            TextButton(onClick = { deletePendingIndex = null }) {
+                            TextButton(onClick = {
+                                onHapticFeedback?.invoke()
+                                deletePendingIndex = null
+                            }) {
                                 Text("取消", color = MaterialTheme.colorScheme.onSurfaceVariant)
                             }
                             Spacer(Modifier.width(4.dp))
                             TextButton(onClick = {
+                                onHapticFeedback?.invoke()
                                 deletePendingIndex = null
                                 callbacks.onCandidateDelete?.invoke(deleteIndex)
                             }) {
@@ -1074,18 +1093,18 @@ fun KeyboardView(
                             schemaSwitches = state.schemaSwitches,
                         ),
                         callbacks = MenuBarCallbacks(
-                            onDismiss = { viewModel.closeOverlay() },
-                            onClipboard = { viewModel.showOverlay(OverlayRoute.Clipboard(0)); callbacks.onClipboard?.invoke() },
-                            onQuickSend = { viewModel.showOverlay(OverlayRoute.Clipboard(1)); callbacks.onQuickSend?.invoke() },
-                            onKeyboardResize = { callbacks.onKeyboardResize?.invoke(); viewModel.closeOverlay() },
-                            onEmoji = { viewModel.showOverlay(OverlayRoute.Emoji) },
-                            onReloadConfig = { callbacks.onReloadConfig?.invoke(); viewModel.closeOverlay() },
-                            onSettings = { callbacks.onSettings?.invoke(); viewModel.closeOverlay() },
-                            onSchemaList = { viewModel.pushOverlay(OverlayRoute.SchemaList) },
-                            onToggleDarkMode = { callbacks.onToggleDarkMode?.invoke() },
-                            onToolbarCustomize = { viewModel.showOverlay(OverlayRoute.ToolbarCustomize) },
-                            onFloatingModeToggle = { callbacks.onFloatingModeChange?.invoke(!state.isFloatingMode); viewModel.closeOverlay() },
-                            onToggleSchemaSwitch = { sw -> callbacks.onToggleSchemaSwitch?.invoke(sw); viewModel.closeOverlay() },
+                            onDismiss = { onHapticFeedback?.invoke(); viewModel.closeOverlay() },
+                            onClipboard = { onHapticFeedback?.invoke(); viewModel.showOverlay(OverlayRoute.Clipboard(0)); callbacks.onClipboard?.invoke() },
+                            onQuickSend = { onHapticFeedback?.invoke(); viewModel.showOverlay(OverlayRoute.Clipboard(1)); callbacks.onQuickSend?.invoke() },
+                            onKeyboardResize = { onHapticFeedback?.invoke(); callbacks.onKeyboardResize?.invoke(); viewModel.closeOverlay() },
+                            onEmoji = { onHapticFeedback?.invoke(); viewModel.showOverlay(OverlayRoute.Emoji) },
+                            onReloadConfig = { onHapticFeedback?.invoke(); callbacks.onReloadConfig?.invoke(); viewModel.closeOverlay() },
+                            onSettings = { onHapticFeedback?.invoke(); callbacks.onSettings?.invoke(); viewModel.closeOverlay() },
+                            onSchemaList = { onHapticFeedback?.invoke(); viewModel.pushOverlay(OverlayRoute.SchemaList) },
+                            onToggleDarkMode = { onHapticFeedback?.invoke(); callbacks.onToggleDarkMode?.invoke() },
+                            onToolbarCustomize = { onHapticFeedback?.invoke(); viewModel.showOverlay(OverlayRoute.ToolbarCustomize) },
+                            onFloatingModeToggle = { onHapticFeedback?.invoke(); callbacks.onFloatingModeChange?.invoke(!state.isFloatingMode); viewModel.closeOverlay() },
+                            onToggleSchemaSwitch = { sw -> onHapticFeedback?.invoke(); callbacks.onToggleSchemaSwitch?.invoke(sw); viewModel.closeOverlay() },
                         ),
                         modifier = Modifier.fillMaxWidth().fillMaxHeight()
                     )
@@ -1164,6 +1183,7 @@ fun KeyboardView(
                     }
                     is OverlayRoute.Emoji -> EmojiKeyboardLayout(
                         onEmojiSelect = { emoji ->
+                            onHapticFeedback?.invoke()
                             if (emoji == "delete") {
                                 callbacks.onKeyPress("delete", false)
                             } else {
@@ -1176,10 +1196,12 @@ fun KeyboardView(
                         textColor = keyTextColor,
                         accentColor = accentColor,
                         bottomPaddingDp = state.keyboardBottomPaddingDp,
-                        modifier = Modifier.fillMaxWidth().fillMaxHeight()
+                        modifier = Modifier.fillMaxWidth().fillMaxHeight(),
+                        onHapticFeedback = onHapticFeedback,
                     )
                     is OverlayRoute.Symbol -> SymbolKeyboardLayout(
                         onSelect = { symbol ->
+                            onHapticFeedback?.invoke()
                             if (symbol == "delete") {
                                 callbacks.onKeyPress("delete", false)
                             } else {
@@ -1192,7 +1214,8 @@ fun KeyboardView(
                         accentColor = accentColor,
                         keyBgColor = keyBgColor,
                         bottomPaddingDp = state.keyboardBottomPaddingDp,
-                        modifier = Modifier.fillMaxWidth().fillMaxHeight()
+                        modifier = Modifier.fillMaxWidth().fillMaxHeight(),
+                        onHapticFeedback = onHapticFeedback,
                     )
                     is OverlayRoute.CandidatePage -> CandidatePage(
                         state = CandidatePageState(
@@ -1214,8 +1237,8 @@ fun KeyboardView(
                                 callbacks.onAssociationSelect?.invoke(index)
                                 viewModel.closeOverlay()
                             },
-                            onPageDown = callbacks.onPageDown,
-                            onPageUp = callbacks.onPageUp,
+                            onPageDown = { onHapticFeedback?.invoke(); callbacks.onPageDown?.invoke() },
+                            onPageUp = { onHapticFeedback?.invoke(); callbacks.onPageUp?.invoke() },
                             onBack = { viewModel.closeOverlay() },
                         ),
                         modifier = Modifier.fillMaxWidth().fillMaxHeight()

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SymbolKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SymbolKeyboardLayout.kt
@@ -57,7 +57,9 @@ fun SymbolKeyboardLayout(
     accentColor: Color,
     keyBgColor: Color,
     bottomPaddingDp: Int = 0,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    /** 分类 tab 切换与返回按钮的振动钩子（符号点击/删除经 onSelect 由调用方统一振动）。 */
+    onHapticFeedback: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
     // 最近使用（LRU）：作为第一个分类页，点击符号时置顶记录
@@ -101,7 +103,10 @@ fun SymbolKeyboardLayout(
                     .size(28.dp)
                     .clip(CircleShape)
                     .background(iconButtonContainer)
-                    .clickable { onBack() },
+                    .clickable {
+                        onHapticFeedback?.invoke()
+                        onBack()
+                    },
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
@@ -193,7 +198,10 @@ fun SymbolKeyboardLayout(
                     SymbolCategoryTab(
                         name = category.name,
                         isSelected = index == pagerState.currentPage,
-                        onClick = { scope.launch { pagerState.animateScrollToPage(index) } },
+                        onClick = {
+                            onHapticFeedback?.invoke()
+                            scope.launch { pagerState.animateScrollToPage(index) }
+                        },
                         backgroundColor = backgroundColor,
                         textColor = textColor,
                         selectedBackgroundColor = accentColor


### PR DESCRIPTION
- 在EmojiKeyboardLayout中添加onHapticFeedback参数，为分类tab切换提供振动反馈
- 在SymbolKeyboardLayout中添加onHapticFeedback参数，为分类tab和返回按钮提供振动反馈
- 在KeyboardView中添加onHapticFeedback参数，为工具栏、候选栏按钮、菜单项等提供振动反馈
- 将振动反馈机制统一到FeedbackManager，保持与按键振动相同的配置
- 修复子项目librime-lua-deps的dirty状态

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] 新功能
- [ ] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
