### PR TITLE
fix(keyboard): 补齐手写候选点选的按键反馈并优化候选栏清理逻辑

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -402,6 +402,9 @@ fun KeyboardView(
                 callbacks = CandidateBarCallbacks(
                     onCandidateSelect = { index ->
                         if (showHandwritingCandidates && index in handwritingCandidates.indices) {
+                            // 手写候选点选绕过了服务层 selectCandidate（其入口统一有按键反馈），
+                            // 这里补齐同款反馈，保证各键盘点选手感一致
+                            callbacks.onKeyPressDown?.invoke("standard")
                             if (isHandwritingLookup) {
                                 // 手写查词：直接上屏（原有行为）
                                 val ch = handwritingCandidates[index]
@@ -411,7 +414,7 @@ fun KeyboardView(
                                 handwritingClearSignal++
                             } else {
                                 // 兜底路径（AssociationOnly 正常走 onAssociationSelect）：
-                                // 与点选替换同语义；候选栏保留供继续改选
+                                // 与点选替换同语义；点选即结束选择期，候选栏清空
                                 val ch = handwritingCandidates[index]
                                 if (index > 0 && handwritingLastSegLen > 0) {
                                     val newTail = handwritingTail.dropLast(handwritingLastSegLen) + ch
@@ -421,6 +424,8 @@ fun KeyboardView(
                                 }
                                 handwritingActiveLen = 0
                                 callbacks.onHandwritingFinalize?.invoke()
+                                handwritingCandidates = emptyList()
+                                handwritingComments = emptyList()
                                 handwritingClearSignal++
                             }
                         } else {
@@ -475,6 +480,9 @@ fun KeyboardView(
                     },
                     onAssociationSelect = { index ->
                         if (showHandwritingCandidates && index in handwritingCandidates.indices) {
+                            // 手写候选点选绕过了服务层 onAssociationSelect（其入口统一有按键反馈），
+                            // 这里补齐同款反馈，保证各键盘点选手感一致
+                            callbacks.onKeyPressDown?.invoke("standard")
                             if (isHandwritingLookup) {
                                 // 手写查词：查词结果直接上屏（原有行为，与叠写状态无关）
                                 val ch = handwritingCandidates[index]
@@ -483,14 +491,16 @@ fun KeyboardView(
                                 handwritingComments = emptyList()
                                 handwritingClearSignal++
                             } else if (index == 0) {
-                                // 首选已自动上屏：点选仅固化当前字并触发联想。
-                                // 候选栏保留——用户可继续改点其他候选，直到下一次书写
+                                // 首选已自动上屏：点选固化当前字并触发联想。
+                                // 点选即结束选择期：候选栏清空（下一轮书写重新填充）
                                 handwritingActiveLen = 0
                                 callbacks.onHandwritingFinalize?.invoke()
+                                handwritingCandidates = emptyList()
+                                handwritingComments = emptyList()
                                 handwritingClearSignal++
                             } else {
                                 // 替换最后上屏的字为点选候选（停顿定型后仍可替换）。
-                                // 候选栏保留供继续改选，笔画清空
+                                // 点选即结束选择期：候选栏清空，笔画清空
                                 val ch = handwritingCandidates[index]
                                 val newTail = handwritingTail.dropLast(handwritingLastSegLen) + ch
                                 val ok = callbacks.onHandwritingAutoCommit?.invoke(newTail, handwritingTail) ?: false
@@ -498,6 +508,8 @@ fun KeyboardView(
                                 handwritingActiveLen = 0
                                 handwritingLastSegLen = ch.length
                                 callbacks.onHandwritingFinalize?.invoke()
+                                handwritingCandidates = emptyList()
+                                handwritingComments = emptyList()
                                 handwritingClearSignal++
                             }
                         } else {


### PR DESCRIPTION
- 手写候选点选绕过了服务层的统一入口，补充标准按键反馈以保证各键盘点选手感一致
- 修正手写候选点选后的清理逻辑，点选后清空候选栏和注释列表，确保选择期正确结束
- 更新注释说明，明确点选操作会结束选择期并清空候选栏

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
