### PR TITLE
feat(app): 优化模型管理并发安全

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,8 +43,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 20260908
-        versionName = "2.8.0-beta5"
+        versionCode = 20260909
+        versionName = "2.8.0"
 
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/kingzcheung/xime/model/ModelManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/model/ModelManager.kt
@@ -9,7 +9,6 @@ object ModelManager {
     private const val TAG = "ModelManager"
 
     private var initialized = false
-    private val remoteModels = mutableListOf<ModelInfo>()
     private val _modelsFlow = kotlinx.coroutines.flow.MutableStateFlow<List<ModelInfo>>(emptyList())
 
     /** 可观察的模型清单（远程 index 加载后自动更新） */
@@ -21,8 +20,11 @@ object ModelManager {
         FileLogger.i(TAG, "ModelManager initialized")
     }
 
-    /** 模型清单完全来自远程 index（xime_index.base_urls 指向的 models/index.yaml） */
-    private fun allModels(): List<ModelInfo> = remoteModels
+    /** 模型清单完全来自远程 index（xime_index.base_urls 指向的 models/index.yaml）。
+     *  以 StateFlow 内的不可变列表为唯一状态源：读方拿到的是发布时的快照，
+     *  与后续刷新互不干扰（历史上共享可变列表曾被遍历方并发 clear/addAll，
+     *  连点刷新触发 ConcurrentModificationException 闪退）。 */
+    private fun allModels(): List<ModelInfo> = _modelsFlow.value
 
     fun getAllModels(): List<ModelInfo> = allModels()
 
@@ -33,17 +35,15 @@ object ModelManager {
 
     suspend fun loadFromRemote(context: Context) {
         val remote = ModelIndexLoader.loadFromRemote(context)
-        remoteModels.clear()
         if (remote.isNotEmpty()) {
-            remoteModels.addAll(remote)
             FileLogger.i(TAG, "Loaded ${remote.size} models from remote index")
         } else {
             FileLogger.w(TAG, "Remote index returned empty, no models available")
         }
-        _modelsFlow.value = remoteModels.toList()
+        _modelsFlow.value = remote
     }
 
-    fun isUsingRemoteIndex(): Boolean = remoteModels.isNotEmpty()
+    fun isUsingRemoteIndex(): Boolean = _modelsFlow.value.isNotEmpty()
 
     fun isModelDownloaded(context: Context, id: String): Boolean {
         val model = getModel(id) ?: return false

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/ModelManagementViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/ModelManagementViewModel.kt
@@ -93,6 +93,8 @@ class ModelManagementViewModel(application: Application) : AndroidViewModel(appl
     }
 
     fun refresh() {
+        // 连点防抖：刷新进行中忽略后续点击（重复拉取网络 index 徒增开销）
+        if (_uiState.value.isLoading) return
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
             refreshFromRemote()


### PR DESCRIPTION
- 将版本号从2.8.0-beta5升级到2.8.0，versionCode更新为20260909
- 移除ModelManager中的可变列表remoteModels，统一使用StateFlow作为唯一数据源
- 修复历史上的ConcurrentModificationException闪退问题，确保读写分离
- 在ModelManagementViewModel中添加连点防抖机制，避免重复网络请求
- 更新librime-lua-deps子模块引用

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [ ] 功能优化
- [x] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
