### PR TITLE
feat(keyboard): 编辑键盘布局支持主题圆角和阴影配置

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/EditKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/EditKeyboardLayout.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -18,12 +19,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowLeft
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -31,23 +31,24 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
-
-private val keyShape = RoundedCornerShape(8.dp)
 
 private data class Quadrant(
     val label: String,
@@ -71,6 +72,11 @@ fun EditKeyboardLayout(
     accentColor: Color,
     keyBgColor: Color,
     bottomPaddingDp: Int = 0,
+    /** 与主键盘一致的主题按键圆角（LocalKeyCornerRadius），供复用的 KeyButton 读取 */
+    keyCornerRadius: Dp = 8.dp,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
     modifier: Modifier = Modifier
 ) {
     val keyBg = keyBgColor
@@ -80,6 +86,10 @@ fun EditKeyboardLayout(
 
     fun arrowAction(base: String): String = if (isSelecting) "select_$base" else base
 
+    CompositionLocalProvider(
+        LocalKeyCornerRadius provides keyCornerRadius,
+        LocalKeyVisualPadding provides PaddingValues(horizontal = 2.dp, vertical = 2.dp),
+    ) {
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -127,6 +137,9 @@ fun EditKeyboardLayout(
                 onAction = onAction,
                 keyBg = keyBg,
                 textColor = textColor,
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
                 modifier = Modifier.weight(1f)
             )
 
@@ -153,6 +166,8 @@ fun EditKeyboardLayout(
                     textColor = textColor,
                     accentColor = accentColor,
                     backgroundColor = backgroundColor,
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
                     modifier = circleModifier
                 )
             }
@@ -166,6 +181,9 @@ fun EditKeyboardLayout(
                 onAction = onAction,
                 keyBg = keyBg,
                 textColor = textColor,
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
                 modifier = Modifier.weight(1f)
             )
         }
@@ -173,6 +191,7 @@ fun EditKeyboardLayout(
         Spacer(
             modifier = Modifier.height(bottomPaddingDp.dp)
         )
+    }
     }
 }
 
