### PR TITLE
feat(keyboard): 数字键盘返回键位置自适应优化

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayoutScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayoutScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kingzcheung.xime.keyboard.GestureAction
 import com.kingzcheung.xime.keyboard.OverlayRoute
 import com.kingzcheung.xime.handwriting.HandwritingCandidate
@@ -156,6 +157,9 @@ fun KeyboardLayoutScreen(
             }
 
             is KeyboardLayoutState.Number -> {
+                // 从全键盘（?123 在左下角）进入数字键盘时，返回键放到左下角与进入位置对齐；
+                // 九键/笔画/手写进入时保持「符号键在最左下角」的九键习惯
+                val lastMainLayout by viewModel.lastMainLayout.collectAsStateWithLifecycle()
                 NumberKeyboardLayout(
                     onKeyPress = onKeyPress,
                     keyBackgroundColor = keyBgColor,
@@ -173,6 +177,8 @@ fun KeyboardLayoutScreen(
                     onKeyPressDown = callbacks.onKeyPressDown,
                     isFloatingMode = uiState.isFloatingMode,
                     specialKeyTextColor = specialKeyTextColor,
+                    backKeyOnLeft = lastMainLayout is KeyboardLayoutState.Chinese ||
+                        lastMainLayout is KeyboardLayoutState.English,
                 )
             }
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/NumberKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/NumberKeyboardLayout.kt
@@ -52,6 +52,10 @@ import com.kingzcheung.xime.util.SubcharHelper
  * 第2行：- | 4 | 5 | 6 | 符号切换
  * 第3行：* | 7 | 8 | 9 | 表情
  * 第4行：ABC | / | 0 | . | 确定
+ *
+ * [backKeyOnLeft] 为 true 时，左下角的「符号」键与数字区底行的「返回(ABC)」键互换位置：
+ * 从全键盘 ?123（位于左下角）进入数字键盘时，返回键保持在用户的进入位置；
+ * 默认 false 保持九键布局习惯（符号键在最左下角）。
  */
 @Composable
 fun NumberKeyboardLayout(
@@ -71,6 +75,7 @@ fun NumberKeyboardLayout(
     onKeyPressDown: ((String) -> Unit)? = null,
     isFloatingMode: Boolean = false,
     specialKeyTextColor: Color = Color.White,
+    backKeyOnLeft: Boolean = false,
 ) {
 
     val configuration = LocalConfiguration.current
@@ -193,6 +198,7 @@ fun NumberKeyboardLayout(
                         onKeyPressDown = onKeyPressDown,
                         compactMode = true,
                         specialKeyTextColor = specialKeyTextColor,
+                        backKeyOnLeft = backKeyOnLeft,
                         onSwipeStateChange = ::processSwipeState
                     )
                     }
@@ -222,6 +228,7 @@ fun NumberKeyboardLayout(
                     shadowShapeRadius = shadowShapeRadius,
                     onKeyPressDown = onKeyPressDown,
                     specialKeyTextColor = specialKeyTextColor,
+                    backKeyOnLeft = backKeyOnLeft,
                     onSwipeStateChange = ::processSwipeState
                 )
             }
@@ -245,6 +252,7 @@ private fun NumberRows(
     onSwipeStateChange: ((SwipeState, Rect) -> Unit)? = null,
     compactMode: Boolean = false,
     specialKeyTextColor: Color = Color.White,
+    backKeyOnLeft: Boolean = false,
 ) {
     val symFontSize = if (compactMode) 14.sp else 18.sp
     val keyFontSize = if (compactMode) 16.sp else androidx.compose.ui.unit.TextUnit.Unspecified
@@ -305,18 +313,32 @@ private fun NumberRows(
                             .fillMaxHeight()
                             .weight(1f),
                     ) {
-                        KeyButton(
-                            text = "符号",
-                            onClick = { onKeyPress("symbol") },
-                            backgroundColor = specialKeyBackgroundColor,
-                            textColor = specialKeyTextColor,
-                            modifier = Modifier.weight(1f),
-                            onPress = { onKeyPressDown?.invoke("symbol") },
-                            shadowEnabled = shadowEnabled,
-                            shadowElevation = shadowElevation,
-                            shadowShapeRadius = shadowShapeRadius,
-                            fontSize = ctrlFontSize,
-                        )
+                        if (backKeyOnLeft) {
+                            IconKeyButton(
+                                icon = rememberVectorPainter(Icons.AutoMirrored.Filled.ArrowBack),
+                                onClick = { onKeyPress("abc") },
+                                backgroundColor = specialKeyBackgroundColor,
+                                iconColor = specialKeyTextColor,
+                                modifier = Modifier.weight(1f),
+                                onPress = { onKeyPressDown?.invoke("abc") },
+                                shadowEnabled = shadowEnabled,
+                                shadowElevation = shadowElevation,
+                                shadowShapeRadius = shadowShapeRadius,
+                            )
+                        } else {
+                            KeyButton(
+                                text = "符号",
+                                onClick = { onKeyPress("symbol") },
+                                backgroundColor = specialKeyBackgroundColor,
+                                textColor = specialKeyTextColor,
+                                modifier = Modifier.weight(1f),
+                                onPress = { onKeyPressDown?.invoke("symbol") },
+                                shadowEnabled = shadowEnabled,
+                                shadowElevation = shadowElevation,
+                                shadowShapeRadius = shadowShapeRadius,
+                                fontSize = ctrlFontSize,
+                            )
+                        }
                     }
 
                 }
@@ -403,17 +425,32 @@ private fun NumberRows(
                     ) {
 
 
-                        IconKeyButton(
-                            icon = rememberVectorPainter(Icons.AutoMirrored.Filled.ArrowBack),
-                            onClick = { onKeyPress("abc") },
-                            backgroundColor = specialKeyBackgroundColor,
-                            iconColor = specialKeyTextColor,
-                            modifier = Modifier.weight(1f),
-                            onPress = { onKeyPressDown?.invoke("abc") },
-                            shadowEnabled = shadowEnabled,
-                            shadowElevation = shadowElevation,
-                            shadowShapeRadius = shadowShapeRadius,
-                        )
+                        if (backKeyOnLeft) {
+                            KeyButton(
+                                text = "符号",
+                                onClick = { onKeyPress("symbol") },
+                                backgroundColor = specialKeyBackgroundColor,
+                                textColor = specialKeyTextColor,
+                                modifier = Modifier.weight(1f),
+                                onPress = { onKeyPressDown?.invoke("symbol") },
+                                shadowEnabled = shadowEnabled,
+                                shadowElevation = shadowElevation,
+                                shadowShapeRadius = shadowShapeRadius,
+                                fontSize = ctrlFontSize,
+                            )
+                        } else {
+                            IconKeyButton(
+                                icon = rememberVectorPainter(Icons.AutoMirrored.Filled.ArrowBack),
+                                onClick = { onKeyPress("abc") },
+                                backgroundColor = specialKeyBackgroundColor,
+                                iconColor = specialKeyTextColor,
+                                modifier = Modifier.weight(1f),
+                                onPress = { onKeyPressDown?.invoke("abc") },
+                                shadowEnabled = shadowEnabled,
+                                shadowElevation = shadowElevation,
+                                shadowShapeRadius = shadowShapeRadius,
+                            )
+                        }
                         KeyButton(
                             text = "0",
                             onClick = { onKeyPress("0") },

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
@@ -111,6 +111,11 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
     private val _keyboardState = MutableStateFlow<KeyboardLayoutState>(KeyboardLayoutState.Chinese)
     val keyboardState: StateFlow<KeyboardLayoutState> = _keyboardState.asStateFlow()
 
+    /** 最近一次停留的主键盘布局（中文/英文全键盘、九键、笔画）；
+     *  数字面板据此判断进入来源，决定「返回/符号」键的位置自适应 */
+    private val _lastMainLayout = MutableStateFlow<KeyboardLayoutState>(KeyboardLayoutState.Chinese)
+    val lastMainLayout: StateFlow<KeyboardLayoutState> = _lastMainLayout.asStateFlow()
+
     private val _page = MutableStateFlow<KeyboardPage>(KeyboardPage.Main(MainType.FULL))
     val page: StateFlow<KeyboardPage> = _page.asStateFlow()
 
@@ -302,6 +307,7 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
             _shiftMode.value = ShiftMode.OFF
         }
         _keyboardState.value = newKbState
+        _syncViewState()
     }
 
     fun toggleShift() {
@@ -363,6 +369,17 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
     private fun _syncViewState() {
         val kb = _keyboardState.value
         val p = _page.value
+        // 主键盘布局真正显示时刷新「最近主布局」来源记录（数字面板返回/符号键位置自适应依赖）。
+        // 必须放在 _syncViewState：切九键/笔画等走 dispatch 直接赋值，不经过 setKeyboardState
+        if (p is KeyboardPage.Main && p.type == com.kingzcheung.xime.keyboard.MainType.FULL) {
+            when (kb) {
+                is KeyboardLayoutState.Chinese,
+                is KeyboardLayoutState.English,
+                is KeyboardLayoutState.T9Pinyin,
+                is KeyboardLayoutState.Stroke -> _lastMainLayout.value = kb
+                else -> {}
+            }
+        }
         val vs: KeyboardViewState = when (p) {
             is KeyboardPage.Overlay -> KeyboardViewState.Overlay(p.route, p.backStack, _viewState.value.let { if (it is KeyboardViewState.Overlay) it.behind else it })
             is KeyboardPage.Panel -> when (p.type) {


### PR DESCRIPTION
## 概述

- 引入 backKeyOnLeft 参数控制数字键盘左下角按键位置
- 从全键盘进入数字键盘时返回键保持在左下角与进入位置对齐
- 九键/笔画/手写进入时保持符号键在最左下角的传统习惯
- 添加 lastMainLayout 状态追踪最近一次主键盘布局来源
- 使用 collectAsStateWithLifecycle 替代旧的状态收集方式


## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
