### PR TITLE
docs(readme): 更新文档添加导航链接并移除重复的AI模型说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ For the full plugin list, see the [Plugin Center](https://ime.ximei.me/plugin-li
 
 For detailed documentation, visit [https://ime.ximei.me](https://ime.ximei.me).
 
+- [FAQ](https://ime.ximei.me/faq.html)
+- [Rime Schemas List](https://ime.ximei.me/rime-list.html)
+- [Plugin List](https://ime.ximei.me/plugin-list.html)
+- [AI Models List](https://ime.ximei.me/model-list.html)
+
 ## Building
 
 ```bash
@@ -126,25 +131,6 @@ git submodule update --init --recursive
 # Build Release APK
 ./gradlew assembleRelease
 ```
-
-### AI Model Download
-
-#### Predictive Text Model
-
-- **Repository**: https://github.com/ximeiorg/predictive-text
-- **Model**: https://www.modelscope.cn/models/bikeand/predictive-text-small
-- **File**: `model_int8_dynamic.onnx` (~17MB)
-- **Vocabulary**: `vocab.json`
-- **Location**: `filesDir/` (app private directory root)
-- **Function**: Transformer-based Chinese word prediction for intelligent candidate suggestions
-
-#### Speech Recognition Model
-
-- **Model**: https://www.modelscope.cn/models/bikeand/asr
-- **File**: `sherpa-onnx-streaming-zipformer-zh-int8-2025-06-30.tar.bz2` (~132MB)
-- **Function**: Streaming zipformer2 Chinese speech recognition (offline, on-device)
-
-**Note**: All models can be downloaded directly from within the app (Settings > Smart Prediction / Speech Recognition) — no manual placement required.
 
 ## Tech Stack
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -120,6 +120,11 @@
 
 详细使用说明请查看 [使用文档](https://ime.ximei.me)。
 
+- [常见问题 FAQ](https://ime.ximei.me/faq.html)
+- [Rime 方案列表](https://ime.ximei.me/rime-list.html)
+- [插件列表](https://ime.ximei.me/plugin-list.html)
+- [AI 模型列表](https://ime.ximei.me/model-list.html)
+
 ## 构建
 
 ```bash
@@ -132,25 +137,6 @@ git submodule update --init --recursive
 # 构建 Release APK
 ./gradlew assembleRelease
 ```
-
-### AI 模型下载
-
-#### 智能联想词模型
-
-- **项目地址**: https://github.com/ximeiorg/predictive-text
-- **模型下载**: https://www.modelscope.cn/models/bikeand/predictive-text-small
-- **模型文件**: `model_int8_dynamic.onnx` (约 17MB)
-- **词表文件**: `vocab.json`
-- **存放位置**: `filesDir/` 目录（即应用私有目录根目录）
-- **功能**: 基于 Transformer 的中文联想词预测，提供智能候选词推荐
-
-#### 语音识别模型
-
-- **模型下载**: https://www.modelscope.cn/models/bikeand/asr
-- **模型文件**: `sherpa-onnx-streaming-zipformer-zh-int8-2025-06-30.tar.bz2` (约 132MB)
-- **功能**: 流式 zipformer2 中文语音识别（本地离线运行）
-
-**注意**: 所有模型均可直接在应用内"设置 > 智能联想/语音识别"页面下载，无需手动放置。
 
 ## 技术栈
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -121,6 +121,11 @@
 
 詳細使用說明請檢視 [使用文件](https://ime.ximei.me)。
 
+- [常見問題 FAQ](https://ime.ximei.me/faq.html)
+- [Rime 方案列表](https://ime.ximei.me/rime-list.html)
+- [外掛列表](https://ime.ximei.me/plugin-list.html)
+- [AI 模型列表](https://ime.ximei.me/model-list.html)
+
 ## 構建
 
 ```bash
@@ -133,25 +138,6 @@ git submodule update --init --recursive
 # 構建 Release APK
 ./gradlew assembleRelease
 ```
-
-### AI 模型下載
-
-#### 智慧聯想詞模型
-
-- **專案地址**: https://github.com/ximeiorg/predictive-text
-- **模型下載**: https://www.modelscope.cn/models/bikeand/predictive-text-small
-- **模型檔案**: `model_int8_dynamic.onnx`（約 17MB）
-- **詞表檔案**: `vocab.json`
-- **存放位置**: `filesDir/` 目錄（即應用私有目錄根目錄）
-- **功能**: 基於 Transformer 的中文聯想詞預測，提供智慧候選詞推薦
-
-#### 語音辨識模型
-
-- **模型下載**: https://www.modelscope.cn/models/bikeand/asr
-- **模型檔案**: `sherpa-onnx-streaming-zipformer-zh-int8-2025-06-30.tar.bz2`（約 132MB）
-- **功能**: 串流 zipformer2 中文語音辨識（本地離線執行）
-
-**注意**: 所有模型均可直接在應用程式內「設定 > 智慧聯想/語音辨識」頁面下載，無需手動放置。
 
 ## 技術棧
 


### PR DESCRIPTION
- 在README中添加了FAQ、Rime方案列表、插件列表和AI模型列表的导航链接
- 移除了重复的AI模型下载说明部分，因为这些内容已在其他文档中维护
- 同步更新了简体中文和繁体中文版本的README文件
- 更新librime-lua-deps子模块引用

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [x] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
