### PR TITLE
refactor(ui): 替换clickable为tolerantClick改善触摸体验

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,8 +43,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 20260906
-        versionName = "2.8.0-beta4"
+        versionCode = 20260907
+        versionName = "2.8.0-beta5"
 
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
@@ -19,6 +19,7 @@ import java.io.IOException
 object RimeConfigHelper {
     private const val TAG = "RimeConfigHelper"
     private const val ASSETS_RIME_DIR = "rime"
+    private const val BUFFER_SIZE = 8192
 
     /** 市场索引中随 app 发布的内置默认方案集条目 id（见 rimes/index.yaml 的 `builtin`）。 */
     private const val BUILTIN_MARKET_ID = "builtin"
@@ -125,6 +126,39 @@ object RimeConfigHelper {
         }
     }
 
+    /**
+     * 部署产物完整性检查（半成品检测）：librime 的 table/prism 产物文件头是固定
+     * magic（"Rime::Table/" / "Rime::Prism/"，Metadata.format 位于文件偏移 0）。
+     * 部署进行中进程被杀会留下空文件或截断的半成品——其 mtime 比源文件新，
+     * librime 增量维护会视为"已是最新"而跳过重编，导致该方案查询永远零命中
+     * （症状：九键方案切换正常、按键进 buffer，但候选恒空、候选栏恒 IDLE）。
+     */
+    internal fun isBrokenBuildArtifact(file: File): Boolean {
+        val expectedMagic = when {
+            file.name.endsWith(".prism.bin") -> "Rime::Prism/"
+            file.name.endsWith(".table.bin") -> "Rime::Table/"
+            // 未知类型（如 reverse.bin、日志）不判损坏，避免误删触发部署循环
+            else -> return false
+        }
+        if (!file.isFile || file.length() == 0L) return true
+        if (file.length() < expectedMagic.length) return true
+        return try {
+            java.io.FileInputStream(file).use { input ->
+                val head = ByteArray(expectedMagic.length)
+                var read = 0
+                while (read < head.size) {
+                    val n = input.read(head, read, head.size - read)
+                    if (n < 0) return true
+                    read += n
+                }
+                !String(head, Charsets.US_ASCII).startsWith(expectedMagic)
+            }
+        } catch (_: IOException) {
+            // 读不了不臆断损坏，交由 librime 运行时自检兜底
+            false
+        }
+    }
+
     fun isDeploymentComplete(context: Context): Boolean {
         val rimeDir = File(context.filesDir, "rime")
         val buildDir = File(rimeDir, "build")
@@ -132,6 +166,20 @@ object RimeConfigHelper {
 
         val enabledSchemas = SchemaManager.getEnabledSchemas(context)
         if (enabledSchemas.isEmpty()) return false
+
+        // 损坏产物统一扫描：*.prism.bin / *.table.bin 存在但 magic 不对（部署中断
+        // 半成品）→ 删除并判定未完成。产物被删除后 librime 增量维护才会重建它；
+        // 同时清 stored hash，避免 ensureDeployment 因 hash 一致而短路跳过重建。
+        // 词典产物按 dictionary 名生成，可能与 schemaId 不同名（如 t9_pinyin 用
+        // pinyin_simp 词典），故扫描整个 build 目录而非按方案枚举。
+        buildDir.listFiles()?.forEach { artifact ->
+            if (artifact.isFile && isBrokenBuildArtifact(artifact)) {
+                artifact.delete()
+                SettingsPreferences.setDeploymentHash(context, "")
+                Log.w(TAG, "Broken build artifact removed: ${artifact.name}")
+                return false
+            }
+        }
 
         for (schemaId in enabledSchemas) {
             if (!File(buildDir, "$schemaId.prism.bin").exists() &&
@@ -220,6 +268,16 @@ object RimeConfigHelper {
         if (alreadyHasSchemas) {
             // 仅兜底确保 default.yaml 存在（librime 入口必需），缺失时补一份，不覆盖已有。
             ensureDefaultYaml(context, targetDir)
+            // 默认方案强制更新（维护者决策）：默认方案随 app 发布、由维护者统一
+            // 维护，升级时以 assets 为准覆盖用户目录残留（治老版本升级残留废弃
+            // 配置——如引用已废弃 t9_translator 的旧 t9_pinyin 方案导致九键零候选）。
+            // 仅覆盖 assets 清单内的文件（内容比对，不同才写），清单外的第三方
+            // 方案一律跳过不处理。覆盖后文件内容变化使部署 hash 失配，后续
+            // ensureDeployment 按增量优先策略只重编受影响方案。
+            val updated = updateBuiltinAssets(context, targetDir)
+            if (updated > 0) {
+                Log.i(TAG, "Updated $updated builtin asset file(s)")
+            }
             return false
         }
         val copied = try {
@@ -257,6 +315,68 @@ object RimeConfigHelper {
         copyAssetFile(context, "$ASSETS_RIME_DIR/default.yaml", defaultYaml)
     }
     
+    /**
+     * 默认方案强制更新：递归遍历 assets 内置清单，对 .yaml/.lua 文件做内容比对，
+     * 缺失或内容不同才覆盖。assets 清单之外的第三方文件不受影响。
+     *
+     * 覆盖 default.yaml 会重置 schema_list，由调用方
+     * [SchemaManager.applyEnabledSchemasToDefaultYaml] 紧随其后恢复用户启用列表。
+     *
+     * @return 覆盖（含新增）的文件数。
+     */
+    private fun updateBuiltinAssets(context: Context, targetDir: File): Int {
+        var updated = 0
+        fun sync(assetSub: String, targetSub: File) {
+            val assetPath = if (assetSub.isEmpty()) ASSETS_RIME_DIR else "$ASSETS_RIME_DIR/$assetSub"
+            for (fileName in context.assets.list(assetPath) ?: return) {
+                val childAsset = if (assetSub.isEmpty()) fileName else "$assetSub/$fileName"
+                val childTarget = File(targetSub, fileName)
+                val subFiles = context.assets.list("$ASSETS_RIME_DIR/$childAsset")
+                if (!subFiles.isNullOrEmpty()) {
+                    childTarget.mkdirs()
+                    sync(childAsset, childTarget)
+                } else if (fileName.endsWith(".yaml") || fileName.endsWith(".lua")) {
+                    // *.custom.yaml 是补丁层文件（用户定制 + app 运行时写入：
+                    // setEnabledSchemas 的启用列表、DoEnsureT9SchemaPatches 的
+                    // T9 注入与个人词库 packs），覆盖会抹掉用户配置与第三方方案——
+                    // 一律排除出默认覆盖范围
+                    if (fileName.endsWith(".custom.yaml")) continue
+                    if (!childTarget.exists() || !assetContentEquals(context, "$ASSETS_RIME_DIR/$childAsset", childTarget)) {
+                        copyAssetFile(context, "$ASSETS_RIME_DIR/$childAsset", childTarget)
+                        updated++
+                    }
+                }
+            }
+        }
+        sync("", targetDir)
+        return updated
+    }
+
+    /** assets 文件与本地文件内容逐块比对（流式，避免大词典整读进内存）。 */
+    private fun assetContentEquals(context: Context, assetPath: String, target: File): Boolean {
+        return try {
+            context.assets.open(assetPath).use { assetStream ->
+                java.io.FileInputStream(target).use { fileStream ->
+                    val assetBuf = ByteArray(BUFFER_SIZE)
+                    val fileBuf = ByteArray(BUFFER_SIZE)
+                    while (true) {
+                        val nAsset = assetStream.read(assetBuf)
+                        val nFile = fileStream.read(fileBuf)
+                        if (nAsset != nFile) return false
+                        if (nAsset < 0) return true
+                        for (i in 0 until nAsset) {
+                            if (assetBuf[i] != fileBuf[i]) return false
+                        }
+                    }
+                    @Suppress("UNREACHABLE_CODE")
+                    true
+                }
+            }
+        } catch (_: IOException) {
+            false
+        }
+    }
+
     private fun copyAssetsRecursively(context: Context, assetPath: String, targetDir: File): Boolean {
         val files = context.assets.list(assetPath)
         

--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
@@ -446,14 +446,26 @@ class RimeEngine {
         // 部署/全量编译进行中（30s+）不阻塞等待：直接返回 false，避免主线程
         // onStartInput/selectSchema 等路径 ANR。部署完成后的 initRimeEngine
         // 流程会重新切换方案。非部署场景保持阻塞锁语义，保证切换可靠。
-        if (isMaintaining()) return false
+        if (isMaintaining()) {
+            Log.w(TAG, "switchSchema($schemaId) skipped: deployment in progress")
+            return false
+        }
         locked {
-            if (!nativeHasSession()) return false
+            if (!nativeHasSession()) {
+                Log.w(TAG, "switchSchema($schemaId) failed: no rime session")
+                return false
+            }
             // 在切换方案前，确保 T9 方案的 schema 补丁已注入
             // 这会在 user_data_dir 中创建 {schemaId}.custom.yaml 文件，
             // RIME 引擎加载方案时会自动应用 custom.yaml 中的 patch 补丁
             nativeEnsureT9SchemaPatches(schemaId)
-            return nativeSwitchSchema(schemaId)
+            val switched = nativeSwitchSchema(schemaId)
+            if (!switched) {
+                // 常见于方案未部署（不在 schema_list，如老版本升级残留）：
+                // 留证便于反馈日志定位（用户症状：键盘已切换但按键无候选）
+                Log.w(TAG, "switchSchema($schemaId) failed: schema not available, current=${getCurrentSchema()}")
+            }
+            return switched
         }
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/service/AsrInferenceClient.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/AsrInferenceClient.kt
@@ -28,7 +28,11 @@ class AsrInferenceClient(private val context: Context) {
 
     private var service: IInferenceAsrService? = null
     private var bound = false
-    private val connectLatch = CountDownLatch(1)
+
+    /** 连接等待锁：一次性 CountDownLatch，countDown 后即失效——
+     *  重绑前必须在 [ensureBound] 中重建，否则断线重连后会立即假醒。 */
+    @Volatile
+    private var connectLatch = CountDownLatch(1)
 
     private val asrCallbackStub = object : IInferenceAsrCallback.Stub() {
         private var callback: AsrCallback? = null
@@ -76,11 +80,17 @@ class AsrInferenceClient(private val context: Context) {
 
         // bindService 必须在主线程调用；等待结果放到 IO 线程避免阻塞 UI
         val boundOk = withContext(Dispatchers.Main) {
-            if (bound && service != null) {
-                true
-            } else {
-                val intent = Intent(context, AsrInferenceService::class.java)
-                context.bindService(intent, connection, Context.BIND_AUTO_CREATE)
+            synchronized(this@AsrInferenceClient) {
+                if (bound && service != null) {
+                    true
+                } else {
+                    // 服务进程可能崩溃/被回收后重启：latch 是一次性的，重绑前必须重建，
+                    // 否则旧 latch 已 countDown 会让 await 立即假醒（实际未连接），
+                    // 重绑后的第一次 startAsr 必然失败（同 InferenceClient 的修复）
+                    connectLatch = CountDownLatch(1)
+                    val intent = Intent(context, AsrInferenceService::class.java)
+                    context.bindService(intent, connection, Context.BIND_AUTO_CREATE)
+                }
             }
         }
         if (!boundOk) return false

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeSchemaController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeSchemaController.kt
@@ -303,8 +303,22 @@ internal class ImeSchemaController(private val service: XimeInputMethodService) 
             // 部署/编译进行中 switchSchema 返回 false（不阻塞等待），
             // 此时不应继续触发其他 native 调用进入编译中的引擎
             if (!service.rimeEngine.switchSchema(schemaId)) {
-                Log.w(XimeInputMethodService.TAG, "switchSchema skipped: deployment in progress")
-                Toast.makeText(service, "词库部署中，请稍后再切换方案", Toast.LENGTH_SHORT).show()
+                if (service.rimeEngine.isMaintaining()) {
+                    Log.w(XimeInputMethodService.TAG, "switchSchema skipped: deployment in progress")
+                    Toast.makeText(service, "词库部署中，请稍后再切换方案", Toast.LENGTH_SHORT).show()
+                    return
+                }
+                // 引擎切换失败（常见：方案未部署/不在 schema_list，老版本升级残留）。
+                // 必须回滚偏好到引擎实际方案：偏好留着目标值会让 UI 状态与引擎
+                // 永久脱节（键盘已显示九键但数字键无人处理，候选栏始终 IDLE）。
+                // getCurrentSchema 无会话时返回空串——此时不动偏好，保留原值由
+                // IME 重启的恢复逻辑兜底，避免把空串写进偏好与 user.yaml
+                val actual = service.rimeEngine.getCurrentSchema()
+                if (actual.isNotEmpty()) {
+                    SettingsPreferences.setCurrentSchema(service, actual)
+                }
+                Log.w(XimeInputMethodService.TAG, "switchSchema failed: target=$schemaId actual=$actual")
+                Toast.makeText(service, "方案未部署，请在方案管理中部署后再试", Toast.LENGTH_SHORT).show()
                 return
             }
             if (!service.rimeEngine.isAsciiMode()) {

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
@@ -751,12 +751,27 @@ object SchemaManager {
         return result.joinToString("\n")
     }
 
+    /** 内置方案（保持默认启用顺序）。 */
+    internal val BUILTIN_SCHEMAS = listOf("wubi86", "wubi86_pinyin", "pinyin_simp", "t9_pinyin")
+
+    /**
+     * 内置方案补齐（纯函数）：用户启用列表尾部按 [BUILTIN_SCHEMAS] 顺序追加缺失项，
+     * 用户已有顺序与选择保持不变；无缺失时原样返回。
+     *
+     * 背景：老版本升级用户的 custom.yaml 早于新内置方案（如 t9_pinyin）创建，
+     * 列表里没有它 → 方案永不部署 → 切九键引擎侧静默失败（按键无候选）。
+     */
+    internal fun mergeBuiltinSchemas(enabled: List<String>): List<String> {
+        val missing = BUILTIN_SCHEMAS.filter { it !in enabled }
+        return if (missing.isEmpty()) enabled else enabled + missing
+    }
+
     fun getEnabledSchemas(context: Context): List<String> {
         val customFile = getCustomYamlFile(context)
         if (!customFile.exists()) {
-            val defaultBuiltIn = listOf("wubi86", "wubi86_pinyin", "pinyin_simp", "t9_pinyin")
-            setEnabledSchemas(context, defaultBuiltIn)
-            return defaultBuiltIn
+            setEnabledSchemas(context, BUILTIN_SCHEMAS)
+            SettingsPreferences.setBuiltinSchemasMerged(context, true)
+            return BUILTIN_SCHEMAS
         }
 
         try {
@@ -778,12 +793,29 @@ object SchemaManager {
                     }
                 }
             }
-            if (schemas.isNotEmpty()) return schemas
+            if (schemas.isNotEmpty()) {
+                // 内置方案补齐只执行一次（新版本首次运行，治老版本升级残留：
+                // 列表无 t9_pinyin → 方案永不部署 → 切九键静默失败）。之后用户
+                // 在方案管理中移除内置方案是有效选择，不得每次读取强行补回。
+                // 补齐写回后 schema_list 计入部署 hash、build 产物按方案校验，
+                // 缺失的方案会自动触发重部署。
+                val merged = if (SettingsPreferences.isBuiltinSchemasMerged(context)) {
+                    schemas
+                } else {
+                    val m = mergeBuiltinSchemas(schemas)
+                    if (m != schemas) {
+                        setEnabledSchemas(context, m)
+                    }
+                    SettingsPreferences.setBuiltinSchemasMerged(context, true)
+                    m
+                }
+                return merged
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to read custom.yaml", e)
         }
 
-        return listOf("wubi86", "wubi86_pinyin", "pinyin_simp", "t9_pinyin")
+        return BUILTIN_SCHEMAS
     }
 
     fun setEnabledSchemas(context: Context, schemaIds: List<String>) {

--- a/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
@@ -10,6 +10,7 @@ object SettingsPreferences {
     /** 双写标记：仅新版本双写后置 true，本地值才可信（旧版本只写 rime，本地是过时迁移值） */
     private const val KEY_CURRENT_SCHEMA_DUAL = "current_schema_dual"
     private const val KEY_DEPLOYMENT_DONE = "deployment_done"
+    private const val KEY_BUILTIN_SCHEMAS_MERGED = "builtin_schemas_merged"
     private const val KEY_DEPLOYMENT_HASH = "deployment_hash"
     private const val KEY_RIME_ASSETS_VERSION = "rime_assets_version"
     private const val KEY_SETUP_COMPLETED = "setup_completed"
@@ -167,9 +168,22 @@ object SettingsPreferences {
     fun isDeploymentDone(context: Context): Boolean {
         return getPrefs(context).getBoolean(KEY_DEPLOYMENT_DONE, false)
     }
-    
+
     fun setDeploymentDone(context: Context, done: Boolean) {
         getPrefs(context).edit().putBoolean(KEY_DEPLOYMENT_DONE, done).apply()
+    }
+
+    /**
+     * 内置方案补齐已执行标记：新版本首次运行时把缺失的内置方案（如 t9_pinyin，
+     * 老版本升级用户列表里没有）补进 schema_list 一次；之后用户在方案管理里
+     * 移除内置方案是有效选择，getEnabledSchemas 不得再强行补回。
+     */
+    fun isBuiltinSchemasMerged(context: Context): Boolean {
+        return getPrefs(context).getBoolean(KEY_BUILTIN_SCHEMAS_MERGED, false)
+    }
+
+    fun setBuiltinSchemasMerged(context: Context, merged: Boolean) {
+        getPrefs(context).edit().putBoolean(KEY_BUILTIN_SCHEMAS_MERGED, merged).apply()
     }
 
     fun getDeploymentHash(context: Context): String {

--- a/app/src/main/java/com/kingzcheung/xime/speech/OfflineAsrBackend.kt
+++ b/app/src/main/java/com/kingzcheung/xime/speech/OfflineAsrBackend.kt
@@ -94,6 +94,13 @@ class OfflineAsrBackend(private val context: Context) : AsrBackend {
             // 否则 preload 预热时 stop() 清空的 callback 会导致 partial 结果丢失
             val modelDir = modelManager.getSelectedModelDir().absolutePath
             runBlocking { client.startAsr(modelDir, asrCallback) }
+        } catch (e: InterruptedException) {
+            // 快速取消竞态：stopRecognition/cancelRecognition 会 interrupt 录音线程，
+            // 中断正好落在等待 :asr 绑定/模型加载的 runBlocking 上——属正常取消，不算错误，
+            // 不打 E 级日志（避免"启动引擎失败"误报污染排查）
+            Thread.currentThread().interrupt()
+            FileLogger.d(TAG, "start aborted: recording cancelled before engine started")
+            false
         } catch (e: Exception) {
             FileLogger.e(TAG, "start failed", e)
             false
@@ -109,6 +116,11 @@ class OfflineAsrBackend(private val context: Context) : AsrBackend {
         if (!initialized) return
         val text = try {
             runBlocking { client.stopAsr() }
+        } catch (e: InterruptedException) {
+            // 录音线程被取消 interrupt 时可能正阻塞在此（同 start 的取消竞态），属正常路径
+            Thread.currentThread().interrupt()
+            FileLogger.d(TAG, "stop aborted: recording cancelled")
+            ""
         } catch (e: Exception) {
             FileLogger.e(TAG, "stop failed", e)
             ""

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidatePage.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidatePage.kt
@@ -1,7 +1,6 @@
 package com.kingzcheung.xime.ui.keyboard
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
@@ -128,7 +127,7 @@ fun CandidatePage(
                             if (state.hasPrevPage && callbacks.onPageUp != null) state.textColor.copy(alpha = 0.5f)
                             else state.textColor.copy(alpha = 0.1f)
                         )
-                        .clickable(
+                        .tolerantClick(
                             enabled = state.hasPrevPage && state.candidates.isNotEmpty() && callbacks.onPageUp != null,
                             onClick = { callbacks.onPageUp?.invoke() }
                         ),
@@ -150,7 +149,7 @@ fun CandidatePage(
                             if (state.hasNextPage && callbacks.onPageDown != null) state.textColor.copy(alpha = 0.25f)
                             else state.textColor.copy(alpha = 0.1f)
                         )
-                        .clickable(
+                        .tolerantClick(
                             enabled = state.hasNextPage && state.candidates.isNotEmpty() && callbacks.onPageDown != null,
                             onClick = { callbacks.onPageDown?.invoke() }
                         ),
@@ -170,7 +169,7 @@ fun CandidatePage(
                     .size(28.dp)
                     .clip(CircleShape)
                     .background(iconButtonContainer)
-                    .clickable { callbacks.onBack?.invoke() },
+                    .tolerantClick { callbacks.onBack?.invoke() },
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
@@ -193,7 +192,8 @@ fun CandidatePage(
                 // 候选条目点击与外层 verticalScroll 存在手势竞争：按下后轻微位移超过
                 // touch slop 即被判定为滚动，点击被静默取消（无任何反馈）。部分 ROM
                 // （如鸿蒙）的 slop/触摸采样更敏感，表现为"偶尔点击候选无反应"。
-                // 内容不超高时彻底禁用滚动容器，保证点击稳定命中；超高时仍可滚动。
+                // 内容不超高时彻底禁用滚动容器，保证点击稳定命中；超高时仍可滚动，
+                // 由候选条目的 tolerantClick（宽容位移判定）兜底。
                 var viewportHeight by remember { mutableStateOf(0) }
                 var contentHeight by remember { mutableStateOf(0) }
                 val scrollState = rememberScrollState()
@@ -287,9 +287,9 @@ fun CandidatePageItem(
         modifier = modifier
             .clip(RoundedCornerShape(6.dp))
             .background(if (isPressed) textColor.copy(alpha = 0.12f) else Color.Transparent)
-            .clickable(
+            .tolerantClick(
+                showRipple = false,
                 interactionSource = interactionSource,
-                indication = null,
                 onClick = onClick
             )
             .padding(horizontal = 4.dp, vertical = 8.dp),

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/EmojiKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/EmojiKeyboardLayout.kt
@@ -2,7 +2,6 @@ package com.kingzcheung.xime.ui.keyboard
 
 import android.widget.Toast
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -163,7 +162,7 @@ fun EmojiKeyboardLayout(
                         .size(28.dp)
                         .clip(CircleShape)
                         .background(iconButtonContainer)
-                        .clickable { onBack() },
+                        .tolerantClick { onBack() },
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
@@ -197,7 +196,7 @@ fun EmojiKeyboardLayout(
                                     if (selectedTopTabIndex == 0) accentColor.copy(0.4f)
                                     else Color.Transparent
                                 )
-                                .clickable {
+                                .tolerantClick {
                                     onHapticFeedback?.invoke()
                                     selectedTopTabIndex = 0
                                     selectedSubCategoryIndex = 0
@@ -223,7 +222,7 @@ fun EmojiKeyboardLayout(
                                         if (selectedTopTabIndex == index + 1) accentColor.copy(0.4f)
                                         else Color.Transparent
                                     )
-                                    .clickable {
+                                    .tolerantClick {
                                         onHapticFeedback?.invoke()
                                         selectedTopTabIndex = index + 1
                                         selectedSubCategoryIndex = 0
@@ -509,7 +508,7 @@ fun EmojiCategoryTab(
                 else backgroundColor
             )
             .padding(horizontal = 5.dp)
-            .clickable(onClick = onClick),
+            .tolerantClick(onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
         if (pluginIcon?.assetName != null) {
@@ -544,7 +543,7 @@ fun EmojiButton(
         modifier = modifier
             .aspectRatio(1f)
             .clip(RoundedCornerShape(4.dp))
-            .clickable(onClick = onClick),
+            .tolerantClick(onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
         Text(
@@ -580,7 +579,7 @@ fun PluginEmojiButton(
             )
             .clip(RoundedCornerShape(4.dp))
             .background(buttonBackgroundColor)
-            .clickable(onClick = onClick)
+            .tolerantClick(onClick = onClick)
             .padding(horizontal = 4.dp, vertical = 2.dp),
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SymbolKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SymbolKeyboardLayout.kt
@@ -1,7 +1,6 @@
 package com.kingzcheung.xime.ui.keyboard
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
@@ -103,7 +102,7 @@ fun SymbolKeyboardLayout(
                     .size(28.dp)
                     .clip(CircleShape)
                     .background(iconButtonContainer)
-                    .clickable {
+                    .tolerantClick {
                         onHapticFeedback?.invoke()
                         onBack()
                     },
@@ -242,9 +241,9 @@ private fun SymbolButton(
                 if (isPressed) androidx.compose.ui.graphics.lerp(backgroundColor, Color.Black, 0.2f)
                 else backgroundColor
             )
-            .clickable(
+            .tolerantClick(
+                showRipple = false,
                 interactionSource = interactionSource,
-                indication = null,
                 onClick = onClick
             ),
         contentAlignment = Alignment.Center
@@ -277,7 +276,7 @@ private fun SymbolCategoryTab(
                 if (isSelected) selectedBackgroundColor
                 else backgroundColor
             )
-            .clickable(onClick = onClick)
+            .tolerantClick(onClick = onClick)
             .padding(horizontal = 6.dp),
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/TolerantClick.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/TolerantClick.kt
@@ -1,0 +1,77 @@
+package com.kingzcheung.xime.ui.keyboard
+
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.input.pointer.changedToUp
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.unit.dp
+
+/**
+ * 宽容点击：语义同 Modifier.clickable，但点击判定改为「抬起时累计位移仍在
+ * 容差内即触发」，不因事件被父级滚动/翻页手势消费而静默取消。
+ *
+ * 背景：候选页、表情页、符号页的按钮外层是 Pager/滚动容器。系统手势判定下，
+ * 按下后位移超过 touch slop 即被判为滚动/翻页，clickable 随之取消点击；
+ * 部分 ROM 的 slop 更小、采样更敏感，轻点的小位移也会超限，表现为
+ * 「点了没反应」。容差取 2 倍 touch slop 与 12dp 的较大者：轻点不再丢点击，
+ * 真实滚动/翻页的位移远超容差，不受影响。
+ *
+ * 本手势不消费任何指针事件，父级 Pager/滚动的行为保持系统默认。
+ * showRipple = false 时涟漪反馈交给调用方自绘（配合 interactionSource 的
+ * Press/Release/Cancel 事件，语义与 clickable 一致）。
+ */
+fun Modifier.tolerantClick(
+    enabled: Boolean = true,
+    showRipple: Boolean = true,
+    interactionSource: MutableInteractionSource? = null,
+    onClick: () -> Unit,
+): Modifier = composed {
+    val currentOnClick by rememberUpdatedState(onClick)
+    val currentEnabled by rememberUpdatedState(enabled)
+    val source = interactionSource ?: remember { MutableInteractionSource() }
+    val resolvedIndication = if (showRipple) LocalIndication.current else null
+
+    val indicationModifier = if (resolvedIndication != null) {
+        Modifier.indication(source, resolvedIndication)
+    } else {
+        Modifier
+    }
+
+    indicationModifier.then(
+        Modifier.pointerInput(currentEnabled) {
+            if (!currentEnabled) return@pointerInput
+            val slopPx = maxOf(2f * viewConfiguration.touchSlop, 12.dp.toPx())
+            awaitEachGesture {
+                val down = awaitFirstDown(requireUnconsumed = false)
+                val press = PressInteraction.Press(down.position)
+                source.tryEmit(press)
+                var travelled = 0f
+                while (true) {
+                    val event = awaitPointerEvent()
+                    val pressedChange = event.changes.firstOrNull { it.pressed }
+                    val upChange = event.changes.firstOrNull { it.changedToUp() }
+                    travelled += (pressedChange ?: upChange)?.positionChange()?.getDistance() ?: 0f
+                    if (pressedChange == null) {
+                        if (upChange != null && travelled <= slopPx) {
+                            currentOnClick()
+                            source.tryEmit(PressInteraction.Release(press))
+                        } else {
+                            source.tryEmit(PressInteraction.Cancel(press))
+                        }
+                        break
+                    }
+                }
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaSettingsViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaSettingsViewModel.kt
@@ -92,6 +92,7 @@ class SchemaSettingsViewModel(application: Application) : AndroidViewModel(appli
 
     fun selectSchema(schema: SchemaMeta) {
         if (_uiState.value.currentSchema == schema.schemaId) return
+        val previous = _uiState.value.currentSchema
         SettingsPreferences.setCurrentSchema(context, schema.schemaId)
         _uiState.update { it.copy(currentSchema = schema.schemaId) }
         if (RimeEngine.isInitialized()) {
@@ -102,12 +103,24 @@ class SchemaSettingsViewModel(application: Application) : AndroidViewModel(appli
                 if (switched) {
                     showToast("已切换到${schema.name}")
                 } else {
+                    rollbackSchemaSelection(previous)
                     showToast("词库部署中，请稍后再切换方案")
                 }
             } else {
+                rollbackSchemaSelection(previous)
                 showToast("请点击「部署」按钮")
             }
         }
+    }
+
+    /**
+     * 切换失败时回滚偏好与 UI 状态。不回滚有两个后果：再次点击会被
+     * [selectSchema] 开头的同值短路拦住（用户永远无法重试）；偏好与
+     * 引擎实际方案脱节后，IME 重启的方案恢复逻辑会拿到偏差好。
+     */
+    private fun rollbackSchemaSelection(previous: String) {
+        SettingsPreferences.setCurrentSchema(context, previous)
+        _uiState.update { it.copy(currentSchema = previous) }
     }
 
     fun importSchemaFile(uri: Uri) {

--- a/app/src/test/java/com/kingzcheung/xime/rime/BuildArtifactIntegrityTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/rime/BuildArtifactIntegrityTest.kt
@@ -1,0 +1,82 @@
+package com.kingzcheung.xime.rime
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * [RimeConfigHelper.isBrokenBuildArtifact] 单测：部署产物半成品检测。
+ *
+ * librime 的 prism/table 产物文件头（偏移 0）是 Metadata.format 字符串：
+ * "Rime::Prism/4.0" / "Rime::Table/4.0"。部署进行中进程被杀会留下空文件或
+ * 截断文件——这类产物 mtime 比源新，librime 增量维护会跳过重编，导致该方案
+ * 查询永远零命中。
+ */
+class BuildArtifactIntegrityTest {
+
+    private fun newDir(): File =
+        File(System.getProperty("java.io.tmpdir"), "build-artifact-test-${System.nanoTime()}")
+            .apply { mkdirs() }
+
+    private fun write(dir: File, name: String, content: ByteArray): File =
+        File(dir, name).apply { writeBytes(content) }
+
+    private val prismMagic = "Rime::Prism/".toByteArray(Charsets.US_ASCII)
+    private val tableMagic = "Rime::Table/".toByteArray(Charsets.US_ASCII)
+
+    @Test
+    fun `合法 prism 头不是损坏`() {
+        val dir = newDir()
+        val file = write(dir, "t9_pinyin.prism.bin", prismMagic + "4.0".toByteArray() + ByteArray(100))
+        assertFalse(RimeConfigHelper.isBrokenBuildArtifact(file))
+        dir.deleteRecursively()
+    }
+
+    @Test
+    fun `合法 table 头不是损坏`() {
+        val dir = newDir()
+        val file = write(dir, "pinyin_simp.table.bin", tableMagic + "4.0".toByteArray() + ByteArray(100))
+        assertFalse(RimeConfigHelper.isBrokenBuildArtifact(file))
+        dir.deleteRecursively()
+    }
+
+    @Test
+    fun `magic 错乱判损坏`() {
+        val dir = newDir()
+        val file = write(dir, "t9_pinyin.prism.bin", "GARBAGE-GARBAGE".toByteArray() + ByteArray(50))
+        assertTrue(RimeConfigHelper.isBrokenBuildArtifact(file))
+        dir.deleteRecursively()
+    }
+
+    @Test
+    fun `空文件判损坏`() {
+        val dir = newDir()
+        val file = write(dir, "pinyin_simp.table.bin", ByteArray(0))
+        assertTrue(RimeConfigHelper.isBrokenBuildArtifact(file))
+        dir.deleteRecursively()
+    }
+
+    @Test
+    fun `截断文件短于magic长度判损坏`() {
+        val dir = newDir()
+        val file = write(dir, "t9_pinyin.prism.bin", prismMagic.copyOf(5))
+        assertTrue(RimeConfigHelper.isBrokenBuildArtifact(file))
+        dir.deleteRecursively()
+    }
+
+    @Test
+    fun `未知产物类型不做magic判定`() {
+        val dir = newDir()
+        val file = write(dir, "wubi86.reverse.bin", "whatever".toByteArray())
+        assertFalse(RimeConfigHelper.isBrokenBuildArtifact(file))
+        dir.deleteRecursively()
+    }
+
+    @Test
+    fun `文件不存在判损坏`() {
+        val dir = newDir()
+        assertTrue(RimeConfigHelper.isBrokenBuildArtifact(File(dir, "missing.prism.bin")))
+        dir.deleteRecursively()
+    }
+}

--- a/app/src/test/java/com/kingzcheung/xime/settings/SchemaListBlockTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/settings/SchemaListBlockTest.kt
@@ -46,8 +46,7 @@ class SchemaListBlockTest {
     }
 
     @Test
-    fun `replaces existing block with a single enabled schema`() {
-        val result = SchemaManager.replaceSchemaListBlock(defaultYaml, listOf("quick5"))
+    fun `replaces existing block with a single enabled schema`() {        val result = SchemaManager.replaceSchemaListBlock(defaultYaml, listOf("quick5"))
         assertEquals(listOf("quick5"), extractSchemaList(result))
         assertFalse("old schemas must be gone", result.contains("wubi86"))
     }
@@ -105,5 +104,42 @@ class SchemaListBlockTest {
         val result = SchemaManager.replaceSchemaListBlock(noBlock, listOf("quick5"))
         assertEquals(listOf("quick5"), extractSchemaList(result))
         assertTrue(result.contains("switcher:"))
+    }
+
+    // ---- mergeBuiltinSchemas：老版本升级用户的内置方案补齐 ----
+
+    @Test
+    fun `老列表缺新内置方案时补到尾部`() {
+        // 老版本只有三个方案：升级后 t9_pinyin 从未部署，切九键静默失败
+        val enabled = listOf("wubi86", "wubi86_pinyin", "pinyin_simp")
+        val merged = SchemaManager.mergeBuiltinSchemas(enabled)
+        assertEquals(
+            listOf("wubi86", "wubi86_pinyin", "pinyin_simp", "t9_pinyin"),
+            merged,
+        )
+    }
+
+    @Test
+    fun `内置方案齐全时原样返回`() {
+        val enabled = listOf("wubi86", "wubi86_pinyin", "pinyin_simp", "t9_pinyin")
+        assertEquals(enabled, SchemaManager.mergeBuiltinSchemas(enabled))
+    }
+
+    @Test
+    fun `用户顺序与第三方方案保持不变`() {
+        val enabled = listOf("my_custom_schema", "pinyin_simp", "wubi86")
+        val merged = SchemaManager.mergeBuiltinSchemas(enabled)
+        assertEquals(
+            listOf("my_custom_schema", "pinyin_simp", "wubi86", "wubi86_pinyin", "t9_pinyin"),
+            merged,
+        )
+    }
+
+    @Test
+    fun `空列表补齐全量内置方案`() {
+        assertEquals(
+            SchemaManager.BUILTIN_SCHEMAS,
+            SchemaManager.mergeBuiltinSchemas(emptyList()),
+        )
     }
 }


### PR DESCRIPTION
- 在候选页、表情键盘、符号键盘等多个组件中使用tolerantClick
- 解决轻微触摸位移导致点击被取消的问题
- 提升在不同ROM下的点击稳定性

fix(deploy): 解决部署中断后半成品文件导致的零候选问题

- 通过magic字节头检测损坏的.prism.bin和.table.bin文件
- 自动清理损坏产物并重置部署hash触发重建
- 防止因部署进程被杀导致的候选为空的问题

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
