### PR TITLE
feat(input-service): 区分粘贴上屏与正常打字统计

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,8 +43,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 20260909
-        versionName = "2.8.0"
+        versionCode = 20260910
+        versionName = "2.8.1"
 
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeTextCommit.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeTextCommit.kt
@@ -126,12 +126,13 @@ internal class ImeTextCommit(private val service: XimeInputMethodService) {
         }
         // 标记为已消费：候选栏/剪贴板点选上屏后不再重复出现在候选栏
         service.clipboardManager.markConsumed(text)
-        service.commitText(text)
+        // 粘贴不计打字统计（不投 text_committed），联想照常
+        service.commitPastedText(text)
         service.clipboardManager.copyToSystemClipboard(text)
     }
 
     internal fun commitClipboardText(text: String) {
-        service.commitText(text)
+        service.commitPastedText(text)
     }
 
     internal fun deleteClipboardChars(count: Int) {

--- a/app/src/main/java/com/kingzcheung/xime/service/PluginEventDispatcher.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/PluginEventDispatcher.kt
@@ -19,6 +19,9 @@ internal class PluginEventDispatcher(private val service: XimeInputMethodService
     /** 上一次投递的 composing 快照：内容未变化时不重复投递。 */
     private var lastDispatchedInputText: String? = null
 
+    /** 累计快照（仅供同模块测试断言）。 */
+    internal val sessionCommittedCharsForTest: Long get() = sessionCommittedChars
+
     /** 进程生命周期累计上屏字符数（text_committed payload，插件统计用）。 */
     private var sessionCommittedChars: Long = 0L
 
@@ -59,10 +62,14 @@ internal class PluginEventDispatcher(private val service: XimeInputMethodService
     /**
      * 文本上屏 → text_committed。payload 携带进程生命周期累计值：
      * conflated 丢中间事件不影响统计（插件用前后差值做增量持久化）。
+     * [isPaste] 标记粘贴性质上屏（剪贴板点选/编辑面板提交）：事件照发、
+     * 计数器照常累计（维持单调差值基准），是否计入打字量由订阅插件按 is_paste 决定。
      */
-    fun onTextCommitted(text: String) {
+    fun onTextCommitted(text: String, isPaste: Boolean = false) {
         if (sensitiveInput) return
-        sessionCommittedChars += text.length
+        // 按 Unicode 代码点计数：emoji/生僻字（增补平面代理对）用户感知为 1 个字，
+        // String.length 的 UTF-16 单元会把它们算成 2（"复制12个字统计13"的根源）
+        sessionCommittedChars += text.codePointCount(0, text.length)
         sessionCommits++
         PluginManager.dispatchEvent(
             PluginEvent(
@@ -71,6 +78,7 @@ internal class PluginEventDispatcher(private val service: XimeInputMethodService
                     PluginEvent.FIELD_COMMITTED_TEXT to text,
                     PluginEvent.FIELD_SESSION_TOTAL_CHARS to sessionCommittedChars,
                     PluginEvent.FIELD_SESSION_TOTAL_COMMITS to sessionCommits,
+                    PluginEvent.FIELD_IS_PASTE to isPaste,
                 )
             )
         )

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -2261,7 +2261,21 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     internal val candidateTransform = CandidateTransformCoordinator(this)
 
     override fun commitText(text: String) {
-        commitTextSilently(text)
+        commitTextAndPredict(text, isPaste = false)
+    }
+
+    /**
+     * 粘贴性质上屏（键盘剪贴板点选/编辑面板提交）：与 [commitText] 相同的上屏与
+     * 联想行为，但 text_committed 事件带 is_paste 标记——事件语义是"文本上屏"
+     * （照常投递给所有订阅插件），是否把粘贴计入打字量由插件自行决定
+     * （typing-stats 过滤，用户反馈"一天一万多字"的主要来源即长文本粘贴）。
+     */
+    internal fun commitPastedText(text: String) {
+        commitTextAndPredict(text, isPaste = true)
+    }
+
+    private fun commitTextAndPredict(text: String, isPaste: Boolean) {
+        commitTextSilently(text, isPaste)
         if (isChineseMode) {
             mainHandler.post {
                 if (!uiState.value.isAsciiMode) {
@@ -2299,9 +2313,10 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
      * 静默上屏：与 [commitText] 相同的落盘路径（内部编辑器重定向、InputConnection、
      * text_committed 事件、联想上下文/输入统计），但不触发联想推理。
      * 手写叠写自动上屏/替换使用——笔画替换频率高，逐次推理既浪费又会闪烁候选栏。
+     * [isPaste] 标记粘贴性质上屏，透传到 text_committed payload（见 commitPastedText）。
      * 需在主线程调用。
      */
-    internal fun commitTextSilently(text: String) {
+    internal fun commitTextSilently(text: String, isPaste: Boolean = false) {
         if (uiState.value.quickSendFormFocused) {
             // 焦点在触发编码输入框时路由到编码框，否则路由到快捷发送文本框
             val codeFocused = uiState.value.quickSendCodeFocused
@@ -2331,8 +2346,9 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         currentInputConnection?.commitText(text, 1)
 
         // text_committed 事件：真实上屏才累计/投递（内部编辑器分支已在上方 return；
-        // 敏感输入框（密码）不计不投；详见 PluginEventDispatcher）
-        pluginEvents.onTextCommitted(text)
+        // 敏感输入框（密码）不计不投；粘贴性质上屏带 is_paste 标记，见 commitPastedText；
+        // 详见 PluginEventDispatcher）
+        pluginEvents.onTextCommitted(text, isPaste)
 
         if (isChineseMode) {
             predictionManager.appendCommittedText(text)

--- a/app/src/test/java/com/kingzcheung/xime/service/PluginEventDispatcherTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/service/PluginEventDispatcherTest.kt
@@ -1,0 +1,86 @@
+package com.kingzcheung.xime.service
+
+import android.text.InputType
+import android.view.inputmethod.EditorInfo
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.junit.MockitoJUnitRunner
+
+/**
+ * PluginEventDispatcher 上屏计数（text_committed payload 基准）：
+ * - 按 Unicode 代码点计数：emoji/生僻字（UTF-16 代理对）计 1 不计 2
+ *   （用户反馈"复制 12 个字统计 13"的根源即 String.length 的代理对双计）
+ * - 敏感输入框（密码类）不计；离开敏感框后恢复计数
+ */
+@RunWith(MockitoJUnitRunner::class)
+class PluginEventDispatcherTest {
+
+    private lateinit var dispatcher: PluginEventDispatcher
+
+    @Before
+    fun setup() {
+        dispatcher = PluginEventDispatcher(mock(XimeInputMethodService::class.java))
+    }
+
+    private fun editorInfo(inputType: Int): EditorInfo = EditorInfo().apply { this.inputType = inputType }
+
+    @Test
+    fun `普通汉字按字数累计`() {
+        dispatcher.onStartInput(editorInfo(InputType.TYPE_CLASS_TEXT))
+        val text = "你好世界再见你好世界再见" // 12 个汉字
+        assertEquals(12, text.length)
+        dispatcher.onTextCommitted(text)
+        assertEquals(12L, dispatcher.sessionCommittedCharsForTest)
+    }
+
+    @Test
+    fun `emoji按一个字计数而非两个UTF16单元`() {
+        dispatcher.onStartInput(editorInfo(InputType.TYPE_CLASS_TEXT))
+        // 12 个用户感知字符，其中 1 个 emoji：String.length 为 13，代码点计数应为 12
+        val text = "复制粘贴测试文本😊" // 8 汉字 + 1 emoji = 9
+        assertEquals(10, text.length) // 验证 emoji 确实占 2 个 UTF-16 单元
+        assertEquals(9, text.codePointCount(0, text.length))
+        dispatcher.onTextCommitted(text)
+        assertEquals(9L, dispatcher.sessionCommittedCharsForTest)
+    }
+
+    @Test
+    fun `增补平面生僻字按一个字计数`() {
+        dispatcher.onStartInput(editorInfo(InputType.TYPE_CLASS_TEXT))
+        val text = "𠮷" // U+20BB7，String.length == 2
+        assertEquals(2, text.length)
+        dispatcher.onTextCommitted(text)
+        assertEquals(1L, dispatcher.sessionCommittedCharsForTest)
+    }
+
+    @Test
+    fun `多次提交跨emoji混合累计`() {
+        dispatcher.onStartInput(editorInfo(InputType.TYPE_CLASS_TEXT))
+        dispatcher.onTextCommitted("你好")
+        dispatcher.onTextCommitted("👍") // 代理对
+        dispatcher.onTextCommitted("abc")
+        dispatcher.onTextCommitted("𠮷tera") // 𠮷=1, t/e/r/a=4
+        assertEquals(2L + 1L + 3L + 5L, dispatcher.sessionCommittedCharsForTest)
+    }
+
+    @Test
+    fun `敏感输入框不计数`() {
+        val passwordType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+        dispatcher.onStartInput(editorInfo(passwordType))
+        dispatcher.onTextCommitted("secret")
+        assertEquals(0L, dispatcher.sessionCommittedCharsForTest)
+    }
+
+    @Test
+    fun `离开敏感输入框后恢复计数`() {
+        val passwordType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+        dispatcher.onStartInput(editorInfo(passwordType))
+        dispatcher.onTextCommitted("secret")
+        dispatcher.onStartInput(editorInfo(InputType.TYPE_CLASS_TEXT))
+        dispatcher.onTextCommitted("你好")
+        assertEquals(2L, dispatcher.sessionCommittedCharsForTest)
+    }
+}

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/PluginEvent.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/PluginEvent.kt
@@ -37,6 +37,13 @@ data class PluginEvent(
         const val FIELD_SESSION_TOTAL_COMMITS = "session_total_commits"
 
         /**
+         * FIELD_IS_PASTE：本次上屏是否为粘贴性质（键盘剪贴板点选/编辑面板提交）。
+         * 事件语义仍为"文本上屏"（照常投递、计数器照常累计以维持差值基准），
+         * 是否把粘贴计入打字量由各订阅插件自行决定（如 typing-stats 过滤）。
+         */
+        const val FIELD_IS_PASTE = "is_paste"
+
+        /**
          * 快捷发送列表变更：payload = { count: Int }。
          * 只通知变更（conflated 只保最新），插件收到后调 host.quickSend.list() 重新拉取。
          */

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaTypingStatsPluginTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaTypingStatsPluginTest.kt
@@ -1,0 +1,107 @@
+package com.kingzcheung.xime.plugin.core.lua
+
+import com.kingzcheung.xime.plugin.core.config.PluginConfigStore
+import com.kingzcheung.xime.plugin.core.lua.crypto.CryptoHostApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * 验证 typing-stats 插件端到端统计口径（Lua 侧）：
+ * - 正常打字上屏（is_paste=false）按差值累计字数与提交次数
+ * - 粘贴上屏（is_paste=true）不计字数/提交次数，但事件照收推进差值基准
+ *   （last_seen 前移，粘贴后的正常输入不重复累计粘贴部分）
+ */
+class LuaTypingStatsPluginTest {
+
+    private class InMemoryConfigStore : PluginConfigStore {
+        private val map = HashMap<String, String>()
+        override fun get(key: String): String? = map[key]
+        override fun set(key: String, value: String) { map[key] = value }
+        override fun remove(key: String) { map.remove(key) }
+        override fun keys(): Set<String> = map.keys.toSet()
+    }
+
+    /** 固定时间源：今日 = 20260910（沙箱无 os，插件经 host.crypto.utcTime 取日期）。 */
+    private class FixedClockCrypto : CryptoHostApi {
+        override fun utcTime(format: String): String =
+            if (format == "YYYYMMDD") "20260910" else "20260910T120000Z"
+        override fun epochSeconds(): Long = 0L
+        override fun sha256(data: ByteArray): ByteArray = ByteArray(0)
+        override fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray = ByteArray(0)
+        override fun hmacSha1(key: ByteArray, data: ByteArray): ByteArray = ByteArray(0)
+        override fun hex(data: ByteArray): String = ""
+        override fun base64(data: ByteArray): String = ""
+    }
+
+    private fun newRuntime(store: InMemoryConfigStore): LuaScriptRuntime {
+        val dir = File("../plugins/typing-stats")
+        assertTrue("typing-stats 插件目录应存在: ${dir.absolutePath}", dir.exists())
+        val runtime = LuaScriptRuntime(
+            "com.kingzcheung.xime.plugin.typing_stats",
+            dir,
+            "main.lua",
+            store,
+            cryptoHostApi = FixedClockCrypto()
+        )
+        // 事件通道必须在 load 之前声明（与宿主 PluginLifecycleManager 同序）
+        runtime.initEvents(setOf("input_changed", "text_committed"))
+        assertTrue("main.lua 应能加载", runtime.load())
+        return runtime
+    }
+
+    private fun committedEvent(sessionChars: Long, isPaste: Boolean) = PluginEvent(
+        PluginEvent.TYPE_TEXT_COMMITTED,
+        mapOf(
+            PluginEvent.FIELD_COMMITTED_TEXT to "文本",
+            PluginEvent.FIELD_SESSION_TOTAL_CHARS to sessionChars,
+            PluginEvent.FIELD_SESSION_TOTAL_COMMITS to 1L,
+            PluginEvent.FIELD_IS_PASTE to isPaste,
+        )
+    )
+
+    /** 事件经 conflated 通道异步消费：轮询 config 直到 last_seen 前移到期望值。 */
+    private fun awaitLastSeen(store: InMemoryConfigStore, expected: Long, timeoutMs: Long = 3000) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (store.get("last_seen_chars") == expected.toString()) return
+            Thread.sleep(20)
+        }
+        assertTrue("等待 last_seen_chars=$expected 超时，实际=${store.get("last_seen_chars")}", false)
+    }
+
+    @Test
+    fun `打字累计而粘贴不计入且不破坏后续差值`() {
+        val store = InMemoryConfigStore()
+        val runtime = newRuntime(store)
+
+        // 正常打字：session 推进 5 字（首次差值按 0，防插件重载重复累计——既有设计语义）
+        assertTrue(runtime.dispatchEvent(committedEvent(5L, isPaste = false)))
+        awaitLastSeen(store, 5L)
+        assertEquals("0", store.get("total_chars"))
+        assertEquals("1", store.get("total_commits"))
+
+        // 第二笔正常打字：差值 4 正常累计
+        assertTrue(runtime.dispatchEvent(committedEvent(9L, isPaste = false)))
+        awaitLastSeen(store, 9L)
+        assertEquals("4", store.get("total_chars"))
+        assertEquals("2", store.get("total_commits"))
+        assertTrue(
+            "daily 应含今日 4 字: ${store.get("daily")}",
+            store.get("daily")?.contains("20260910") == true && store.get("daily")!!.contains("4")
+        )
+
+        // 粘贴 12 字：不计字数/次数，但 last_seen 推进到 21（差值基准不被粘贴破坏）
+        assertTrue(runtime.dispatchEvent(committedEvent(21L, isPaste = true)))
+        awaitLastSeen(store, 21L)
+        assertEquals("粘贴不应计入累计字数", "4", store.get("total_chars"))
+        assertEquals("粘贴不应计入提交次数", "2", store.get("total_commits"))
+
+        // 粘贴后继续打字 3 字：只累计 3，不把粘贴的 12 重复算入
+        assertTrue(runtime.dispatchEvent(committedEvent(24L, isPaste = false)))
+        awaitLastSeen(store, 24L)
+        assertEquals("7", store.get("total_chars"))
+        assertEquals("3", store.get("total_commits"))
+    }
+}

--- a/plugins/typing-stats/main.lua
+++ b/plugins/typing-stats/main.lua
@@ -5,10 +5,11 @@
 --   宿主  = 事件投递（conflated 快照）+ InfoPanel 渲染（display: passive）+ action 回调
 --
 -- 事件语义（snake_case）：
---   text_committed: { committed_text, session_total_chars, session_total_commits }
+--   text_committed: { committed_text, session_total_chars, session_total_commits, is_paste }
 --     - session_* 为宿主进程生命周期累计；conflated 丢中间事件不影响统计（差值增量）
 --     - 宿主重启后 session 归零：delta 为负时视为新会话起点
 --     - 插件重载后：last_seen 持久化，首次差值按 0，避免重复累计
+--     - is_paste = 粘贴性质上屏（剪贴板点选/编辑面板提交），不计入打字量
 --   input_changed:  { input_text }  当前编码快照（高频，仅内存不落盘）
 --
 -- 沙箱约束：无 os/io——日期与速度的时间源为 host.crypto.utcTime（UTC），
@@ -182,13 +183,17 @@ function plugin.onPluginEvent(eventType, payload)
       -- 宿主重启（session 归零）：新会话起点，本快照即增量
       delta = sessionChars
     end
-    if delta > 0 then
-      totalChars = totalChars + delta
-      local d = todayStr()
-      daily[d] = (daily[d] or 0) + delta
-      recordSpeed(nowSec(), delta)
+    -- is_paste（键盘剪贴板点选/编辑面板提交）：事件照收以推进差值基准，
+    -- 但粘贴不是打字，不计字数/提交次数/速度
+    if not payload.is_paste then
+      if delta > 0 then
+        totalChars = totalChars + delta
+        local d = todayStr()
+        daily[d] = (daily[d] or 0) + delta
+        recordSpeed(nowSec(), delta)
+      end
+      totalCommits = totalCommits + 1
     end
-    totalCommits = totalCommits + 1
     persist()
   elseif eventType == "input_changed" and payload ~= nil then
     -- 高频事件：只更新内存态，不写盘

--- a/plugins/typing-stats/manifest.yaml
+++ b/plugins/typing-stats/manifest.yaml
@@ -8,14 +8,16 @@ name: 输入统计
 icon: "统"
 description: 统计打字量（今日/累计字数、提交次数）。基于宿主下行事件，无网络访问。
 
-version: 0.2.0
+# 0.3.0：text_committed 事件契约扩展——payload 新增 is_paste（粘贴性质上屏标记），
+# 本插件据此不计粘贴字数；依赖宿主 2.8.1 投递该字段，低于此版本禁用本插件。
+version: 0.3.0
 
 type: tool
 activation: multi
 
 entry: main.lua
 
-minHostVersion: 2.8.0
+minHostVersion: 2.8.1
 
 # 工具栏入口
 toolbarButtons:


### PR DESCRIPTION
版本号从 2.8.0 (20260909) 更新至 2.8.1 (20260910)

- 新增 commitPastedText 方法处理粘贴性质上屏，携带 is_paste 标记
- 修改 PluginEventDispatcher 支持 isPaste 参数传递到 text_committed 事件
- 修复字符计数使用 codePointCount 替代 length，正确处理 emoji 和代理对字符
- typing-stats 插件过滤粘贴事件，避免长文本粘贴计入打字量统计
- 添加测试辅助字段 sessionCommittedCharsForTest

这解决了用户反馈"一天一万多字"的问题，该问题主要来源于长文本粘贴被误计入打字量。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [x] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
