### PR TITLE
feat(speech): 添加语音引擎常驻开关支持跨会话保留模型

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,12 @@ android {
     namespace = "com.kingzcheung.xime"
     compileSdk = 36
 
+    // JVM 单测中未 mock 的 Android 框架方法（如 android.util.Log）返回默认值而非抛异常，
+    // 使服务层状态机（如语音收尾流程）可直接实例化测试
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
+
     defaultConfig {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28

--- a/app/src/main/aidl/com/kingzcheung/xime/service/IInferenceAsrService.aidl
+++ b/app/src/main/aidl/com/kingzcheung/xime/service/IInferenceAsrService.aidl
@@ -13,4 +13,9 @@ interface IInferenceAsrService {
     void cancelAsr();
     /** 释放 ASR 模型 */
     void releaseAsr();
+    /**
+     * "保持引擎常驻"开关：true 时服务端不做 60s 空闲自动释放，
+     * 模型常驻内存（用户已明确选择以内存换响应速度）；false 恢复默认回收。
+     */
+    oneway void setKeepModelAlive(boolean keepAlive);
 }

--- a/app/src/main/java/com/kingzcheung/xime/service/AsrInferenceClient.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/AsrInferenceClient.kt
@@ -151,4 +151,11 @@ class AsrInferenceClient(private val context: Context) {
             requireService().releaseAsr()
         } catch (_: Exception) {}
     }
+
+    /** 同步"保持引擎常驻"设置到 :asr 进程（服务端据此决定是否空闲自动释放模型）。 */
+    suspend fun setKeepModelAlive(keepAlive: Boolean) {
+        try {
+            requireService().setKeepModelAlive(keepAlive)
+        } catch (_: Exception) {}
+    }
 }

