### PR TITLE
feat(plugin-core): 重构插件XML解析逻辑并修复capabilities解析问题

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,7 +43,7 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 20260907
+        versionCode = 20260908
         versionName = "2.8.0-beta5"
 
 

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/XmlManager.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/XmlManager.kt
@@ -10,6 +10,213 @@ import java.io.File
 class XmlManager(private val context: Application) {
     companion object {
         private const val PLUGINS_XML = "plugins.xml"
+
+        /**
+         * 注册表 XML 文本 → 插件列表（纯函数，[loadFromDisk] 与单测共用）。
+         *
+         * 注意 capabilities 节点：写入时 JSON 经 [escapeXml] 转义（`"` → `&quot;`），
+         * 读取必须先 [unescapeXml] 再交给 JSON 解码，否则解码必然失败、能力声明
+         * 静默丢失——进程冷启动后事件订阅/面板 display 等全部失效（统计插件
+         * 重启后不统计、面板退化成 direct 布局的根因）。
+         */
+        internal fun parsePluginsXmlContent(content: String): List<PluginInfo> {
+            val result = mutableListOf<PluginInfo>()
+            val pluginRegex = Regex("<plugin>(.*?)</plugin>", RegexOption.DOT_MATCHES_ALL)
+            val matches = pluginRegex.findAll(content)
+
+            for (match in matches) {
+                val pluginContent = match.groupValues[1]
+                val id = extractTag(pluginContent, "id")
+                val name = extractTag(pluginContent, "name")
+                val description = extractTag(pluginContent, "description")
+                val versionCode = extractTag(pluginContent, "versionCode")?.toLongOrNull() ?: 0
+                val versionName = extractTag(pluginContent, "versionName") ?: ""
+                val path = extractTag(pluginContent, "path")
+                val type = extractTag(pluginContent, "type") ?: "unknown"
+                val enabled = extractTag(pluginContent, "enabled")?.toBoolean() ?: true
+                val installTime = extractTag(pluginContent, "installTime")?.toLongOrNull() ?: System.currentTimeMillis()
+                val source = extractTag(pluginContent, "source")
+                    ?.let { runCatching { PluginSource.valueOf(it) }.getOrNull() }
+                    ?: PluginSource.SYSTEM
+                val iconResId = extractTag(pluginContent, "iconResId")?.toIntOrNull() ?: 0
+                val minHostVersion = extractTag(pluginContent, "minHostVersion")?.takeIf { it.isNotBlank() }
+                val maxHostVersion = extractTag(pluginContent, "maxHostVersion")?.takeIf { it.isNotBlank() }
+                val entryScript = extractTag(pluginContent, "entryScript")?.takeIf { it.isNotBlank() }
+                val networkHosts = extractTag(pluginContent, "networkHosts")
+                    ?.split(",")
+                    ?.map { it.trim() }
+                    ?.filter { it.isNotBlank() }
+                    ?: emptyList()
+                val allowCustomHosts = extractTag(pluginContent, "allowCustomHosts")?.toBoolean() ?: false
+                val toolbarButtons = parseToolbarButtons(pluginContent)
+                val trustLevel = com.kingzcheung.xime.plugin.core.util.PluginSignatureUtil.classifyLuaPlugin(source)
+                val manifestIcon = extractTag(pluginContent, "manifestIcon")?.takeIf { it.isNotBlank() }
+                val capabilities = extractTag(pluginContent, "capabilities")
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { decodeCapabilities(unescapeXml(it)) }
+
+                if (id != null && path != null) {
+                    result.add(
+                        PluginInfo(
+                            id = id,
+                            name = name ?: "",
+                            iconResId = iconResId,
+                            description = description ?: "",
+                            versionCode = versionCode,
+                            versionName = versionName,
+                            path = path,
+                            type = type,
+                            enabled = enabled,
+                            installTime = installTime,
+                            source = source,
+                            minHostVersion = minHostVersion,
+                            maxHostVersion = maxHostVersion,
+                            trustLevel = trustLevel,
+                            entryScript = entryScript,
+                            declaredHosts = networkHosts,
+                            allowCustomHosts = allowCustomHosts,
+                            toolbarButtons = toolbarButtons,
+                            manifestIcon = manifestIcon,
+                            capabilities = capabilities
+                        )
+                    )
+                }
+            }
+            return result
+        }
+
+        private fun parseToolbarButtons(pluginContent: String): List<PluginToolbarButton> {
+            val regex = Regex("<toolbarButton\\b([^>]*)/>")
+            return regex.findAll(pluginContent).mapNotNull { m ->
+                val tag = m.groupValues[1]
+                val id = extractAttribute(tag, "id") ?: return@mapNotNull null
+                val rawIcon = extractAttribute(tag, "icon")
+                PluginToolbarButton(
+                    id = unescapeXml(id),
+                    label = unescapeXml(extractAttribute(tag, "label").orEmpty()),
+                    icon = rawIcon?.let { if (it.isEmpty()) null else unescapeXml(it) },
+                    action = unescapeXml(extractAttribute(tag, "action").orEmpty())
+                        .ifBlank { "open_panel" }
+                )
+            }.toList()
+        }
+
+        private fun extractAttribute(tag: String, name: String): String? {
+            val regex = Regex("(?:^|\\s)$name=\"([^\"]*)\"")
+            return regex.find(tag)?.groupValues?.get(1)
+        }
+
+        private fun extractTag(content: String, tagName: String): String? {
+            val regex = Regex("<$tagName>(.*?)</$tagName>")
+            return regex.find(content)?.groupValues?.get(1)
+        }
+
+        private fun escapeXml(text: String): String {
+            return text
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;")
+        }
+
+        private fun unescapeXml(text: String): String {
+            return text
+                .replace("&apos;", "'")
+                .replace("&quot;", "\"")
+                .replace("&lt;", "<")
+                .replace("&gt;", ">")
+                .replace("&amp;", "&")
+        }
+
+        /** capabilities → JSON 文本（便于单个 XML 节点持久化）。 */
+        private fun encodeCapabilities(cap: com.kingzcheung.xime.plugin.core.model.PluginCapabilities): String {
+            val root = mutableMapOf<String, Any?>()
+            cap.emoji?.let {
+                root["emoji"] = mapOf(
+                    "supportsSearch" to it.supportsSearch,
+                    "columns" to it.columns,
+                    "itemHeightDp" to it.itemHeightDp
+                )
+            }
+            cap.speech?.let {
+                root["speech"] = mapOf(
+                    "inputMode" to it.inputMode,
+                    "supportsPartialResults" to it.supportsPartialResults,
+                    "requiresNetwork" to it.requiresNetwork
+                )
+            }
+            cap.tool?.let {
+                root["tool"] = mapOf("display" to it.display?.name)
+            }
+            cap.clipboardSync?.let {
+                root["clipboardSync"] = mapOf("protocols" to it.protocols)
+            }
+            cap.backup?.let {
+                root["backup"] = mapOf("protocols" to it.protocols)
+            }
+            if (cap.events.isNotEmpty()) {
+                root["events"] = cap.events
+            }
+            if (cap.candidateTransform) {
+                root["candidateTransform"] = true
+            }
+            if (cap.quickSendRead) {
+                root["quickSendRead"] = true
+            }
+            if (cap.clipboardRead) {
+                root["clipboardRead"] = true
+            }
+            return com.kingzcheung.xime.plugin.core.lua.sdk.SimpleJson.encode(root) ?: ""
+        }
+
+        /** capabilities JSON 文本 → 类型化模型（解析失败返回 null，不影响插件加载）。 */
+        private fun decodeCapabilities(json: String): com.kingzcheung.xime.plugin.core.model.PluginCapabilities? {
+            return runCatching {
+                val root = com.kingzcheung.xime.plugin.core.lua.sdk.SimpleJson.decode(json)
+                    as? Map<*, *> ?: return null
+                com.kingzcheung.xime.plugin.core.model.PluginCapabilities(
+                    emoji = (root["emoji"] as? Map<*, *>)?.let { m ->
+                        com.kingzcheung.xime.plugin.core.model.PluginCapabilities.EmojiCapabilities(
+                            supportsSearch = (m["supportsSearch"] as? Boolean) ?: false,
+                            columns = (m["columns"] as? Number)?.toInt(),
+                            itemHeightDp = (m["itemHeightDp"] as? Number)?.toInt()
+                        )
+                    },
+                    speech = (root["speech"] as? Map<*, *>)?.let { m ->
+                        com.kingzcheung.xime.plugin.core.model.PluginCapabilities.SpeechCapabilities(
+                            inputMode = (m["inputMode"] as? String) ?: "streaming",
+                            supportsPartialResults = (m["supportsPartialResults"] as? Boolean) ?: true,
+                            requiresNetwork = (m["requiresNetwork"] as? Boolean) ?: true
+                        )
+                    },
+                    tool = (root["tool"] as? Map<*, *>)?.let { m ->
+                        com.kingzcheung.xime.plugin.core.model.PluginCapabilities.ToolCapabilities(
+                            display = (m["display"] as? String)?.let { s ->
+                                // 旧契约 "select"（全屏结果页）已并入 passive（InfoPanel 内 items 点选上屏）
+                                if (s.equals("select", ignoreCase = true)) com.kingzcheung.xime.plugin.core.api.ToolResult.PASSIVE
+                                else com.kingzcheung.xime.plugin.core.api.ToolResult.entries
+                                    .firstOrNull { it.name.equals(s, ignoreCase = true) }
+                            }
+                        )
+                    },
+                    clipboardSync = (root["clipboardSync"] as? Map<*, *>)?.let { m ->
+                        com.kingzcheung.xime.plugin.core.model.PluginCapabilities.ClipboardSyncCapabilities(
+                            protocols = (m["protocols"] as? List<*>)?.mapNotNull { it as? String } ?: emptyList()
+                        )
+                    },
+                    backup = (root["backup"] as? Map<*, *>)?.let { m ->
+                        com.kingzcheung.xime.plugin.core.model.PluginCapabilities.BackupCapabilities(
+                            protocols = (m["protocols"] as? List<*>)?.mapNotNull { it as? String } ?: emptyList()
+                        )
+                    },
+                    events = (root["events"] as? List<*>)?.mapNotNull { it as? String } ?: emptyList(),
+                    candidateTransform = (root["candidateTransform"] as? Boolean) ?: false,
+                    quickSendRead = (root["quickSendRead"] as? Boolean) ?: false,
+                    clipboardRead = (root["clipboardRead"] as? Boolean) ?: false
+                )
+            }.getOrNull()
+        }
     }
 
     private val pluginsFile: File by lazy {
@@ -114,197 +321,8 @@ class XmlManager(private val context: Application) {
     }
 
     private fun parsePluginsXml(content: String) {
-        val pluginRegex = Regex("<plugin>(.*?)</plugin>", RegexOption.DOT_MATCHES_ALL)
-        val matches = pluginRegex.findAll(content)
-
-        for (match in matches) {
-            val pluginContent = match.groupValues[1]
-            val id = extractTag(pluginContent, "id")
-            val name = extractTag(pluginContent, "name")
-            val description = extractTag(pluginContent, "description")
-            val versionCode = extractTag(pluginContent, "versionCode")?.toLongOrNull() ?: 0
-            val versionName = extractTag(pluginContent, "versionName") ?: ""
-            val path = extractTag(pluginContent, "path")
-            val type = extractTag(pluginContent, "type") ?: "unknown"
-            val enabled = extractTag(pluginContent, "enabled")?.toBoolean() ?: true
-            val installTime = extractTag(pluginContent, "installTime")?.toLongOrNull() ?: System.currentTimeMillis()
-            val source = extractTag(pluginContent, "source")
-                ?.let { runCatching { PluginSource.valueOf(it) }.getOrNull() }
-                ?: PluginSource.SYSTEM
-            val iconResId = extractTag(pluginContent, "iconResId")?.toIntOrNull() ?: 0
-            val minHostVersion = extractTag(pluginContent, "minHostVersion")?.takeIf { it.isNotBlank() }
-            val maxHostVersion = extractTag(pluginContent, "maxHostVersion")?.takeIf { it.isNotBlank() }
-            val entryScript = extractTag(pluginContent, "entryScript")?.takeIf { it.isNotBlank() }
-            val networkHosts = extractTag(pluginContent, "networkHosts")
-                ?.split(",")
-                ?.map { it.trim() }
-                ?.filter { it.isNotBlank() }
-                ?: emptyList()
-            val allowCustomHosts = extractTag(pluginContent, "allowCustomHosts")?.toBoolean() ?: false
-            val toolbarButtons = parseToolbarButtons(pluginContent)
-            val trustLevel = com.kingzcheung.xime.plugin.core.util.PluginSignatureUtil.classifyLuaPlugin(source)
-            val manifestIcon = extractTag(pluginContent, "manifestIcon")?.takeIf { it.isNotBlank() }
-            val capabilities = extractTag(pluginContent, "capabilities")
-                ?.takeIf { it.isNotBlank() }
-                ?.let { decodeCapabilities(it) }
-
-            if (id != null && path != null) {
-                plugins[id] = PluginInfo(
-                    id = id,
-                    name = name ?: "",
-                    iconResId = iconResId,
-                    description = description ?: "",
-                    versionCode = versionCode,
-                    versionName = versionName,
-                    path = path,
-                    type = type,
-                    enabled = enabled,
-                    installTime = installTime,
-                    source = source,
-                    minHostVersion = minHostVersion,
-                    maxHostVersion = maxHostVersion,
-                    trustLevel = trustLevel,
-                    entryScript = entryScript,
-                    declaredHosts = networkHosts,
-                    allowCustomHosts = allowCustomHosts,
-                    toolbarButtons = toolbarButtons,
-                    manifestIcon = manifestIcon,
-                    capabilities = capabilities
-                )
-            }
+        for (plugin in parsePluginsXmlContent(content)) {
+            plugins[plugin.id] = plugin
         }
-    }
-
-    private fun parseToolbarButtons(pluginContent: String): List<PluginToolbarButton> {
-        val regex = Regex("<toolbarButton\\b([^>]*)/>")
-        return regex.findAll(pluginContent).mapNotNull { m ->
-            val tag = m.groupValues[1]
-            val id = extractAttribute(tag, "id") ?: return@mapNotNull null
-            val rawIcon = extractAttribute(tag, "icon")
-            PluginToolbarButton(
-                id = unescapeXml(id),
-                label = unescapeXml(extractAttribute(tag, "label").orEmpty()),
-                icon = rawIcon?.let { if (it.isEmpty()) null else unescapeXml(it) },
-                action = unescapeXml(extractAttribute(tag, "action").orEmpty())
-                    .ifBlank { "open_panel" }
-            )
-        }.toList()
-    }
-
-    private fun extractAttribute(tag: String, name: String): String? {
-        val regex = Regex("(?:^|\\s)$name=\"([^\"]*)\"")
-        return regex.find(tag)?.groupValues?.get(1)
-    }
-
-    private fun extractTag(content: String, tagName: String): String? {
-        val regex = Regex("<$tagName>(.*?)</$tagName>")
-        return regex.find(content)?.groupValues?.get(1)
-    }
-
-    private fun escapeXml(text: String): String {
-        return text
-            .replace("&", "&amp;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
-            .replace("\"", "&quot;")
-            .replace("'", "&apos;")
-    }
-
-    private fun unescapeXml(text: String): String {
-        return text
-            .replace("&apos;", "'")
-            .replace("&quot;", "\"")
-            .replace("&lt;", "<")
-            .replace("&gt;", ">")
-            .replace("&amp;", "&")
-    }
-
-    /** capabilities → JSON 文本（便于单个 XML 节点持久化）。 */
-    private fun encodeCapabilities(cap: com.kingzcheung.xime.plugin.core.model.PluginCapabilities): String {
-        val root = mutableMapOf<String, Any?>()
-        cap.emoji?.let {
-            root["emoji"] = mapOf(
-                "supportsSearch" to it.supportsSearch,
-                "columns" to it.columns,
-                "itemHeightDp" to it.itemHeightDp
-            )
-        }
-        cap.speech?.let {
-            root["speech"] = mapOf(
-                "inputMode" to it.inputMode,
-                "supportsPartialResults" to it.supportsPartialResults,
-                "requiresNetwork" to it.requiresNetwork
-            )
-        }
-        cap.tool?.let {
-            root["tool"] = mapOf("display" to it.display?.name)
-        }
-        cap.clipboardSync?.let {
-            root["clipboardSync"] = mapOf("protocols" to it.protocols)
-        }
-        cap.backup?.let {
-            root["backup"] = mapOf("protocols" to it.protocols)
-        }
-        if (cap.events.isNotEmpty()) {
-            root["events"] = cap.events
-        }
-        if (cap.candidateTransform) {
-            root["candidateTransform"] = true
-        }
-        if (cap.quickSendRead) {
-            root["quickSendRead"] = true
-        }
-        if (cap.clipboardRead) {
-            root["clipboardRead"] = true
-        }
-        return com.kingzcheung.xime.plugin.core.lua.sdk.SimpleJson.encode(root) ?: ""
-    }
-
-    /** capabilities JSON 文本 → 类型化模型（解析失败返回 null，不影响插件加载）。 */
-    private fun decodeCapabilities(json: String): com.kingzcheung.xime.plugin.core.model.PluginCapabilities? {
-        return runCatching {
-            val root = com.kingzcheung.xime.plugin.core.lua.sdk.SimpleJson.decode(json)
-                as? Map<*, *> ?: return null
-            com.kingzcheung.xime.plugin.core.model.PluginCapabilities(
-                emoji = (root["emoji"] as? Map<*, *>)?.let { m ->
-                    com.kingzcheung.xime.plugin.core.model.PluginCapabilities.EmojiCapabilities(
-                        supportsSearch = (m["supportsSearch"] as? Boolean) ?: false,
-                        columns = (m["columns"] as? Number)?.toInt(),
-                        itemHeightDp = (m["itemHeightDp"] as? Number)?.toInt()
-                    )
-                },
-                speech = (root["speech"] as? Map<*, *>)?.let { m ->
-                    com.kingzcheung.xime.plugin.core.model.PluginCapabilities.SpeechCapabilities(
-                        inputMode = (m["inputMode"] as? String) ?: "streaming",
-                        supportsPartialResults = (m["supportsPartialResults"] as? Boolean) ?: true,
-                        requiresNetwork = (m["requiresNetwork"] as? Boolean) ?: true
-                    )
-                },
-                tool = (root["tool"] as? Map<*, *>)?.let { m ->
-                    com.kingzcheung.xime.plugin.core.model.PluginCapabilities.ToolCapabilities(
-                        display = (m["display"] as? String)?.let { s ->
-                            // 旧契约 "select"（全屏结果页）已并入 passive（InfoPanel 内 items 点选上屏）
-                            if (s.equals("select", ignoreCase = true)) com.kingzcheung.xime.plugin.core.api.ToolResult.PASSIVE
-                            else com.kingzcheung.xime.plugin.core.api.ToolResult.entries
-                                .firstOrNull { it.name.equals(s, ignoreCase = true) }
-                        }
-                    )
-                },
-                clipboardSync = (root["clipboardSync"] as? Map<*, *>)?.let { m ->
-                    com.kingzcheung.xime.plugin.core.model.PluginCapabilities.ClipboardSyncCapabilities(
-                        protocols = (m["protocols"] as? List<*>)?.mapNotNull { it as? String } ?: emptyList()
-                    )
-                },
-                backup = (root["backup"] as? Map<*, *>)?.let { m ->
-                    com.kingzcheung.xime.plugin.core.model.PluginCapabilities.BackupCapabilities(
-                        protocols = (m["protocols"] as? List<*>)?.mapNotNull { it as? String } ?: emptyList()
-                    )
-                },
-                events = (root["events"] as? List<*>)?.mapNotNull { it as? String } ?: emptyList(),
-                candidateTransform = (root["candidateTransform"] as? Boolean) ?: false,
-                quickSendRead = (root["quickSendRead"] as? Boolean) ?: false,
-                clipboardRead = (root["clipboardRead"] as? Boolean) ?: false
-            )
-        }.getOrNull()
     }
 }

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/runtime/installer/XmlRegistryParseTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/runtime/installer/XmlRegistryParseTest.kt
@@ -1,0 +1,124 @@
+package com.kingzcheung.xime.plugin.core.runtime.installer
+
+import com.kingzcheung.xime.plugin.core.api.ToolResult
+import com.kingzcheung.xime.plugin.core.model.PluginSource
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 注册表 plugins.xml 解析回归测试。
+ *
+ * 根因背景：flushToDisk 写入时 capabilities 节点里的 JSON 经 escapeXml 转义
+ * （`"` → `&quot;`），读取端此前未反转义就交给 JSON 解码 → 必然失败 →
+ * capabilities 静默置 null。进程冷启动（手机重启/后台被杀重建）后所有插件
+ * 能力声明丢失：事件订阅通道不建立（统计插件不统计、速度恒 0）、
+ * tool.display 丢失（passive 面板退化成 direct 布局）。
+ */
+class XmlRegistryParseTest {
+
+    /** 模拟 flushToDisk 实际写出的格式：capabilities 为 escapeXml 后的 JSON。 */
+    private fun registryXml(capabilitiesNode: String?): String {
+        val cap = capabilitiesNode?.let { "    <capabilities>$it</capabilities>\n" } ?: ""
+        return """
+            <?xml version="1.0" encoding="utf-8"?>
+            <plugins>
+              <plugin>
+                <id>com.kingzcheung.xime.plugin.typing_stats</id>
+                <name>输入统计</name>
+                <description>统计打字量</description>
+                <versionCode>0</versionCode>
+                <versionName>0.2.0</versionName>
+                <path>/data/user/0/app/files/plugins/com.kingzcheung.xime.plugin.typing_stats/main.lua</path>
+                <type>tool</type>
+                <enabled>true</enabled>
+                <installTime>1757289600000</installTime>
+                <source>REMOTE</source>
+                <iconResId>0</iconResId>
+                <trustLevel>TRUSTED</trustLevel>
+                <minHostVersion>2.8.0</minHostVersion>
+                <entryScript>main.lua</entryScript>
+                <manifestIcon>统</manifestIcon>
+            $cap  </plugin>
+            </plugins>
+        """.trimIndent()
+    }
+
+    @Test
+    fun `回归 - 转义过的 capabilities JSON 读取后能力声明完整`() {
+        // 与 encodeCapabilities + escapeXml 的真实输出一致（passive 工具 + 事件订阅）
+        val xml = registryXml(
+            "{&quot;tool&quot;:{&quot;display&quot;:&quot;passive&quot;}," +
+                "&quot;events&quot;:[&quot;input_changed&quot;,&quot;text_committed&quot;]}"
+        )
+
+        val plugin = XmlManager.parsePluginsXmlContent(xml).single()
+        val cap = plugin.capabilities
+        assertNotNull("转义 JSON 必须能解码出 capabilities（此前未反转义直接解码必失败）", cap)
+        cap!!
+        assertEquals(
+            listOf("input_changed", "text_committed"),
+            cap.events
+        )
+        assertEquals(ToolResult.PASSIVE, cap.tool?.display)
+    }
+
+    @Test
+    fun `direct 显示面板的能力声明解析`() {
+        val xml = registryXml("{&quot;tool&quot;:{&quot;display&quot;:&quot;direct&quot;}}")
+
+        val plugin = XmlManager.parsePluginsXmlContent(xml).single()
+        assertEquals(ToolResult.DIRECT, plugin.capabilities?.tool?.display)
+        assertTrue("事件未声明时为空列表", plugin.capabilities?.events!!.isEmpty())
+    }
+
+    @Test
+    fun `旧注册表无 capabilities 节点时为 null`() {
+        val plugin = XmlManager.parsePluginsXmlContent(registryXml(null)).single()
+        assertNull(plugin.capabilities)
+    }
+
+    @Test
+    fun `损坏的 capabilities 解析失败不影响插件本身加载`() {
+        val xml = registryXml("{不是合法JSON}")
+
+        val plugin = XmlManager.parsePluginsXmlContent(xml).single()
+        assertNull(plugin.capabilities)
+        assertEquals("com.kingzcheung.xime.plugin.typing_stats", plugin.id)
+        assertEquals("0.2.0", plugin.versionName)
+    }
+
+    @Test
+    fun `注册表其余字段解析正确`() {
+        val xml = registryXml(
+            "{&quot;tool&quot;:{&quot;display&quot;:&quot;passive&quot;}}"
+        )
+
+        val plugin = XmlManager.parsePluginsXmlContent(xml).single()
+        assertEquals("输入统计", plugin.name)
+        assertEquals("tool", plugin.type)
+        assertEquals(PluginSource.REMOTE, plugin.source)
+        assertEquals("2.8.0", plugin.minHostVersion)
+        assertEquals("main.lua", plugin.entryScript)
+        assertEquals("统", plugin.manifestIcon)
+        assertTrue(plugin.enabled)
+    }
+
+    @Test
+    fun `toolbarButton 属性反转义解析`() {
+        val xml = """
+            <plugins>
+              <plugin>
+                <id>demo</id>
+                <path>/p/main.lua</path>
+                <toolbarButton id="demo:open" label="AI &amp; 翻译" action="open_panel"/>
+              </plugin>
+            </plugins>
+        """.trimIndent()
+
+        val button = XmlManager.parsePluginsXmlContent(xml).single().toolbarButtons.single()
+        assertEquals("AI & 翻译", button.label)
+    }
+}


### PR DESCRIPTION
- 将XML解析逻辑提取为纯函数parsePluginsXmlContent，支持单元测试复用
- 修复capabilities节点的XML转义/反序列化问题，防止JSON解码失败导致 的插件能力声明静默丢失
- 解决因capabilities解析错误导致的进程冷启动后事件订阅/面板显示失效问题
- 更新版本号从20260907到20260908

BREAKING CHANGE: 插件注册表解析逻辑调整，修复了capabilities字段的处理方式

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