@@ -185,15 +204,33 @@ private fun CircularDPad(
     textColor: Color,
     accentColor: Color,
     backgroundColor: Color,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
     modifier: Modifier = Modifier
 ) {
     val outerFraction = 0.92f
     val innerFraction = 0.38f
 
     var pressedAction by remember { mutableStateOf<String?>(null) }
+    val density = LocalDensity.current
+    val shadowModifier = remember(shadowEnabled, shadowElevation, density, keyBg) {
+        if (shadowEnabled) {
+            val offsetPx = with(density) { shadowElevation.toPx() }
+            val color = crispShadowColor(keyBg)
+            Modifier.drawBehind {
+                // 底部投影：与各键盘按键的 crisp 阴影同风格（圆形）
+                drawCircle(
+                    color = color,
+                    radius = size.minDimension / 2f,
+                    center = Offset(size.width / 2f, size.height / 2f + offsetPx)
+                )
+            }
+        } else Modifier
+    }
     Box(
         modifier = modifier
             .aspectRatio(1f)
+            .then(shadowModifier)
             .clip(CircleShape)
             .background(keyBg)
             .pointerInput(isSelecting) {
@@ -268,6 +305,21 @@ private fun CircularDPad(
                 )
             }
 
+            // 四象限分隔槽：沿对角线方向（象限边界）用键盘背景色画圆头细线，
+            // 把上/下/左/右四个方向区隔开，与其他键盘的键间距观感对齐
+            val dividerWidth = 2.dp.toPx()
+            for (deg in listOf(45f, 135f, 225f, 315f)) {
+                val rad = Math.toRadians(deg.toDouble()).toFloat()
+                val startR = innerR * 1.06f
+                drawLine(
+                    color = backgroundColor,
+                    start = Offset(cx + startR * cos(rad), cy + startR * sin(rad)),
+                    end = Offset(cx + outerR * cos(rad), cy + outerR * sin(rad)),
+                    strokeWidth = dividerWidth,
+                    cap = StrokeCap.Round
+                )
+            }
+
             drawCircle(color = backgroundColor, radius = innerR)
 
             val centerR = innerR * 0.82f
@@ -302,8 +354,10 @@ private fun CircularDPad(
                 )
             }
 
+            // 箭头与按键文字同源（主题 keyTextColor），但 28sp 大字形全不透明时显得过黑，
+            // 降一档不透明度柔和处理；深浅主题均随主题色
             directionLabelPaint.textSize = 28.sp.toPx()
-            directionLabelPaint.color = textColor.toArgb()
+            directionLabelPaint.color = textColor.copy(alpha = 0.72f).toArgb()
             val labelR = (innerR + outerR) / 2f
             for (q in quadrants) {
                 val midDeg = Math.toRadians((q.startAngle + 45f).toDouble()).toFloat()
@@ -343,55 +397,41 @@ private fun SideButtonGrid(
     onAction: (String) -> Unit,
     keyBg: Color,
     textColor: Color,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
     modifier: Modifier = Modifier
 ) {
     val rows = items.chunked(columns)
     Column(
         modifier = modifier
             .fillMaxHeight()
-            .padding(4.dp),
-        verticalArrangement = Arrangement.spacedBy(6.dp)
+            .padding(2.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         rows.forEach { row ->
             Row(
                 modifier = Modifier.weight(1f),
-                horizontalArrangement = Arrangement.spacedBy(6.dp)
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 row.forEach { (label, action) ->
-                    SideButton(label, { onAction(action) }, keyBg, textColor, Modifier.weight(1f).fillMaxHeight())
+                    KeyButton(
+                        text = label,
+                        onClick = { onAction(action) },
+                        backgroundColor = keyBg,
+                        textColor = textColor,
+                        modifier = Modifier.weight(1f).fillMaxHeight(),
+                        fontSize = 14.sp,
+                        shadowEnabled = shadowEnabled,
+                        shadowElevation = shadowElevation,
+                        shadowShapeRadius = shadowShapeRadius,
+                    )
                 }
                 repeat(columns - row.size) {
                     Spacer(modifier = Modifier.weight(1f))
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun SideButton(
-    label: String,
-    onClick: () -> Unit,
-    keyBg: Color,
-    textColor: Color,
-    modifier: Modifier = Modifier
-) {
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(keyShape)
-            .background(keyBg)
-            .clickable(onClick = onClick),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(
-            text = label,
-            color = textColor,
-            fontSize = 14.sp,
-            textAlign = TextAlign.Center,
-            maxLines = 1,
-            fontFamily = AppFonts.keyFontFamily
-        )
     }
 }
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -1178,6 +1178,10 @@ fun KeyboardView(
                             accentColor = accentColor,
                             keyBgColor = keyBgColor,
                             bottomPaddingDp = state.keyboardBottomPaddingDp,
+                            keyCornerRadius = kbKey.cornerRadius.dp,
+                            shadowEnabled = kbShadow.enabled,
+                            shadowElevation = kbShadow.elevation.dp,
+                            shadowShapeRadius = kbShadow.shapeRadius.dp,
                             modifier = Modifier.fillMaxWidth().fillMaxHeight()
                         )
                     }


### PR DESCRIPTION
- 引入 keyCornerRadius 参数用于统一键盘按键圆角
- 添加 shadowEnabled、shadowElevation、shadowShapeRadius 参数控制阴影效果
- 使用 CompositionLocalProvider 共享按键圆角和内边距配置
- 为编辑键盘布局中的各个组件传递阴影参数

style(keyboard): 优化 CircularDPad 组件视觉效果

- 实现圆形按键底部投影效果，与主键盘风格保持一致
- 添加四象限分隔槽，用圆头细线区分上下左右方向
- 调整箭头文字不透明度至 0.72f，使视觉更柔和

refactor(keyboard): 侧边按钮网格改用通用 KeyButton 组件

- 移除自定义 SideButton 组件，统一使用 KeyButton
- 调整网格间距从 6dp 改为 4dp，内边距从 4dp 改为 2dp
- 为侧边按钮添加阴影配置参数支持

chore(deps): 更新 librime-lua 子模块到 dirty 版本

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [x] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