--- a/app/src/main/java/com/kingzcheung/xime/service/AsrInferenceService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/AsrInferenceService.kt
@@ -33,6 +33,9 @@ class AsrInferenceService : Service() {
     private var asrHandle: Long = 0L
     private var asrCallback: IInferenceAsrCallback? = null
     private val asrLock = Any()
+    // "保持引擎常驻"：开启时跳过空闲自动释放，模型常驻内存换响应速度
+    @Volatile
+    private var keepModelAlive = false
 
     private val idleHandler = Handler(Looper.getMainLooper())
     private val idleReleaseRunnable = Runnable {
@@ -47,6 +50,7 @@ class AsrInferenceService : Service() {
     }
 
     private fun scheduleIdleRelease() {
+        if (keepModelAlive) return
         idleHandler.removeCallbacks(idleReleaseRunnable)
         idleHandler.postDelayed(idleReleaseRunnable, IDLE_RELEASE_DELAY_MS)
     }
@@ -136,6 +140,18 @@ class AsrInferenceService : Service() {
                 }
                 asrCallback = null
             }
+        }
+
+        override fun setKeepModelAlive(keepAlive: Boolean) {
+            keepModelAlive = keepAlive
+            if (keepAlive) {
+                // 取消可能已排期的空闲释放
+                cancelIdleRelease()
+            } else if (synchronized(asrLock) { asrHandle } != 0L) {
+                // 从常驻切回默认：模型仍在内存，恢复空闲回收
+                scheduleIdleRelease()
+            }
+            FileLogger.i(TAG, "setKeepModelAlive: $keepAlive")
         }
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/service/VoiceRecognitionHandler.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/VoiceRecognitionHandler.kt
@@ -22,10 +22,21 @@ class VoiceRecognitionHandler(
     private val onAmplitudeChanged: (Float) -> Unit = {},
     private val onSpectrumChanged: (FloatArray) -> Unit = {},
     /** 语音向输入框写入 composing 文本时回调（标记 composing 区域存在，供 endComposingInputBox 判断）。 */
-    private val onComposingWritten: () -> Unit = {}
+    private val onComposingWritten: () -> Unit = {},
+    /** manager 工厂，供测试注入 mock。 */
+    private val managerFactory: (Context) -> SpeechRecognitionManager = { SpeechRecognitionManager(it) },
+    /** 超时调度器，供测试注入并手动推进。 */
+    private val mainHandler: Handler = Handler(Looper.getMainLooper())
 ) {
     companion object {
         private const val TAG = "VoiceRecognition"
+
+        /**
+         * 松手后等待 ASR 引擎最终结果的超时。在线插件 stop() 只发送结束信号
+         * （finish-task/最后一包标记），服务端处理完尾点才经 WebSocket 异步回调
+         * 最终结果，通常 1~2s；超时仍未收到则回退提交已收到的部分结果。
+         */
+        private const val FINISH_TIMEOUT_MS = 3000L
     }
 
     private lateinit var speechRecognitionManager: SpeechRecognitionManager
@@ -36,7 +47,7 @@ class VoiceRecognitionHandler(
     fun initialize() {
         FileLogger.i(TAG, "Initializing speech recognition system")
 
-        speechRecognitionManager = SpeechRecognitionManager(context)
+        speechRecognitionManager = managerFactory(context)
 
         speechRecognitionManager.setCallbacks(
             onResult = { text ->
@@ -65,7 +76,10 @@ class VoiceRecognitionHandler(
         FileLogger.i(TAG, "STT provider: $providerName")
 
         // 若"使用本地模型"开关已开启，启动时即加载模型并常驻，
-        // 保证语音时绝不现场加载模型（避免丢开头音频）
+        // 保证语音时绝不现场加载模型（避免丢开头音频）。
+        // 注意：keep-alive 预热也走这里（AsrSupport.warmup 注册常驻后端），
+        // 不要再走 manager.preload——那会经 AsrSupport.create 造一个临时后端，
+        // 与本 warmup 并发时双重绑定 :asr、双重加载模型（日志曾见两次 initialize）
         if (SettingsPreferences.isSttUseLocal(context) &&
             AsrBackendFactory.getLocalName() != null
         ) {
@@ -75,7 +89,6 @@ class VoiceRecognitionHandler(
         }
     }
 
-    private val mainHandler by lazy { Handler(Looper.getMainLooper()) }
     private val delayedPreStartRunnable = Runnable {
         if (::speechRecognitionManager.isInitialized) {
             speechRecognitionManager.startPreStart()
@@ -104,6 +117,11 @@ class VoiceRecognitionHandler(
             ))
             return
         }
+
+        // 上一次会话若还在收尾等待中（快速再次开始），直接废弃收尾状态
+        finishing = false
+        mainHandler.removeCallbacks(finishTimeoutRunnable)
+        suppressDuplicateFinal = false
 
         textBeforeVoiceInput = getInputConnection()?.getTextBeforeCursor(1000, 0)?.toString() ?: ""
         textLengthBeforeVoiceInput = textBeforeVoiceInput.length
@@ -155,13 +173,20 @@ class VoiceRecognitionHandler(
     private var smoothedSpectrum = FloatArray(16)
     // 抬起时已提交当前识别文本后，置真以忽略随后可能迟到的重复最终结果
     private var suppressDuplicateFinal = false
+    // 松手收尾中：已停止送音，等待引擎吐出最终结果（超时由 finishTimeoutRunnable 兜底）
+    @Volatile
+    private var finishing = false
     // 输入法窗口隐藏等场景：丢弃本会话，迟到结果不得写入任何输入框
     private var sessionAbandoned = false
     private var errorToast: Toast? = null
 
+    private val finishTimeoutRunnable = Runnable { onFinishTimeout() }
+
     /** 输入法隐藏/切换输入框时调用：丢弃当前会话的未识别文本，忽略迟到的最终结果 */
     fun abandonSession() {
         sessionAbandoned = true
+        finishing = false
+        mainHandler.removeCallbacks(finishTimeoutRunnable)
         lastPartialText = ""
     }
 
@@ -179,8 +204,52 @@ class VoiceRecognitionHandler(
         lastPartialText = ""
     }
 
+    /**
+     * 松手/点按结束语音的收尾入口：停止送音后等待引擎最终结果，而不是立即提交
+     * 部分结果——在线 ASR 需 1~2s 处理尾点，立即提交会把未处理完的语音截断。
+     * 收到最终结果正常提交；超时（[FINISH_TIMEOUT_MS]）才回退提交部分结果。
+     * 完成路径（最终结果/超时/错误）统一经 onVoiceComplete 通知宿主恢复键盘。
+     */
+    fun finishRecognition() {
+        if (!::speechRecognitionManager.isInitialized) return
+        if (finishing) return
+        if (sessionAbandoned) {
+            speechRecognitionManager.stopRecognition()
+            return
+        }
+        if (lastPartialText.isEmpty()) {
+            // 无已识别文本（没说话/极短语音）：无内容可等，直接结束；
+            // 迟到的最终结果仍走正常提交路径（说了话就该上屏）
+            speechRecognitionManager.stopRecognition()
+            onVoiceComplete()
+            return
+        }
+        finishing = true
+        // 收尾期间保持"正在识别..."显示：引擎 stop 过程中的 IDLE 状态由
+        // handleSpeechStateChange 过滤，直到最终结果/超时才结束
+        onStateChanged(getState().copy(voiceRecognitionState = RecognitionState.PROCESSING))
+        mainHandler.removeCallbacks(finishTimeoutRunnable)
+        mainHandler.postDelayed(finishTimeoutRunnable, FINISH_TIMEOUT_MS)
+        speechRecognitionManager.stopRecognition()
+    }
+
+    private fun onFinishTimeout() {
+        if (!finishing) return
+        finishing = false
+        Log.d(TAG, "finish timeout: committing partial result as fallback")
+        // 超时未收到最终结果：提交已收到的部分结果兜底（会话已丢弃时内部直接跳过）
+        commitPendingOnRelease()
+        onVoiceComplete()
+    }
+
     private fun handleSpeechResult(text: String) {
         Log.d(TAG, "Speech result (final): $text")
+
+        if (finishing) {
+            // 收尾中收到最终结果：取消超时兜底，正常提交完整结果
+            finishing = false
+            mainHandler.removeCallbacks(finishTimeoutRunnable)
+        }
 
         if (sessionAbandoned) {
             sessionAbandoned = false
@@ -270,12 +339,16 @@ class VoiceRecognitionHandler(
             suppressDuplicateFinal = false
             sessionAbandoned = false
         }
+        // 收尾等待最终结果期间，引擎 stop 产生的 IDLE 不覆盖"正在识别..."显示
+        if (finishing && state == RecognitionState.IDLE) return
         onStateChanged(getState().copy(voiceRecognitionState = state))
     }
 
     private fun handleSpeechError(error: String, userVisible: Boolean) {
         Log.e(TAG, "Speech error: $error")
         FileLogger.e(TAG, "Speech error: $error")
+        finishing = false
+        mainHandler.removeCallbacks(finishTimeoutRunnable)
         lastPartialText = ""
         if (userVisible && error.isNotBlank()) {
             errorToast?.cancel()

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -86,6 +86,7 @@ import com.kingzcheung.xime.plugin.core.api.ToolPlugin
 import com.kingzcheung.xime.plugin.core.api.ToolResult
 import com.kingzcheung.xime.plugin.core.lua.PluginEvent
 import com.kingzcheung.xime.plugin.core.runtime.PluginManager
+import com.kingzcheung.xime.speech.AsrBackendFactory
 import com.kingzcheung.xime.speech.RecognitionState
 import com.kingzcheung.xime.rime.RimeConfigHelper
 import com.kingzcheung.xime.rime.RimeEngine
@@ -283,7 +284,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             pendingVoiceAction = null
             action?.invoke()
 
-            endVoiceSession()
+            restoreAfterVoiceFinish()
         },
         onAmplitudeChanged = { amplitude ->
             voiceAmplitudeState.floatValue = amplitude
@@ -295,13 +296,19 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     )
 
     /**
-     * 结束语音会话的统一出口：提交已识别文本、停止识别与预启动、恢复键盘状态。
-     * 幂等：识别已停止/无文本时各步骤自动跳过。
+     * 结束语音会话的统一出口：停止预启动并进入收尾——等待引擎最终结果后提交，
+     * 超时回退提交部分结果（见 VoiceRecognitionHandler.finishRecognition）。
+     * 键盘状态在收尾完成时经 onVoiceComplete → [restoreAfterVoiceFinish] 恢复，
+     * 期间语音面板保持"正在识别..."显示，避免用户感知到结果被截断。
+     * 幂等：收尾已在进行中时重复调用自动跳过。
      */
     internal fun endVoiceSession() {
-        voiceRecognitionHandler.commitPendingOnRelease()
-        voiceRecognitionHandler.stopRecognition()
         voiceRecognitionHandler.cancelPreStart()
+        voiceRecognitionHandler.finishRecognition()
+    }
+
+    /** 语音会话真正完成（最终结果已提交/超时兜底/出错）后恢复键盘状态。幂等。 */
+    internal fun restoreAfterVoiceFinish() {
         keyboardViewModel.exitVoice()
         isTrackingVoiceButtons = false
         voiceRecordingStarted = false
@@ -386,6 +393,14 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 }
                 "stt_enabled" -> {
                     uiState.value = uiState.value.copy(isSttEnabled = SettingsPreferences.isSttEnabled(this@XimeInputMethodService))
+                }
+                SettingsPreferences.KEY_STT_KEEP_ENGINE_ALIVE -> {
+                    // 开启时立即预热模型常驻待命（走 AsrSupport.warmup 注册常驻后端）；
+                    // 关闭时不主动销毁，:asr 服务端按同步到的设置恢复空闲回收，
+                    // 且下一会话开始时 OfflineAsrBackend 会重新同步设置
+                    if (SettingsPreferences.isSttKeepEngineAlive(this@XimeInputMethodService)) {
+                        Thread { AsrBackendFactory.warmup(this@XimeInputMethodService) }.start()
+                    }
                 }
                 SettingsPreferences.KEY_SMART_PREDICTION_ENABLED -> onPredictionSettingChanged()
                 SettingsPreferences.KEY_CLIPBOARD_SYNC_ENABLED -> updateClipboardSync()
@@ -1102,8 +1117,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             onPerformUndo = { pendingVoiceAction = { textCommit.performUndo() } },
             onPerformSearch = { pendingVoiceAction = { textCommit.performSearch() } },
             onStopRecognition = {
-                voiceRecognitionHandler.commitPendingOnRelease()
-                voiceRecognitionHandler.stopRecognition()
+                endVoiceSession()
             },
             isRecording = { voiceRecordingStarted },
             setRecording = { voiceRecordingStarted = it },

--- a/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
@@ -32,6 +32,7 @@ object SettingsPreferences {
     const val KEY_STT_ENABLED = "stt_enabled"
     const val KEY_STT_ONLINE_PLUGIN_ID = "stt_online_plugin_id"
     const val KEY_STT_USE_LOCAL = "stt_use_local"
+    const val KEY_STT_KEEP_ENGINE_ALIVE = "stt_keep_engine_alive"
     const val KEY_STT_DEBUG_RECORD = "stt_debug_record"
     
     /** 默认主题 ID，可从 xime.yaml 的 style.color_scheme 初始化。 */
@@ -412,6 +413,21 @@ object SettingsPreferences {
 
     fun setSttUseLocal(context: Context, useLocal: Boolean) {
         getPrefs(context).edit().putBoolean(KEY_STT_USE_LOCAL, useLocal).apply()
+    }
+
+    /**
+     * 语音结束后是否保持识别引擎常驻（不随会话结束销毁）。
+     * 开启后闲置一段时间再使用无需重新加载引擎，"开始聆听"响应快。
+     * 仅本地（离线）模式生效：模型本就常驻 :asr 进程，保留 wrapper 代价极小；
+     * 在线插件常驻需保持 WebSocket 长连接（耗电、占用服务端资源），不提供常驻。
+     */
+    fun isSttKeepEngineAlive(context: Context): Boolean {
+        return isSttUseLocal(context) &&
+            getPrefs(context).getBoolean(KEY_STT_KEEP_ENGINE_ALIVE, false)
+    }
+
+    fun setSttKeepEngineAlive(context: Context, enabled: Boolean) {
+        getPrefs(context).edit().putBoolean(KEY_STT_KEEP_ENGINE_ALIVE, enabled).apply()
     }
 
     /** 是否把语音识别期间的录音写入文件（调试用）。 */

--- a/app/src/main/java/com/kingzcheung/xime/speech/AsrModelManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/speech/AsrModelManager.kt
@@ -10,7 +10,7 @@ import java.io.File
  * ASR 模型管理与选择。
  *
  * 模型推理由自研的 streaming zipformer2 实现（libasr_jni.so）负责。
- * 模型清单与描述来自「模型中心」远程索引（[ModelManager]，category=asr），
+ * 模型清单与描述来自「扩展商店」远程索引（[ModelManager]，category=asr），
  * 索引未加载时回退到内置默认模型（zipformer-zh-int8）。
  */
 class AsrModelManager(private val context: Context) {

--- a/app/src/main/java/com/kingzcheung/xime/speech/OfflineAsrBackend.kt
+++ b/app/src/main/java/com/kingzcheung/xime/speech/OfflineAsrBackend.kt
@@ -61,6 +61,7 @@ class OfflineAsrBackend(private val context: Context) : AsrBackend {
                 return false
             }
             initialized = true
+            syncKeepAlive()
             // 预热模型：绑定后立即创建模型句柄并驻留，避免首次语音时
             // 1s 模型加载导致开头音频（如"你觉得"）在录音缓冲中被丢弃
             try {
@@ -92,6 +93,7 @@ class OfflineAsrBackend(private val context: Context) : AsrBackend {
             }
             // 每次会话开始都重新 startAsr：服务端会 nativeReset 并重设回调，
             // 否则 preload 预热时 stop() 清空的 callback 会导致 partial 结果丢失
+            syncKeepAlive()
             val modelDir = modelManager.getSelectedModelDir().absolutePath
             runBlocking { client.startAsr(modelDir, asrCallback) }
         } catch (e: InterruptedException) {
@@ -159,4 +161,19 @@ class OfflineAsrBackend(private val context: Context) : AsrBackend {
     }
 
     override fun isAvailable(): Boolean = true
+
+    /**
+     * 把"保持引擎常驻"设置同步到 :asr 服务。每次绑定/会话开始都同步一次：
+     * 用户中途切换设置后，下一个会话立即按新设置决定是否空闲释放模型。
+     */
+    private fun syncKeepAlive() {
+        try {
+            runBlocking {
+                client.setKeepModelAlive(
+                    com.kingzcheung.xime.settings.SettingsPreferences.isSttKeepEngineAlive(context)
+                )
+            }
+        } catch (_: Exception) {
+        }
+    }
 }

--- a/app/src/main/java/com/kingzcheung/xime/speech/SpeechRecognitionManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/speech/SpeechRecognitionManager.kt
@@ -23,6 +23,16 @@ class SpeechRecognitionManager(private val context: Context) {
         private const val AUDIO_FORMAT = AudioFormat.ENCODING_PCM_16BIT
         private const val BUFFER_SIZE_SECONDS = 0.1f
         private const val SPEECH_THRESHOLD = 25
+
+        /** 停止时等待录音线程退出的超时：覆盖 backend.stop() 同步等待最终结果的耗时。 */
+        private const val JOIN_TIMEOUT_MS = 5000L
+
+        /**
+         * 停止后延迟释放后端的窗口：在线插件 stop() 只发送结束信号，最终结果由
+         * 服务端处理完尾点后经 WebSocket 异步回调（1~2s），需比
+         * VoiceRecognitionHandler.FINISH_TIMEOUT_MS 更长，保证回调通道存活。
+         */
+        private const val BACKEND_RELEASE_DELAY_MS = 3500L
     }
 
     private var backend: AsrBackend? = null
@@ -31,6 +41,24 @@ class SpeechRecognitionManager(private val context: Context) {
 
     // 会话序号：用于区分连续语音会话，防止旧会话的回收线程误释放新会话的后端
     private var sessionId = 0
+    // 待执行的延迟释放所对应的会话序号（-1 表示无待释放）
+    @Volatile
+    private var pendingReleaseSession = -1
+    private val pendingBackendRelease = Runnable {
+        val session = pendingReleaseSession
+        pendingReleaseSession = -1
+        // 主线程只取引用；release() 含跨进程 IPC/断连，放后台线程执行
+        val b = synchronized(preloadLock) {
+            if (session != -1 && sessionId == session) {
+                val tmp = backend
+                backend = null
+                tmp
+            } else null
+        }
+        if (b != null) {
+            Thread { b.release() }.start()
+        }
+    }
     // 后台加载 ASR 模型的进行中标记与取消标记
     @Volatile
     private var loadingInProgress = false
@@ -121,6 +149,10 @@ class SpeechRecognitionManager(private val context: Context) {
         val currentBackend = synchronized(preloadLock) { backend } ?: return
         synchronized(preloadLock) { sessionId++ }
 
+        // 新会话复用后端：取消上一次会话遗留的延迟释放
+        mainHandler.removeCallbacks(pendingBackendRelease)
+        pendingReleaseSession = -1
+
         // 预启动的 AudioRecord 已运行 ~250ms，直接交给录音线程
         var preStarted: AudioRecord? = null
         synchronized(this) {
@@ -131,6 +163,21 @@ class SpeechRecognitionManager(private val context: Context) {
 
         recordingThread = RecordingThread(currentBackend, preStarted)
         recordingThread!!.start()
+    }
+
+    /**
+     * 延迟释放后端：给在线插件的异步最终结果留出送达窗口。窗口内新会话开始
+     * （startRecording）会取消释放并复用后端；释放前校验会话序号，避免误释放
+     * 新会话正在使用的后端。
+     * "引擎常驻"开启时不安排释放——后端跨会话保留，闲置后再用免重建
+     * （重新加载模型/重建 Lua 后端与连接正是"闲置后首次使用慢"的根源）；
+     * 关闭设置后自然回退为延迟释放，无需主动清理。
+     */
+    private fun scheduleBackendRelease(session: Int) {
+        if (SettingsPreferences.isSttKeepEngineAlive(context)) return
+        pendingReleaseSession = session
+        mainHandler.removeCallbacks(pendingBackendRelease)
+        mainHandler.postDelayed(pendingBackendRelease, BACKEND_RELEASE_DELAY_MS)
     }
 
     fun stopRecognition() {
@@ -149,31 +196,23 @@ class SpeechRecognitionManager(private val context: Context) {
         recordingThread = null
         thread.stopRequested = true
         val session = synchronized(preloadLock) { sessionId }
-        thread.interrupt()
+        // 不能 interrupt：录音线程可能正阻塞在 backend.stop() 同步等待最终结果
+        // （本地 stopAsr 的 runBlocking），中断会吞掉最终文本；forceStopAudio 释放
+        // AudioRecord 使 read() 返回错误、循环自然退出后执行 stop()
         thread.forceStopAudio()
         Thread {
             try {
                 // join 超时兜底：录音线程若卡在 Lua 调用中（最坏 CALL_TIMEOUT_MS=180s），
                 // 不能让后端释放无限期阻塞（否则 WebSocket 与麦克风一直占着）
-                thread.join(3000)
+                thread.join(JOIN_TIMEOUT_MS)
             } catch (_: InterruptedException) {
                 Thread.currentThread().interrupt()
             }
-            val releaseBackend = true
-            // release() 含跨进程 IPC，放到后台线程执行，避免阻塞主线程；
-            // 仅当会话序号未变化时释放并置空，避免误释放新会话正在使用的后端
-            if (releaseBackend) {
-                val b = synchronized(preloadLock) {
-                    if (sessionId == session) {
-                        val tmp = backend
-                        backend = null
-                        tmp
-                    } else null
-                }
-                if (b != null) {
-                    b.release()
-                }
+            if (thread.isAlive) {
+                // 卡死兜底：标记中断，尽快从可中断调用中退出
+                thread.interrupt()
             }
+            scheduleBackendRelease(session)
             mainHandler.post {
                 setState(RecognitionState.IDLE)
             }
@@ -196,29 +235,18 @@ class SpeechRecognitionManager(private val context: Context) {
         recordingThread = null
         thread.stopRequested = true
         val session = synchronized(preloadLock) { sessionId }
-        thread.interrupt()
+        // 同 stopRecognition：不打断 backend.stop()，避免破坏引擎收尾状态
         thread.forceStopAudio()
         Thread {
             try {
-                thread.join(3000)
+                thread.join(JOIN_TIMEOUT_MS)
             } catch (_: InterruptedException) {
                 Thread.currentThread().interrupt()
             }
-            val releaseBackend = true
-            // release() 含跨进程 IPC，放到后台线程执行，避免阻塞主线程；
-            // 仅当会话序号未变化时释放并置空，避免误释放新会话正在使用的后端
-            if (releaseBackend) {
-                val b = synchronized(preloadLock) {
-                    if (sessionId == session) {
-                        val tmp = backend
-                        backend = null
-                        tmp
-                    } else null
-                }
-                if (b != null) {
-                    b.release()
-                }
+            if (thread.isAlive) {
+                thread.interrupt()
             }
+            scheduleBackendRelease(session)
             mainHandler.post {
                 setState(RecognitionState.IDLE)
             }
@@ -274,6 +302,8 @@ class SpeechRecognitionManager(private val context: Context) {
     fun release() {
         Log.d(TAG, "Releasing speech recognition")
         cancelPreStart()
+        mainHandler.removeCallbacks(pendingBackendRelease)
+        pendingReleaseSession = -1
         cancelRecognition()
         val b = synchronized(preloadLock) {
             val tmp = backend

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/OfflineModelCard.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/OfflineModelCard.kt
@@ -138,7 +138,7 @@ internal fun OfflineModelCard() {
                 text = if (downloaded)
                     "本地 Zipformer 流式识别，无网络也能用，识别在独立进程运行。"
                 else
-                    "尚未安装模型，请前往「模型中心」下载「${model.name}」。",
+                    "尚未安装模型，请前往「扩展商店」下载「${model.name}」。",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SpeechToTextSettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SpeechToTextSettingsScreen.kt
@@ -37,6 +37,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -96,6 +98,10 @@ fun SpeechToTextSettingsContent(
 
     var useLocal by remember {
         mutableStateOf(OfflineAsrSettings.isSupported() && SettingsPreferences.isSttUseLocal(context))
+    }
+
+    var keepEngineAlive by remember {
+        mutableStateOf(SettingsPreferences.isSttKeepEngineAlive(context))
     }
 
     val onlineProviders = remember(activeAsrPluginId) {
@@ -191,11 +197,59 @@ fun SpeechToTextSettingsContent(
                 Spacer(modifier = Modifier.height(8.dp))
 
                 if (useLocal) {
-                    // 本地模型下载/管理卡片
-                    OfflineAsrSettings.ModelSection()
+                    // 引擎常驻开关（仅本地模式显示/生效）：语音结束后保留引擎，闲置后再用免重建。
+                    // 在线插件常驻需保持 WebSocket 长连接（耗电、占用服务端资源），不提供该选项。
+                    // 注意：必须放在 ModelSection 之前——其内部 Column 为 fillMaxSize，
+                    // 放在它后面会被挤出可视区
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        shape = RoundedCornerShape(16.dp),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surface
+                        ),
+                        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = "保持引擎常驻",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                                Text(
+                                    text = "语音结束后模型不自动释放（约150MB常驻内存），闲置后再用免重新加载，响应更快",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.7f)
+                                )
+                            }
+                            Switch(
+                                checked = keepEngineAlive,
+                                onCheckedChange = {
+                                    keepEngineAlive = it
+                                    SettingsPreferences.setSttKeepEngineAlive(context, it)
+                                },
+                                colors = SwitchDefaults.colors(
+                                    checkedThumbColor = MaterialTheme.colorScheme.primary,
+                                    checkedTrackColor = MaterialTheme.colorScheme.primaryContainer
+                                )
+                            )
+                        }
+                    }
                     Spacer(modifier = Modifier.height(8.dp))
+
+                    // 本地模型下载/管理卡片（内部 fillMaxSize 自滚动，须放在本分支最后）
+                    OfflineAsrSettings.ModelSection()
                 }
             }
+
+            Spacer(modifier = Modifier.height(8.dp))
 
             if (!useLocal) {
                 OnlineAsrTab(

--- a/app/src/test/java/com/kingzcheung/xime/service/VoiceRecognitionHandlerFinishTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/service/VoiceRecognitionHandlerFinishTest.kt
@@ -1,0 +1,205 @@
+package com.kingzcheung.xime.service
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Handler
+import android.view.inputmethod.InputConnection
+import com.kingzcheung.xime.settings.SettingsPreferences
+import com.kingzcheung.xime.speech.RecognitionState
+import com.kingzcheung.xime.speech.SpeechRecognitionManager
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.then
+import org.mockito.kotlin.whenever
+
+/**
+ * 语音松手收尾状态机测试：finishRecognition 停止送音后等待引擎最终结果，
+ * 超时才回退提交部分结果（修复"说完立刻松手，尾部语音被截断"）。
+ */
+@RunWith(MockitoJUnitRunner.Silent::class)
+class VoiceRecognitionHandlerFinishTest {
+
+    @Mock
+    private lateinit var mockContext: Context
+
+    @Mock
+    private lateinit var mockPrefs: SharedPreferences
+
+    @Mock
+    private lateinit var mockInputConnection: InputConnection
+
+    @Mock
+    private lateinit var mockManager: SpeechRecognitionManager
+
+    @Mock
+    private lateinit var mockMainHandler: Handler
+
+    private lateinit var handler: VoiceRecognitionHandler
+
+    private val stateChanges = mutableListOf<InputUIState>()
+    private var voiceCompleteCount = 0
+
+    /** mock mainHandler 的 postDelayed 队列，可手动推进超时。 */
+    private val posted = mutableListOf<Runnable>()
+
+    private lateinit var onResult: (String) -> Unit
+    private lateinit var onPartial: (String) -> Unit
+    private lateinit var onState: (RecognitionState) -> Unit
+
+    @Before
+    fun setup() {
+        whenever(mockContext.getSharedPreferences(any(), anyInt())).thenReturn(mockPrefs)
+        // 所有布尔设置返回默认值；isSttUseLocal 置 true 使 resolveProviderName 走本地引擎
+        // 早退（不触碰未初始化的 PluginManager/ExtensionManager），warmup 分支为异步线程无副作用
+        whenever(mockPrefs.getBoolean(any(), any<Boolean>())).thenAnswer { it.getArgument(1) }
+        whenever(mockPrefs.getBoolean(eq(SettingsPreferences.KEY_STT_USE_LOCAL), any<Boolean>()))
+            .thenReturn(true)
+        whenever(mockMainHandler.postDelayed(any<Runnable>(), anyLong())).thenAnswer {
+            posted.add(it.getArgument(0))
+            true
+        }
+        whenever(mockMainHandler.removeCallbacks(any<Runnable>())).thenAnswer {
+            posted.remove(it.getArgument<Runnable>(0))
+        }
+
+        handler = VoiceRecognitionHandler(
+            context = mockContext,
+            onStateChanged = { stateChanges.add(it) },
+            getState = { InputUIState() },
+            getInputConnection = { mockInputConnection },
+            onVoiceComplete = { voiceCompleteCount++ },
+            managerFactory = { mockManager },
+            mainHandler = mockMainHandler
+        )
+        handler.initialize()
+
+        val onResultCaptor = argumentCaptor<(String) -> Unit>()
+        val onPartialCaptor = argumentCaptor<(String) -> Unit>()
+        val onStateCaptor = argumentCaptor<(RecognitionState) -> Unit>()
+        verify(mockManager).setCallbacks(
+            onResultCaptor.capture(), onPartialCaptor.capture(), onStateCaptor.capture(),
+            any(), any(), any()
+        )
+        onResult = onResultCaptor.firstValue
+        onPartial = onPartialCaptor.firstValue
+        onState = onStateCaptor.firstValue
+    }
+
+    private fun runTimeouts() {
+        val copy = posted.toList()
+        posted.clear()
+        copy.forEach { it.run() }
+    }
+
+    @Test
+    fun `收尾时收到最终结果则提交完整结果并取消超时兜底`() {
+        onPartial.invoke("你好")
+        handler.finishRecognition()
+
+        // 停止送音、进入"正在识别"、安排了超时兜底
+        verify(mockManager).stopRecognition()
+        assertEquals(RecognitionState.PROCESSING, stateChanges.last().voiceRecognitionState)
+        assertEquals(1, posted.size)
+
+        // 引擎吐出最终结果：提交增量部分（partial 已通过 composing 上屏，句号由启发式补齐）
+        onResult.invoke("你好世界再见")
+
+        verify(mockInputConnection).finishComposingText()
+        verify(mockInputConnection).commitText(eq("世界再见。"), eq(1))
+        assertEquals(1, voiceCompleteCount)
+        // 超时兜底已被取消，手动推进不再重复提交
+        assertTrue(posted.isEmpty())
+        runTimeouts()
+        verify(mockInputConnection, never()).commitText(eq("你好，"), eq(1))
+        assertEquals(1, voiceCompleteCount)
+    }
+
+    @Test
+    fun `超时未收到最终结果则回退提交部分结果且忽略迟到的最终结果`() {
+        onPartial.invoke("你好")
+        handler.finishRecognition()
+        runTimeouts()
+
+        // 部分结果"你好"已通过 composing 上屏，兜底只补上启发式句号"，"
+        verify(mockInputConnection).finishComposingText()
+        verify(mockInputConnection).commitText(eq("，"), eq(1))
+        assertEquals(1, voiceCompleteCount)
+
+        // 迟到的最终结果被抑制：不再写入输入框（避免重复/错乱）
+        onResult.invoke("你好世界再见")
+        verify(mockInputConnection, times(1)).commitText(any(), anyInt())
+        assertEquals(2, voiceCompleteCount)
+    }
+
+    @Test
+    fun `无已识别文本时收尾不等待直接结束`() {
+        handler.finishRecognition()
+
+        verify(mockManager).stopRecognition()
+        assertEquals(1, voiceCompleteCount)
+        assertTrue(posted.isEmpty())
+        assertFalse(stateChanges.any { it.voiceRecognitionState == RecognitionState.PROCESSING })
+    }
+
+    @Test
+    fun `收尾中重复调用幂等`() {
+        onPartial.invoke("你好")
+        handler.finishRecognition()
+        handler.finishRecognition()
+
+        verify(mockManager).stopRecognition()
+        assertEquals(1, posted.size)
+        // 收尾尚未完成（在等最终结果），不触发 onVoiceComplete
+        assertEquals(0, voiceCompleteCount)
+    }
+
+    @Test
+    fun `会话被丢弃后收尾不提交文本且超时兜底失效`() {
+        onPartial.invoke("你好")
+        handler.abandonSession()
+        handler.finishRecognition()
+
+        verify(mockManager).stopRecognition()
+        runTimeouts()
+        verify(mockInputConnection, never()).commitText(any(), anyInt())
+        verify(mockInputConnection, never()).finishComposingText()
+        assertEquals(0, voiceCompleteCount)
+    }
+
+    @Test
+    fun `收尾期间引擎的IDLE状态不覆盖正在识别显示`() {
+        onPartial.invoke("你好")
+        handler.finishRecognition()
+        assertEquals(RecognitionState.PROCESSING, stateChanges.last().voiceRecognitionState)
+
+        // 引擎 stop 过程中回调 IDLE：保持"正在识别..."显示
+        onState.invoke(RecognitionState.IDLE)
+        assertEquals(RecognitionState.PROCESSING, stateChanges.last().voiceRecognitionState)
+
+        // 其他状态（如 ERROR）不被过滤
+        onState.invoke(RecognitionState.ERROR)
+        assertEquals(RecognitionState.ERROR, stateChanges.last().voiceRecognitionState)
+    }
+
+    @Test
+    fun `部分结果写入composing区域并同步到UI状态`() {
+        onPartial.invoke("你好")
+
+        verify(mockInputConnection).setComposingText(eq("你好"), eq(1))
+        assertEquals("你好", stateChanges.last().voiceRecognizedText)
+    }
+}


### PR DESCRIPTION
- 新增 AIDL 接口 IInferenceAsrService.setKeepModelAlive 控制模型释放策略
- 在 AsrInferenceService 中实现 keepModelAlive 标志，支持跳过空闲自动释放
- 在 AsrInferenceClient 中添加同步方法将设置传递到 :asr 进程
- 在 OfflineAsrBackend 中每次绑定时同步设置到服务端
- 在 SettingsPreferences 中添加 KEY_STT_KEEP_ENGINE_ALIVE 配置项
- 在语音设置界面添加开关控件，仅本地模式生效
- 优化语音识别收尾逻辑，等待引擎最终结果而非立即提交部分结果
- 添加 finishRecognition 方法处理松手后的收尾等待和超时兜底机制

refactor(speech): 重构语音识别状态机收尾流程

- 将 endVoiceSession 重命名为 restoreAfterVoiceFinish 作为收尾完成后的恢复入口
- 新增 finishRecognition 方法处理引擎收尾等待逻辑，包含超时保护
- 修复快速连续语音会话时的收尾状态冲突问题
- 优化 SpeechRecognitionManager 的后端释放时机，支持延迟释放机制
- 添加会话序号校验避免误释放新会话的后端实例

test(build): 配置单元测试默认值返回避免 Android 框架调用异常

- 在 build.gradle.kts 中配置 testOptions.isReturnDefaultValues = true
- 使服务层状态机可在 JVM 单元测试中直接实例化测试
- 避免未 mock 的 Android 框架方法（如 Log）抛出异常

refactor(ui): 统一语音收尾完成状态恢复入口

- 修改 XimeInputMethodService.endVoiceSession 为调用 finishRecognition
- 将键盘状态恢复逻辑移到 restoreAfterVoiceFinish 方法
- 更新语音按钮点击事件使用统一的收尾入口

docs: 更新模型中心相关文案为扩展商店

- 将 AsrModelManager 中的「模型中心」改为「扩展商店」
- 更新 OfflineModelCard 中的下载提示文案

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] 新功能
- [x] 功能优化
- [ ] Bug 修复
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
